### PR TITLE
move to requests, throw friendly exception when downloading a file fails

### DIFF
--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -9,13 +9,9 @@ from __future__ import print_function
 from collections import namedtuple
 
 import csv
+import os
 import librosa
 import numpy as np
-import os
-try:
-    from urllib.request import urlretrieve  # py3
-except ImportError:
-    from urllib import urlretrieve  # py2
 
 import mirdata.utils as utils
 
@@ -177,11 +173,10 @@ def _reload_metadata(data_home):
 
 
 def _load_metadata(data_home):
-
     id_map_path = utils.get_local_path(
         data_home, os.path.join(IKALA_DIR, "id_mapping.txt"))
     if not os.path.exists(id_map_path):
-        urlretrieve(ID_MAPPING_URL, filename=id_map_path)
+        utils.downlad_large_file(ID_MAPPING_URL, id_map_path)
 
     with open(id_map_path, 'r') as fhandle:
         reader = csv.reader(fhandle, delimiter='\t')

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -176,7 +176,7 @@ def _load_metadata(data_home):
     id_map_path = utils.get_local_path(
         data_home, os.path.join(IKALA_DIR, "id_mapping.txt"))
     if not os.path.exists(id_map_path):
-        utils.downlad_large_file(ID_MAPPING_URL, id_map_path)
+        utils.download_large_file(ID_MAPPING_URL, id_map_path)
 
     with open(id_map_path, 'r') as fhandle:
         reader = csv.reader(fhandle, delimiter='\t')

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -10,15 +10,8 @@ import os
 import json
 import tarfile
 import shutil
-try:
-    from urllib.request import urlopen  # py3
-except ImportError:
-    from urllib2 import urlopen  # py2
-try:
-    from urllib.request import urlretrieve  # py3
-except ImportError:
-    from urllib import urlretrieve  # py2
 import zipfile
+import requests
 from tqdm import tqdm
 
 MIR_DATASETS_DIR = os.path.join(os.getenv("HOME", "/tmp"), "mir_datasets")
@@ -184,6 +177,17 @@ class DownloadProgressBar(tqdm):
         self.update(b * bsize - self.n)
 
 
+def download_large_file(url, download_path, callback=None):
+    response = requests.get(url)
+    response.raise_for_status()
+    with open(download_path, 'wb') as handle:
+        for block in response.iter_content(1024):
+            handle.write(block)
+            if callback:
+                callback()
+    return download_path
+
+
 def download_from_remote(remote, data_home=None, clobber=False):
     """Download a remote dataset into path
     Fetch a dataset pointed by remote's url, save into path using remote's
@@ -217,8 +221,16 @@ def download_from_remote(remote, data_home=None, clobber=False):
         with DownloadProgressBar(unit='B', unit_scale=True,
                                  miniters=1,
                                  desc=remote.url.split('/')[-1]) as t:
-            urlretrieve(
-                remote.url, filename=download_path, reporthook=t.update_to)
+            try:
+                download_large_file(remote.url, download_path, t.update_to)
+            except requests.exceptions.HTTPError:
+                error_msg = 'mirdata failed to download {}! \
+                             Please try again in a few minutes. \
+                             If this error persists, please raise an issue at \
+                             https://github.com/mir-dataset-loaders/mirdata, \
+                             and tag it with "broken-link". \
+                             '.format(remote.filename)
+                raise IOError(error_msg)
 
     checksum = md5(download_path)
     if remote.checksum != checksum:

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -12,6 +12,7 @@ import tarfile
 import shutil
 import zipfile
 import requests
+from requests.exceptions import HTTPError
 from tqdm import tqdm
 
 MIR_DATASETS_DIR = os.path.join(os.getenv("HOME", "/tmp"), "mir_datasets")
@@ -223,14 +224,15 @@ def download_from_remote(remote, data_home=None, clobber=False):
                                  desc=remote.url.split('/')[-1]) as t:
             try:
                 download_large_file(remote.url, download_path, t.update_to)
-            except requests.exceptions.HTTPError:
-                error_msg = 'mirdata failed to download {}! \
-                             Please try again in a few minutes. \
-                             If this error persists, please raise an issue at \
-                             https://github.com/mir-dataset-loaders/mirdata, \
-                             and tag it with "broken-link". \
-                             '.format(remote.filename)
-                raise IOError(error_msg)
+            except HTTPError:
+                error_msg = """
+                            mirdata failed to download the dataset!
+                            Please try again in a few minutes.
+                            If this error persists, please raise an issue at
+                            https://github.com/mir-dataset-loaders/mirdata,
+                            and tag it with "broken-link".
+                            """
+                raise HTTPError(error_msg)
 
     checksum = md5(download_path)
     if remote.checksum != checksum:
@@ -312,5 +314,3 @@ def clobber_all(remote, dataset_path, data_home=None):
 
     if dataset_path:
         shutil.rmtree(dataset_path)
-
-

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -182,7 +182,7 @@ def download_large_file(url, download_path, callback=lambda: None):
     response = requests.get(url)
     response.raise_for_status()
     with open(download_path, 'wb') as handle:
-        for block in response.iter_content(1024):
+        for block in response.iter_content(4096):
             handle.write(block)
             callback()
     return download_path

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -178,14 +178,13 @@ class DownloadProgressBar(tqdm):
         self.update(b * bsize - self.n)
 
 
-def download_large_file(url, download_path, callback=None):
+def download_large_file(url, download_path, callback=lambda: None):
     response = requests.get(url)
     response.raise_for_status()
     with open(download_path, 'wb') as handle:
         for block in response.iter_content(1024):
             handle.write(block)
-            if callback:
-                callback()
+            callback()
     return download_path
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-coveralls>=1.7.0
 six
-requests=2.21.0
 testcontainers
+coveralls>=1.7.0
+requests==2.21.0
 future==0.17.1
 pytest>=4.4.0
 pytest-mock>=1.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 coveralls>=1.7.0
 six
+requests=2.21.0
 testcontainers
 future==0.17.1
 pytest>=4.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 six
 testcontainers
-coveralls>=1.7.0
-requests==2.21.0
 future==0.17.1
+coveralls>=1.7.0
+requests>=2.21.0
 pytest>=4.4.0
 pytest-mock>=1.10.1
 pytest-localserver>=0.5.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,7 +164,7 @@ def test_download_from_remote(httpserver, tmpdir):
 
 
 def test_download_from_remote_raises_IOError(httpserver, tmpdir):
-    httpserver.serve_content(open('tests/resources/remote.wav').read())
+    httpserver.serve_content('File not found!', 404)
 
     TEST_META = utils.RemoteFileMetadata(
         filename="remote.wav",
@@ -244,4 +244,3 @@ def test_clobber_all_nonempty_data_home(httpserver, tmpdir):
     utils.clobber_all(TEST_META, tmpdir_str, tmpdir_str)
     assert not os.path.exists(os.path.join(tmpdir_str, remote_filename))
     assert not os.path.exists(tmpdir_str)
-


### PR DESCRIPTION
Fixes #52 and #34!

- Replaces the try/catch for imports with a single import for `requests`.  (We would have needed another try/catch for the `HTTPError`, which `requests` gives us for free)
- Creates our own `download_large_file` function to replace `urlretrieve`, which is the one thing requests does _not_ do out of the box.
- Updates `download_from_remote` to throw an HTTPError if things fail, with the discussed friendly error message.
- Updates tests accordingly.

I am not sure if `remote.filename` is the correct thing to format the string with.  @rabitt?  Also cc @drubinstein for review.
