### PR TITLE
validated/invalid files

### DIFF
--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -12,12 +12,9 @@ import json
 import numpy as np
 import os
 
-from .utils import (
-    get_local_path, validator, F0Data, get_save_path, load_json_index
-)
+import mirdata.utils as utils
 
-
-MEDLEYDB_PITCH_INDEX = load_json_index('medleydb_pitch_index.json')
+MEDLEYDB_PITCH_INDEX = utils.load_json_index('medleydb_pitch_index.json')
 MEDLEYDB_PITCH_DIR = "MedleyDB-Pitch"
 MEDLEYDB_METADATA = None
 
@@ -33,22 +30,37 @@ MedleydbPitchTrack = namedtuple(
 )
 
 
-def download(data_home=None):
-    save_path = get_save_path(data_home)
-    print("""
-      To download this dataset, visit:
-      https://zenodo.org/record/2620624#.XKZc7hNKh24
-      and request access.
+def download(data_home=None, clobber=False):
+    save_path = utils.get_save_path(data_home)
+    dataset_path = os.path.join(save_path, MEDLEYDB_PITCH_DIR)
 
-      Once downloaded, unzip the file MedleyDB-Pitch.zip
-      and place the result in:
-      {}
-    """.format(save_path))
+    if clobber:
+        utils.clobber_all(MEDLEYDB_METADATA,
+                          dataset_path,
+                          data_home)
+    if utils.check_validated(dataset_path):
+        print("""
+                The {} dataset has already been validated.
+                If you feel this is a mistake please rerun and set clobber to true.
+                """.format(MEDLEYDB_PITCH_DIR))
+        return
+
+    missing_files, invalid_checksums = validate(dataset_path, data_home)
+    if missing_files or invalid_checksums:
+        print("""
+            To download this dataset, visit:
+            https://zenodo.org/record/2620624#.XKZc7hNKh24
+            and request access.
+
+            Once downloaded, unzip the file MedleyDB-Pitch.zip
+            and place the result in:
+            {}
+        """.format(save_path))
 
 
-def validate(data_home=None):
-    missing_files = validator(MEDLEYDB_PITCH_INDEX, data_home)
-    return missing_files
+def validate(dataset_path, data_home=None):
+    missing_files, invalid_checksums = utils.validator(MEDLEYDB_PITCH_INDEX, data_home, dataset_path)
+    return missing_files, invalid_checksums
 
 
 def track_ids():
@@ -79,12 +91,12 @@ def load_track(track_id, data_home=None):
     track_metadata = MEDLEYDB_METADATA[track_id]
 
     pitch_data = _load_pitch(
-        get_local_path(data_home, track_data['pitch'][0]))
+        utils.get_local_path(data_home, track_data['pitch'][0]))
 
     return MedleydbPitchTrack(
         track_id,
         pitch_data,
-        get_local_path(data_home, track_data['audio'][0]),
+        utils.get_local_path(data_home, track_data['audio'][0]),
         track_metadata['instrument'],
         track_metadata['artist'],
         track_metadata['title'],
@@ -105,7 +117,7 @@ def _load_pitch(pitch_path):
             freqs.append(float(line[1]))
             confidence.append(0 if line[1] == '0' else 1)
 
-    melody_data = F0Data(
+    melody_data = utils.F0Data(
         np.array(times), np.array(freqs), np.array(confidence))
     return melody_data
 
@@ -116,7 +128,7 @@ def _reload_metadata(data_home):
 
 
 def _load_metadata(data_home):
-    metadata_path = get_local_path(
+    metadata_path = utils.get_local_path(
         data_home,
         os.path.join(MEDLEYDB_PITCH_DIR, "medleydb_pitch_metadata.json"))
     if not os.path.exists(metadata_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 coveralls>=1.7.0
-nose>=1.3.7
 six
 testcontainers
 future==0.17.1

--- a/scripts/make_beatles_index.py
+++ b/scripts/make_beatles_index.py
@@ -5,6 +5,7 @@ import os
 
 
 BEATLES_INDEX_PATH = "../mir_dataset_loaders/indexes/beatles_index.json"
+BEATLES_ANNOTATION_SCHEMA = ['beat', 'chordlab', 'keylab', 'seglab']
 
 
 def md5(file_path):
@@ -54,7 +55,7 @@ def make_beatles_index(data_path):
 
                 annot_checksum, annot_rels = [], []
 
-                for annot_type in ['beat', 'chordlab', 'keylab', 'seglab']:
+                for annot_type in BEATLES_ANNOTATION_SCHEMA:
                     cds_dir = os.path.join(annotations_dir, annot_type, 'The Beatles')
                     annot_path = os.path.join(cds_dir, c)
                     if annot_type is 'beat':

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -1,0 +1,109 @@
+from __future__ import absolute_import
+
+import os
+import json
+
+import pytest
+
+from mirdata import beatles, utils
+from tests.test_utils import (mock_validated, mock_download, mock_untar,
+                              mock_validator, mock_clobber_all)
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    return mocker.patch.object(beatles, 'validate')
+
+
+@pytest.fixture
+def data_home(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def save_path(data_home):
+    return utils.get_save_path(data_home)
+
+
+@pytest.fixture
+def dataset_path(save_path):
+    return os.path.join(save_path, beatles.BEATLES_DIR)
+
+
+def test_download_already_valid(data_home, mocker,
+                                mock_clobber_all,
+                                mock_validated,
+                                mock_validator,
+                                mock_download,
+                                mock_untar):
+    mock_validated.return_value = True
+
+    beatles.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_download.assert_not_called()
+    mock_untar.assert_not_called()
+    mock_validator.assert_not_called()
+
+
+def test_download_clean(data_home,
+                        dataset_path,
+                        mocker,
+                        mock_clobber_all,
+                        mock_validated,
+                        mock_download,
+                        mock_untar,
+                        mock_validate):
+
+    mock_validated.return_value = False
+    mock_download.return_value = "foobar"
+    mock_untar.return_value = ""
+    mock_validate.return_value = (False, False)
+
+    beatles.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_download.assert_called_once()
+    mock_untar.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_download_clobber(data_home,
+                          dataset_path,
+                          mocker,
+                          mock_clobber_all,
+                          mock_validated,
+                          mock_download,
+                          mock_untar,
+                          mock_validate):
+
+    mock_validated.return_value = False
+    mock_download.return_value = "foobar"
+    mock_untar.return_value = ""
+    mock_validate.return_value = (False, False)
+
+    beatles.download(data_home, clobber=True)
+
+    mock_clobber_all.assert_called_once_with(beatles.BEATLES_ANNOT_REMOTE, dataset_path, data_home)
+    mock_validated.assert_called_once()
+    mock_download.assert_called_once()
+    mock_untar.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_validate_invalid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (True, True)
+
+    missing_files, invalid_checksums = beatles.validate(dataset_path)
+    assert missing_files and invalid_checksums
+    mock_validator.assert_called_once()
+
+
+def test_validate_valid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (False, False)
+
+    missing_files, invalid_checksums = beatles.validate(dataset_path)
+    assert not (missing_files or invalid_checksums)
+    mock_validator.assert_called_once()

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+
+import os
+import json
+
+import pytest
+
+from mirdata import ikala, utils
+from tests.test_utils import mock_validated, mock_validator, mock_clobber_all
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    return mocker.patch.object(ikala, 'validate')
+
+
+@pytest.fixture
+def data_home(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def save_path(data_home):
+    return utils.get_save_path(data_home)
+
+
+@pytest.fixture
+def dataset_path(save_path):
+    return os.path.join(save_path, ikala.IKALA_DIR)
+
+
+def test_download_already_valid(data_home, mocker,
+                                mock_clobber_all,
+                                mock_validated,
+                                mock_validator):
+    mock_validated.return_value = True
+
+    ikala.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_validator.assert_not_called()
+
+
+def test_download_clean(data_home,
+                        save_path,
+                        dataset_path,
+                        mocker,
+                        mock_clobber_all,
+                        mock_validated,
+                        mock_validate):
+
+    mock_validated.return_value = False
+    mock_validate.return_value = (False, False)
+
+    ikala.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_download_clobber(data_home,
+                          save_path,
+                          dataset_path,
+                          mocker,
+                          mock_clobber_all,
+                          mock_validated,
+                          mock_validate):
+
+    mock_validated.return_value = False
+    mock_validate.return_value = (False, False)
+
+    ikala.download(data_home, clobber=True)
+
+    mock_clobber_all.assert_called_once_with(ikala.IKALA_METADATA, dataset_path, data_home)
+    mock_validated.assert_called_once()
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_validate_invalid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (True, True)
+
+    missing_files, invalid_checksums = ikala.validate(dataset_path)
+    assert missing_files and invalid_checksums
+    mock_validator.assert_called_once()
+
+
+def test_validate_valid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (False, False)
+
+    missing_files, invalid_checksums = ikala.validate(dataset_path)
+    assert not (missing_files or invalid_checksums)
+    mock_validator.assert_called_once()

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+
+import os
+import json
+
+import pytest
+
+from mirdata import medleydb_melody, utils
+from tests.test_utils import mock_validated, mock_validator, mock_clobber_all
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    return mocker.patch.object(medleydb_melody, 'validate')
+
+
+@pytest.fixture
+def data_home(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def save_path(data_home):
+    return utils.get_save_path(data_home)
+
+
+@pytest.fixture
+def dataset_path(save_path):
+    return os.path.join(save_path, medleydb_melody.MEDLEYDB_MELODY_DIR)
+
+
+def test_download_already_valid(data_home, mocker,
+                                mock_clobber_all,
+                                mock_validated,
+                                mock_validator):
+    mock_validated.return_value = True
+
+    medleydb_melody.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_validator.assert_not_called()
+
+
+def test_download_clean(data_home,
+                        save_path,
+                        dataset_path,
+                        mocker,
+                        mock_clobber_all,
+                        mock_validated,
+                        mock_validate):
+
+    mock_validated.return_value = False
+    mock_validate.return_value = (False, False)
+
+    medleydb_melody.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_download_clobber(data_home,
+                          save_path,
+                          dataset_path,
+                          mocker,
+                          mock_clobber_all,
+                          mock_validated,
+                          mock_validate):
+
+    mock_validated.return_value = False
+    mock_validate.return_value = (False, False)
+
+    medleydb_melody.download(data_home, clobber=True)
+
+    mock_clobber_all.assert_called_once_with(medleydb_melody.MEDLEYDB_METADATA, dataset_path, data_home)
+    mock_validated.assert_called_once()
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_validate_invalid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (True, True)
+
+    missing_files, invalid_checksums = medleydb_melody.validate(dataset_path)
+    assert missing_files and invalid_checksums
+    mock_validator.assert_called_once()
+
+
+def test_validate_valid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (False, False)
+
+    missing_files, invalid_checksums = medleydb_melody.validate(dataset_path)
+    assert not (missing_files or invalid_checksums)
+    mock_validator.assert_called_once()

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -1,0 +1,94 @@
+from __future__ import absolute_import
+
+import os
+import json
+
+import pytest
+
+from mirdata import medleydb_pitch, utils
+from tests.test_utils import mock_validated, mock_validator, mock_clobber_all
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    return mocker.patch.object(medleydb_pitch, 'validate')
+
+
+@pytest.fixture
+def data_home(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def save_path(data_home):
+    return utils.get_save_path(data_home)
+
+
+@pytest.fixture
+def dataset_path(save_path):
+    return os.path.join(save_path, medleydb_pitch.MEDLEYDB_PITCH_DIR)
+
+
+def test_download_already_valid(data_home, mocker,
+                                mock_clobber_all,
+                                mock_validated,
+                                mock_validator):
+    mock_validated.return_value = True
+
+    medleydb_pitch.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_validator.assert_not_called()
+
+
+def test_download_clean(data_home,
+                        save_path,
+                        dataset_path,
+                        mocker,
+                        mock_clobber_all,
+                        mock_validated,
+                        mock_validate):
+
+    mock_validated.return_value = False
+    mock_validate.return_value = (False, False)
+
+    medleydb_pitch.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_download_clobber(data_home,
+                          save_path,
+                          dataset_path,
+                          mocker,
+                          mock_clobber_all,
+                          mock_validated,
+                          mock_validate):
+
+    mock_validated.return_value = False
+    mock_validate.return_value = (False, False)
+
+    medleydb_pitch.download(data_home, clobber=True)
+
+    mock_clobber_all.assert_called_once_with(medleydb_pitch.MEDLEYDB_METADATA, dataset_path, data_home)
+    mock_validated.assert_called_once()
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_validate_invalid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (True, True)
+
+    missing_files, invalid_checksums = medleydb_pitch.validate(dataset_path)
+    assert missing_files and invalid_checksums
+    mock_validator.assert_called_once()
+
+
+def test_validate_valid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (False, False)
+
+    missing_files, invalid_checksums = medleydb_pitch.validate(dataset_path)
+    assert not (missing_files or invalid_checksums)
+    mock_validator.assert_called_once()

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -1,0 +1,109 @@
+from __future__ import absolute_import
+
+import os
+import json
+
+import pytest
+
+from mirdata import orchset, utils
+from tests.test_utils import (mock_validated, mock_download, mock_unzip,
+                              mock_validator, mock_clobber_all)
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    return mocker.patch.object(orchset, 'validate')
+
+
+@pytest.fixture
+def data_home(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def save_path(data_home):
+    return utils.get_save_path(data_home)
+
+
+@pytest.fixture
+def dataset_path(save_path):
+    return os.path.join(save_path, orchset.ORCHSET_DIR)
+
+
+def test_download_already_valid(data_home, mocker,
+                                mock_clobber_all,
+                                mock_validated,
+                                mock_validator,
+                                mock_download,
+                                mock_unzip):
+    mock_validated.return_value = True
+
+    orchset.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_download.assert_not_called()
+    mock_unzip.assert_not_called()
+    mock_validator.assert_not_called()
+
+
+def test_download_clean(data_home,
+                        save_path,
+                        dataset_path,
+                        mocker,
+                        mock_clobber_all,
+                        mock_validated,
+                        mock_download,
+                        mock_unzip,
+                        mock_validate):
+
+    mock_validated.return_value = False
+    mock_download.return_value = "foobar"
+    mock_unzip.return_value = ""
+
+    orchset.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_download.assert_called_once()
+    mock_unzip.assert_called_once_with(mock_download.return_value, save_path, dataset_path)
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_download_clobber(data_home,
+                          save_path,
+                          dataset_path,
+                          mocker,
+                          mock_clobber_all,
+                          mock_validated,
+                          mock_download,
+                          mock_unzip,
+                          mock_validate):
+
+    mock_validated.return_value = False
+    mock_download.return_value = "foobar"
+    mock_unzip.return_value = ""
+
+    orchset.download(data_home, clobber=True)
+
+    mock_clobber_all.assert_called_once_with(orchset.ORCHSET_META, dataset_path, data_home)
+    mock_validated.assert_called_once()
+    mock_download.assert_called_once()
+    mock_unzip.assert_called_once_with(mock_download.return_value, save_path, dataset_path)
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_validate_invalid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (True, True)
+
+    missing_files, invalid_checksums = orchset.validate(dataset_path)
+    assert missing_files and invalid_checksums
+    mock_validator.assert_called_once()
+
+
+def test_validate_valid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (False, False)
+
+    missing_files, invalid_checksums = orchset.validate(dataset_path)
+    assert not (missing_files or invalid_checksums)
+    mock_validator.assert_called_once()

--- a/tests/test_salami.py
+++ b/tests/test_salami.py
@@ -1,0 +1,109 @@
+from __future__ import absolute_import
+
+import os
+import json
+
+import pytest
+
+from mirdata import salami, utils
+from tests.test_utils import (mock_validated, mock_download, mock_unzip,
+                              mock_validator, mock_clobber_all)
+
+
+@pytest.fixture
+def mock_validate(mocker):
+    return mocker.patch.object(salami, 'validate')
+
+
+@pytest.fixture
+def data_home(tmpdir):
+    return str(tmpdir)
+
+
+@pytest.fixture
+def save_path(data_home):
+    return utils.get_save_path(data_home)
+
+
+@pytest.fixture
+def dataset_path(save_path):
+    return os.path.join(save_path, salami.SALAMI_DIR)
+
+
+def test_download_already_valid(data_home, mocker,
+                                mock_clobber_all,
+                                mock_validated,
+                                mock_validator,
+                                mock_download,
+                                mock_unzip):
+    mock_validated.return_value = True
+
+    salami.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_download.assert_not_called()
+    mock_unzip.assert_not_called()
+    mock_validator.assert_not_called()
+
+
+def test_download_clean(data_home,
+                        dataset_path,
+                        mocker,
+                        mock_clobber_all,
+                        mock_validated,
+                        mock_download,
+                        mock_unzip,
+                        mock_validate):
+
+    mock_validated.return_value = False
+    mock_download.return_value = "foobar"
+    mock_unzip.return_value = ""
+    mock_validate.return_value = (False, False)
+
+    salami.download(data_home)
+
+    mock_clobber_all.assert_not_called()
+    mock_validated.assert_called_once()
+    mock_download.assert_called_once()
+    mock_unzip.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_download_clobber(data_home,
+                          dataset_path,
+                          mocker,
+                          mock_clobber_all,
+                          mock_validated,
+                          mock_download,
+                          mock_unzip,
+                          mock_validate):
+
+    mock_validated.return_value = False
+    mock_download.return_value = "foobar"
+    mock_unzip.return_value = ""
+    mock_validate.return_value = (False, False)
+
+    salami.download(data_home, clobber=True)
+
+    mock_clobber_all.assert_called_once_with(salami.SALAMI_ANNOT_REMOTE, dataset_path, data_home)
+    mock_validated.assert_called_once()
+    mock_download.assert_called_once()
+    mock_unzip.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)
+    mock_validate.assert_called_once_with(dataset_path, data_home)
+
+
+def test_validate_invalid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (True, True)
+
+    missing_files, invalid_checksums = salami.validate(dataset_path)
+    assert missing_files and invalid_checksums
+    mock_validator.assert_called_once()
+
+
+def test_validate_valid(dataset_path, mocker, mock_validator):
+    mock_validator.return_value = (False, False)
+
+    missing_files, invalid_checksums = salami.validate(dataset_path)
+    assert not (missing_files or invalid_checksums)
+    mock_validator.assert_called_once()


### PR DESCRIPTION
For #17 

I added functions and tests to create the `VALIDATED` and `INVALID.json` files. I've added a pretty good test coverage hopefully via unit tests and tried it out on the beatles datasets with what I think are the correct results (the `.wav`, `.txt` and `.lab` files are missing), which then show up in the json file.

We can merge this in and then adapt the other datasets later or we can do it all in here. Until then. Enjoy.