### PR TITLE
Suggestion: rename download argument "clobber" to "force_overwrite"

### DIFF
--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -28,12 +28,12 @@ BeatlesTrack = namedtuple(
 )
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = utils.get_save_path(data_home)
     dataset_path = os.path.join(save_path, BEATLES_DIR)
 
-    if clobber:
-        utils.clobber_all(BEATLES_ANNOT_REMOTE,
+    if force_overwrite:
+        utils.force_overwrite_all(BEATLES_ANNOT_REMOTE,
                           dataset_path,
                           data_home)
 
@@ -41,12 +41,12 @@ def download(data_home=None, clobber=False):
         print("""
                 The {} dataset has already been downloaded and validated.
                 Skipping download of dataset. If you feel this is a mistake please
-                rerun and set clobber to true
+                rerun and set force_overwrite to true
                 """.format(BEATLES_DIR))
         return
 
     download_path = utils.download_from_remote(
-        BEATLES_ANNOT_REMOTE, data_home=data_home, clobber=clobber)
+        BEATLES_ANNOT_REMOTE, data_home=data_home, force_overwrite=force_overwrite)
     if not os.path.exists(dataset_path):
         os.makedirs(dataset_path)
     utils.untar(download_path, dataset_path, cleanup=True)

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -34,18 +34,18 @@ IKalaTrack = namedtuple(
 )
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = utils.get_save_path(data_home)
     dataset_path = os.path.join(save_path, IKALA_DIR)
 
-    if clobber:
-        utils.clobber_all(IKALA_METADATA,
+    if force_overwrite:
+        utils.force_overwrite_all(IKALA_METADATA,
                           dataset_path,
                           data_home)
     if utils.check_validated(dataset_path):
         print("""
                 The {} dataset has already been validated.
-                If you feel this is a mistake please rerun and set clobber to true.
+                If you feel this is a mistake please rerun and set force_overwrite to true.
                 """.format(IKALA_DIR))
         return
 

--- a/mirdata/maps.py
+++ b/mirdata/maps.py
@@ -12,9 +12,9 @@ MAPS_META = RemoteFileMetadata(
 MAPS_DIR = "MAPS"
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = get_save_path(data_home)
-    download_path = download_from_remote(MAPS_META, clobber=clobber)
+    download_path = download_from_remote(MAPS_META, force_overwrite=force_overwrite)
     untar(download_path, save_path)
     validate()
 

--- a/mirdata/medleydb_melody.py
+++ b/mirdata/medleydb_melody.py
@@ -34,18 +34,18 @@ MedleydbMelodyTrack = namedtuple(
 )
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = utils.get_save_path(data_home)
     dataset_path = os.path.join(save_path, MEDLEYDB_MELODY_DIR)
 
-    if clobber:
-        utils.clobber_all(MEDLEYDB_METADATA,
+    if force_overwrite:
+        utils.force_overwrite_all(MEDLEYDB_METADATA,
                           dataset_path,
                           data_home)
     if utils.check_validated(dataset_path):
         print("""
                 The {} dataset has already been validated.
-                If you feel this is a mistake please rerun and set clobber to true.
+                If you feel this is a mistake please rerun and set force_overwrite to true.
                 """.format(MEDLEYDB_MELODY_DIR))
         return
 

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -30,18 +30,18 @@ MedleydbPitchTrack = namedtuple(
 )
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = utils.get_save_path(data_home)
     dataset_path = os.path.join(save_path, MEDLEYDB_PITCH_DIR)
 
-    if clobber:
-        utils.clobber_all(MEDLEYDB_METADATA,
+    if force_overwrite:
+        utils.force_overwrite_all(MEDLEYDB_METADATA,
                           dataset_path,
                           data_home)
     if utils.check_validated(dataset_path):
         print("""
                 The {} dataset has already been validated.
-                If you feel this is a mistake please rerun and set clobber to true.
+                If you feel this is a mistake please rerun and set force_overwrite to true.
                 """.format(MEDLEYDB_PITCH_DIR))
         return
 

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -44,12 +44,12 @@ OrchsetTrack = namedtuple(
 )
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = utils.get_save_path(data_home)
     dataset_path = os.path.join(save_path, ORCHSET_DIR)
 
-    if clobber:
-        utils.clobber_all(ORCHSET_META,
+    if force_overwrite:
+        utils.force_overwrite_all(ORCHSET_META,
                           dataset_path,
                           data_home)
 
@@ -57,11 +57,11 @@ def download(data_home=None, clobber=False):
         print("""
                 The {} dataset has already been downloaded and validated.
                 Skipping download of dataset. If you feel this is a mistake please
-                rerun and set clobber to true
+                rerun and set force_overwrite to true
                 """.format(ORCHSET_DIR))
         return
 
-    download_path = utils.download_from_remote(ORCHSET_META, clobber=clobber)
+    download_path = utils.download_from_remote(ORCHSET_META, force_overwrite=force_overwrite)
     utils.unzip(download_path, save_path, dataset_path)
     validate(dataset_path, data_home)
 

--- a/mirdata/salami.py
+++ b/mirdata/salami.py
@@ -36,12 +36,12 @@ SalamiTrack = namedtuple(
 )
 
 
-def download(data_home=None, clobber=False):
+def download(data_home=None, force_overwrite=False):
     save_path = utils.get_save_path(data_home)
     dataset_path = os.path.join(save_path, SALAMI_DIR)
 
-    if clobber:
-        utils.clobber_all(SALAMI_ANNOT_REMOTE,
+    if force_overwrite:
+        utils.force_overwrite_all(SALAMI_ANNOT_REMOTE,
                           dataset_path,
                           data_home)
 
@@ -49,12 +49,12 @@ def download(data_home=None, clobber=False):
         print("""
                 The {} dataset has already been downloaded and validated.
                 Skipping download of dataset. If you feel this is a mistake please
-                rerun and set clobber to true
+                rerun and set force_overwrite to true
                 """.format(SALAMI_DIR))
         return
 
     download_path = utils.download_from_remote(
-        SALAMI_ANNOT_REMOTE, data_home=data_home, clobber=clobber)
+        SALAMI_ANNOT_REMOTE, data_home=data_home, force_overwrite=force_overwrite)
     if not os.path.exists(dataset_path):
         os.makedirs(dataset_path)
     utils.unzip(download_path, dataset_path, cleanup=True)

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -188,7 +188,7 @@ def download_large_file(url, download_path, callback=lambda: None):
     return download_path
 
 
-def download_from_remote(remote, data_home=None, clobber=False):
+def download_from_remote(remote, data_home=None, force_overwrite=False):
     """Download a remote dataset into path
     Fetch a dataset pointed by remote's url, save into path using remote's
     filename and ensure its integrity based on the MD5 Checksum of the
@@ -203,7 +203,7 @@ def download_from_remote(remote, data_home=None, clobber=False):
         and checksum
     data_home: string
         Directory to save the file to.
-    clobber: bool
+    force_overwrite: bool
         If True, overwrite existing file with the downloaded file.
         If False, does not overwrite, but checks that checksum is consistent.
 
@@ -216,7 +216,7 @@ def download_from_remote(remote, data_home=None, clobber=False):
         os.path.join(MIR_DATASETS_DIR, remote.filename) if data_home is None
         else os.path.join(data_home, remote.filename)
     )
-    if not os.path.exists(download_path) or clobber:
+    if not os.path.exists(download_path) or force_overwrite:
         # If file doesn't exist or we want to overwrite, download it
         with DownloadProgressBar(unit='B', unit_scale=True,
                                  miniters=1,
@@ -303,7 +303,7 @@ def create_invalid(dataset_path, missing_files, invalid_checksums):
                    'invalid_checksums': invalid_checksums}, f, indent=2)
 
 
-def clobber_all(remote, dataset_path, data_home=None):
+def force_overwrite_all(remote, dataset_path, data_home=None):
     if remote:
         download_path = (
             os.path.join(MIR_DATASETS_DIR, remote.filename) if data_home is None

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -7,7 +7,7 @@ import pytest
 
 from mirdata import beatles, utils
 from tests.test_utils import (mock_validated, mock_download, mock_untar,
-                              mock_validator, mock_clobber_all)
+                              mock_validator, mock_force_overwrite_all)
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def dataset_path(save_path):
 
 
 def test_download_already_valid(data_home, mocker,
-                                mock_clobber_all,
+                                mock_force_overwrite_all,
                                 mock_validated,
                                 mock_validator,
                                 mock_download,
@@ -40,7 +40,7 @@ def test_download_already_valid(data_home, mocker,
 
     beatles.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_download.assert_not_called()
     mock_untar.assert_not_called()
@@ -50,7 +50,7 @@ def test_download_already_valid(data_home, mocker,
 def test_download_clean(data_home,
                         dataset_path,
                         mocker,
-                        mock_clobber_all,
+                        mock_force_overwrite_all,
                         mock_validated,
                         mock_download,
                         mock_untar,
@@ -63,17 +63,17 @@ def test_download_clean(data_home,
 
     beatles.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_download.assert_called_once()
     mock_untar.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)
     mock_validate.assert_called_once_with(dataset_path, data_home)
 
 
-def test_download_clobber(data_home,
+def test_download_force_overwrite(data_home,
                           dataset_path,
                           mocker,
-                          mock_clobber_all,
+                          mock_force_overwrite_all,
                           mock_validated,
                           mock_download,
                           mock_untar,
@@ -84,9 +84,9 @@ def test_download_clobber(data_home,
     mock_untar.return_value = ""
     mock_validate.return_value = (False, False)
 
-    beatles.download(data_home, clobber=True)
+    beatles.download(data_home, force_overwrite=True)
 
-    mock_clobber_all.assert_called_once_with(beatles.BEATLES_ANNOT_REMOTE, dataset_path, data_home)
+    mock_force_overwrite_all.assert_called_once_with(beatles.BEATLES_ANNOT_REMOTE, dataset_path, data_home)
     mock_validated.assert_called_once()
     mock_download.assert_called_once()
     mock_untar.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from mirdata import ikala, utils
-from tests.test_utils import mock_validated, mock_validator, mock_clobber_all
+from tests.test_utils import mock_validated, mock_validator, mock_force_overwrite_all
 
 
 @pytest.fixture
@@ -30,14 +30,14 @@ def dataset_path(save_path):
 
 
 def test_download_already_valid(data_home, mocker,
-                                mock_clobber_all,
+                                mock_force_overwrite_all,
                                 mock_validated,
                                 mock_validator):
     mock_validated.return_value = True
 
     ikala.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_validator.assert_not_called()
 
@@ -46,7 +46,7 @@ def test_download_clean(data_home,
                         save_path,
                         dataset_path,
                         mocker,
-                        mock_clobber_all,
+                        mock_force_overwrite_all,
                         mock_validated,
                         mock_validate):
 
@@ -55,25 +55,25 @@ def test_download_clean(data_home,
 
     ikala.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_validate.assert_called_once_with(dataset_path, data_home)
 
 
-def test_download_clobber(data_home,
+def test_download_force_overwrite(data_home,
                           save_path,
                           dataset_path,
                           mocker,
-                          mock_clobber_all,
+                          mock_force_overwrite_all,
                           mock_validated,
                           mock_validate):
 
     mock_validated.return_value = False
     mock_validate.return_value = (False, False)
 
-    ikala.download(data_home, clobber=True)
+    ikala.download(data_home, force_overwrite=True)
 
-    mock_clobber_all.assert_called_once_with(ikala.IKALA_METADATA, dataset_path, data_home)
+    mock_force_overwrite_all.assert_called_once_with(ikala.IKALA_METADATA, dataset_path, data_home)
     mock_validated.assert_called_once()
     mock_validate.assert_called_once_with(dataset_path, data_home)
 

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from mirdata import medleydb_melody, utils
-from tests.test_utils import mock_validated, mock_validator, mock_clobber_all
+from tests.test_utils import mock_validated, mock_validator, mock_force_overwrite_all
 
 
 @pytest.fixture
@@ -30,14 +30,14 @@ def dataset_path(save_path):
 
 
 def test_download_already_valid(data_home, mocker,
-                                mock_clobber_all,
+                                mock_force_overwrite_all,
                                 mock_validated,
                                 mock_validator):
     mock_validated.return_value = True
 
     medleydb_melody.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_validator.assert_not_called()
 
@@ -46,7 +46,7 @@ def test_download_clean(data_home,
                         save_path,
                         dataset_path,
                         mocker,
-                        mock_clobber_all,
+                        mock_force_overwrite_all,
                         mock_validated,
                         mock_validate):
 
@@ -55,25 +55,25 @@ def test_download_clean(data_home,
 
     medleydb_melody.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_validate.assert_called_once_with(dataset_path, data_home)
 
 
-def test_download_clobber(data_home,
+def test_download_force_overwrite(data_home,
                           save_path,
                           dataset_path,
                           mocker,
-                          mock_clobber_all,
+                          mock_force_overwrite_all,
                           mock_validated,
                           mock_validate):
 
     mock_validated.return_value = False
     mock_validate.return_value = (False, False)
 
-    medleydb_melody.download(data_home, clobber=True)
+    medleydb_melody.download(data_home, force_overwrite=True)
 
-    mock_clobber_all.assert_called_once_with(medleydb_melody.MEDLEYDB_METADATA, dataset_path, data_home)
+    mock_force_overwrite_all.assert_called_once_with(medleydb_melody.MEDLEYDB_METADATA, dataset_path, data_home)
     mock_validated.assert_called_once()
     mock_validate.assert_called_once_with(dataset_path, data_home)
 

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -6,7 +6,7 @@ import json
 import pytest
 
 from mirdata import medleydb_pitch, utils
-from tests.test_utils import mock_validated, mock_validator, mock_clobber_all
+from tests.test_utils import mock_validated, mock_validator, mock_force_overwrite_all
 
 
 @pytest.fixture
@@ -30,14 +30,14 @@ def dataset_path(save_path):
 
 
 def test_download_already_valid(data_home, mocker,
-                                mock_clobber_all,
+                                mock_force_overwrite_all,
                                 mock_validated,
                                 mock_validator):
     mock_validated.return_value = True
 
     medleydb_pitch.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_validator.assert_not_called()
 
@@ -46,7 +46,7 @@ def test_download_clean(data_home,
                         save_path,
                         dataset_path,
                         mocker,
-                        mock_clobber_all,
+                        mock_force_overwrite_all,
                         mock_validated,
                         mock_validate):
 
@@ -55,25 +55,25 @@ def test_download_clean(data_home,
 
     medleydb_pitch.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_validate.assert_called_once_with(dataset_path, data_home)
 
 
-def test_download_clobber(data_home,
+def test_download_force_overwrite(data_home,
                           save_path,
                           dataset_path,
                           mocker,
-                          mock_clobber_all,
+                          mock_force_overwrite_all,
                           mock_validated,
                           mock_validate):
 
     mock_validated.return_value = False
     mock_validate.return_value = (False, False)
 
-    medleydb_pitch.download(data_home, clobber=True)
+    medleydb_pitch.download(data_home, force_overwrite=True)
 
-    mock_clobber_all.assert_called_once_with(medleydb_pitch.MEDLEYDB_METADATA, dataset_path, data_home)
+    mock_force_overwrite_all.assert_called_once_with(medleydb_pitch.MEDLEYDB_METADATA, dataset_path, data_home)
     mock_validated.assert_called_once()
     mock_validate.assert_called_once_with(dataset_path, data_home)
 

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -7,7 +7,7 @@ import pytest
 
 from mirdata import orchset, utils
 from tests.test_utils import (mock_validated, mock_download, mock_unzip,
-                              mock_validator, mock_clobber_all)
+                              mock_validator, mock_force_overwrite_all)
 
 
 @pytest.fixture
@@ -31,7 +31,7 @@ def dataset_path(save_path):
 
 
 def test_download_already_valid(data_home, mocker,
-                                mock_clobber_all,
+                                mock_force_overwrite_all,
                                 mock_validated,
                                 mock_validator,
                                 mock_download,
@@ -40,7 +40,7 @@ def test_download_already_valid(data_home, mocker,
 
     orchset.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_download.assert_not_called()
     mock_unzip.assert_not_called()
@@ -51,7 +51,7 @@ def test_download_clean(data_home,
                         save_path,
                         dataset_path,
                         mocker,
-                        mock_clobber_all,
+                        mock_force_overwrite_all,
                         mock_validated,
                         mock_download,
                         mock_unzip,
@@ -63,18 +63,18 @@ def test_download_clean(data_home,
 
     orchset.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_download.assert_called_once()
     mock_unzip.assert_called_once_with(mock_download.return_value, save_path, dataset_path)
     mock_validate.assert_called_once_with(dataset_path, data_home)
 
 
-def test_download_clobber(data_home,
+def test_download_force_overwrite(data_home,
                           save_path,
                           dataset_path,
                           mocker,
-                          mock_clobber_all,
+                          mock_force_overwrite_all,
                           mock_validated,
                           mock_download,
                           mock_unzip,
@@ -84,9 +84,9 @@ def test_download_clobber(data_home,
     mock_download.return_value = "foobar"
     mock_unzip.return_value = ""
 
-    orchset.download(data_home, clobber=True)
+    orchset.download(data_home, force_overwrite=True)
 
-    mock_clobber_all.assert_called_once_with(orchset.ORCHSET_META, dataset_path, data_home)
+    mock_force_overwrite_all.assert_called_once_with(orchset.ORCHSET_META, dataset_path, data_home)
     mock_validated.assert_called_once()
     mock_download.assert_called_once()
     mock_unzip.assert_called_once_with(mock_download.return_value, save_path, dataset_path)

--- a/tests/test_salami.py
+++ b/tests/test_salami.py
@@ -4,7 +4,7 @@ import os
 import pytest
 from mirdata import salami, utils
 from tests.test_utils import (mock_validated, mock_download, mock_unzip,
-                              mock_validator, mock_clobber_all)
+                              mock_validator, mock_force_overwrite_all)
 
 
 @pytest.fixture
@@ -32,7 +32,7 @@ def dataset_path(save_path):
 
 
 def test_download_already_valid(data_home, mocker,
-                                mock_clobber_all,
+                                mock_force_overwrite_all,
                                 mock_validated,
                                 mock_validator,
                                 mock_download,
@@ -41,7 +41,7 @@ def test_download_already_valid(data_home, mocker,
 
     salami.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_download.assert_not_called()
     mock_unzip.assert_not_called()
@@ -51,7 +51,7 @@ def test_download_already_valid(data_home, mocker,
 def test_download_clean(data_home,
                         dataset_path,
                         mocker,
-                        mock_clobber_all,
+                        mock_force_overwrite_all,
                         mock_validated,
                         mock_download,
                         mock_unzip,
@@ -64,17 +64,17 @@ def test_download_clean(data_home,
 
     salami.download(data_home)
 
-    mock_clobber_all.assert_not_called()
+    mock_force_overwrite_all.assert_not_called()
     mock_validated.assert_called_once()
     mock_download.assert_called_once()
     mock_unzip.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)
     mock_validate.assert_called_once_with(dataset_path, data_home)
 
 
-def test_download_clobber(data_home,
+def test_download_force_overwrite(data_home,
                           dataset_path,
                           mocker,
-                          mock_clobber_all,
+                          mock_force_overwrite_all,
                           mock_validated,
                           mock_download,
                           mock_unzip,
@@ -85,9 +85,9 @@ def test_download_clobber(data_home,
     mock_unzip.return_value = ""
     mock_validate.return_value = (False, False)
 
-    salami.download(data_home, clobber=True)
+    salami.download(data_home, force_overwrite=True)
 
-    mock_clobber_all.assert_called_once_with(salami.SALAMI_ANNOT_REMOTE, dataset_path, data_home)
+    mock_force_overwrite_all.assert_called_once_with(salami.SALAMI_ANNOT_REMOTE, dataset_path, data_home)
     mock_validated.assert_called_once()
     mock_download.assert_called_once()
     mock_unzip.assert_called_once_with(mock_download.return_value, dataset_path, cleanup=True)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -40,8 +40,8 @@ def mock_validator(mocker):
 
 
 @pytest.fixture
-def mock_clobber_all(mocker):
-    return mocker.patch.object(utils, 'clobber_all')
+def mock_force_overwrite_all(mocker):
+    return mocker.patch.object(utils, 'force_overwrite_all')
 
 
 @pytest.fixture
@@ -226,7 +226,7 @@ def test_create_invalid(tmpdir,
                                    'invalid_checksums': invalid_checksums}
 
 
-def test_clobber_all_nonempty_data_home(httpserver, tmpdir):
+def test_force_overwrite_all_nonempty_data_home(httpserver, tmpdir):
     tmpdir_str = str(tmpdir)
     remote_filename = "remote.wav"
     TEST_META = utils.RemoteFileMetadata(
@@ -241,6 +241,6 @@ def test_clobber_all_nonempty_data_home(httpserver, tmpdir):
     utils.untar("tests/resources/remote.tar.gz", tmpdir_str)
     assert os.path.exists(os.path.join(tmpdir_str, remote_filename))
     assert os.path.exists(tmpdir_str)
-    utils.clobber_all(TEST_META, tmpdir_str, tmpdir_str)
+    utils.force_overwrite_all(TEST_META, tmpdir_str, tmpdir_str)
     assert not os.path.exists(os.path.join(tmpdir_str, remote_filename))
     assert not os.path.exists(tmpdir_str)


### PR DESCRIPTION
Just a suggestion.

Method signatures should be self-explaining if possible. "clobber" is not immediately obvious.