### PR TITLE
update tox to run black, run black

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import os
 import six
 import sys
+
 sys.path.insert(0, os.path.abspath('../'))
 
 # -- Project information -----------------------------------------------------
@@ -47,11 +48,12 @@ author = 'Rachel Bittner, Magdalena Fuentes, David Rubinstein, Andreas Jansson, 
 # # Add any Sphinx extension module names here, as strings. They can be
 # # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # # ones.
-extensions = ['recommonmark',
-              'sphinx.ext.autodoc',
-              'sphinx.ext.coverage',
-              'sphinx.ext.napoleon',
-              'sphinx.ext.viewcode',
+extensions = [
+    'recommonmark',
+    'sphinx.ext.autodoc',
+    'sphinx.ext.coverage',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
 ]
 
 

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -51,10 +51,10 @@ class Track(object):
         sections (SectionData): sections annotation
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
-            raise ValueError(
-                '{} is not a valid track ID in Beatles'.format(track_id))
+            raise ValueError('{} is not a valid track ID in Beatles'.format(track_id))
 
         self.track_id = track_id
 
@@ -64,43 +64,47 @@ class Track(object):
         self._data_home = data_home
         self._track_paths = INDEX[track_id]
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
 
-        self.title = os.path.basename(
-            self._track_paths['sections'][0]).split('.')[0]
+        self.title = os.path.basename(self._track_paths['sections'][0]).split('.')[0]
 
     def __repr__(self):
-        repr_string = "Beatles Track(track_id={}, audio_path={}, title={}, " + \
-            "beats=BeatData('beat_times, 'beat_positions'), " + \
-            "chords=ChordData('start_times', 'end_times', 'chords'), " + \
-            "key=KeyData('start_times', 'end_times', 'keys'), " + \
-            "sections=SectionData('start_times', 'end_times', 'sections'))"
+        repr_string = (
+            "Beatles Track(track_id={}, audio_path={}, title={}, "
+            + "beats=BeatData('beat_times, 'beat_positions'), "
+            + "chords=ChordData('start_times', 'end_times', 'chords'), "
+            + "key=KeyData('start_times', 'end_times', 'keys'), "
+            + "sections=SectionData('start_times', 'end_times', 'sections'))"
+        )
         return repr_string.format(self.track_id, self.audio_path, self.title)
 
     @utils.cached_property
     def beats(self):
         if not self._track_paths['beat'][0] is None:
-            return _load_beats(os.path.join(
-                self._data_home, self._track_paths['beat'][0]))
+            return _load_beats(
+                os.path.join(self._data_home, self._track_paths['beat'][0])
+            )
         return None
 
     @utils.cached_property
     def chords(self):
-        return _load_chords(os.path.join(
-            self._data_home, self._track_paths['chords'][0]))
+        return _load_chords(
+            os.path.join(self._data_home, self._track_paths['chords'][0])
+        )
 
     @utils.cached_property
     def key(self):
         if not self._track_paths['keys'][0] is None:
-            return _load_key(os.path.join(
-                self._data_home, self._track_paths['keys'][0]))
+            return _load_key(
+                os.path.join(self._data_home, self._track_paths['keys'][0])
+            )
         return None
 
     @utils.cached_property
     def sections(self):
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['sections'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['sections'][0])
+        )
 
     @property
     def audio(self):
@@ -130,11 +134,16 @@ def download(data_home=None, force_overwrite=False):
                 > annotations/
                 > audio/
         and copy the Beatles folder to {}
-    """.format(data_home)
+    """.format(
+        data_home
+    )
 
     download_utils.downloader(
-        data_home, tar_downloads=[ANNOTATIONS_REMOTE],
-        info_message=download_message, force_overwrite=force_overwrite)
+        data_home,
+        tar_downloads=[ANNOTATIONS_REMOTE],
+        info_message=download_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -24,8 +24,14 @@ from mirdata.utils import md5
 RemoteFileMetadata = namedtuple('RemoteFileMetadata', ['filename', 'url', 'checksum'])
 
 
-def downloader(save_dir, zip_downloads=None, tar_downloads=None,
-               file_downloads=None, info_message=None, force_overwrite=False):
+def downloader(
+    save_dir,
+    zip_downloads=None,
+    tar_downloads=None,
+    file_downloads=None,
+    info_message=None,
+    force_overwrite=False,
+):
     """Download data to `save_dir` and optionally print a message.
 
     Args:
@@ -59,8 +65,7 @@ def downloader(save_dir, zip_downloads=None, tar_downloads=None,
 
     if file_downloads is not None:
         for file_download in file_downloads:
-            download_from_remote(
-                file_download, save_dir, force_overwrite)
+            download_from_remote(file_download, save_dir, force_overwrite)
 
     if info_message is not None:
         print(info_message)
@@ -68,6 +73,7 @@ def downloader(save_dir, zip_downloads=None, tar_downloads=None,
 
 class DownloadProgressBar(tqdm):
     """Wrap `tqdm` to show download progress"""
+
     def update_to(self, b=1, bsize=1, tsize=None):
         if tsize is not None:
             self.total = tsize
@@ -138,8 +144,7 @@ def download_from_remote(remote, data_home, force_overwrite=False):
 
 
 def download_zip_file(zip_remote, save_dir, force_overwrite, cleanup=False):
-    zip_download_path = download_from_remote(
-        zip_remote, save_dir, force_overwrite)
+    zip_download_path = download_from_remote(zip_remote, save_dir, force_overwrite)
     unzip(zip_download_path, save_dir, cleanup=cleanup)
 
 
@@ -163,8 +168,7 @@ def unzip(zip_path, save_dir, cleanup=False):
 
 
 def download_tar_file(tar_remote, save_dir, force_overwrite, cleanup=False):
-    tar_download_path = download_from_remote(
-        tar_remote, save_dir, force_overwrite)
+    tar_download_path = download_from_remote(tar_remote, save_dir, force_overwrite)
     untar(tar_download_path, save_dir, cleanup=cleanup)
 
 

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -44,7 +44,7 @@ METADATA = None
 ID_MAPPING_REMOTE = download_utils.RemoteFileMetadata(
     filename='id_mapping.txt',
     url='http://mac.citi.sinica.edu.tw/ikala/id_mapping.txt',
-    checksum='81097b587804ce93e56c7a331ba06abc'
+    checksum='81097b587804ce93e56c7a331ba06abc',
 )
 
 
@@ -66,10 +66,10 @@ class Track(object):
         lyrics (LyricData): lyrics
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
-            raise ValueError(
-                '{} is not a valid track ID in iKala'.format(track_id))
+            raise ValueError('{} is not a valid track ID in iKala'.format(track_id))
 
         if METADATA is None or METADATA['data_home'] != data_home:
             _reload_metadata(data_home)
@@ -82,8 +82,7 @@ class Track(object):
         self._data_home = data_home
         self._track_paths = INDEX[track_id]
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
         self.song_id = track_id.split('_')[0]
         self.section = track_id.split('_')[1]
         if METADATA is not None and self.song_id in METADATA:
@@ -92,23 +91,25 @@ class Track(object):
             self.singer_id = None
 
     def __repr__(self):
-        repr_string = "iKala Track(track_id={}, audio_path={}, song_id={}, " + \
-            "section={}, singer_id={}, " + \
-            "f0=F0Data('times', 'frequencies', 'confidence'), " + \
-            "lyrics=LyricData('start_times', 'end_times', 'lyrics', 'pronounciations'))"
+        repr_string = (
+            "iKala Track(track_id={}, audio_path={}, song_id={}, "
+            + "section={}, singer_id={}, "
+            + "f0=F0Data('times', 'frequencies', 'confidence'), "
+            + "lyrics=LyricData('start_times', 'end_times', 'lyrics', 'pronounciations'))"
+        )
         return repr_string.format(
             self.track_id, self.audio_path, self.song_id, self.section, self.singer_id
         )
 
     @utils.cached_property
     def f0(self):
-        return _load_f0(os.path.join(
-            self._data_home, self._track_paths['pitch'][0]))
+        return _load_f0(os.path.join(self._data_home, self._track_paths['pitch'][0]))
 
     @utils.cached_property
     def lyrics(self):
-        return _load_lyrics(os.path.join(
-            self._data_home, self._track_paths['lyrics'][0]))
+        return _load_lyrics(
+            os.path.join(self._data_home, self._track_paths['lyrics'][0])
+        )
 
     @property
     def vocal_audio(self):
@@ -170,10 +171,16 @@ def download(data_home=None, force_overwrite=False):
                 > PitchLabel/
                 > Wavfile/
         and copy the {ikala_dir} folder to {save_path}
-    """.format(ikala_dir=DATASET_DIR, save_path=data_home)
+    """.format(
+        ikala_dir=DATASET_DIR, save_path=data_home
+    )
 
-    download_utils.downloader(data_home, file_downloads=[ID_MAPPING_REMOTE],
-                              info_message=download_message, force_overwrite=force_overwrite)
+    download_utils.downloader(
+        data_home,
+        file_downloads=[ID_MAPPING_REMOTE],
+        info_message=download_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -265,8 +272,11 @@ def _load_lyrics(lyrics_path):
                 pronunciations.append(None)
 
     lyrics_data = utils.LyricData(
-        np.array(start_times), np.array(end_times),
-        np.array(lyrics), np.array(pronunciations))
+        np.array(start_times),
+        np.array(end_times),
+        np.array(lyrics),
+        np.array(pronunciations),
+    )
     return lyrics_data
 
 

--- a/mirdata/medleydb_melody.py
+++ b/mirdata/medleydb_melody.py
@@ -60,6 +60,7 @@ class Track(object):
         melody3 (F0Data):
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
             raise ValueError(
@@ -86,11 +87,10 @@ class Track(object):
                 'genre': None,
                 'is_excerpt': None,
                 'is_instrumental': None,
-                'n_sources': None
+                'n_sources': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
         self.artist = self._track_metadata['artist']
         self.title = self._track_metadata['title']
         self.genre = self._track_metadata['genre']
@@ -99,12 +99,14 @@ class Track(object):
         self.n_sources = self._track_metadata['n_sources']
 
     def __repr__(self):
-        repr_string = "MedleyDb-Melody Track(track_id={}, audio_path={}, " + \
-            "artist={}, title={}, genre={}, is_excerpt={}, " + \
-            "is_instrumental={}, n_sources={}, " + \
-            "melody1=F0Data('times', 'frequencies', confidence'), " + \
-            "melody2=F0Data('times', 'frequencies', confidence'), " + \
-            "melody3=F0Data('times', 'frequencies', confidence'))"
+        repr_string = (
+            "MedleyDb-Melody Track(track_id={}, audio_path={}, "
+            + "artist={}, title={}, genre={}, is_excerpt={}, "
+            + "is_instrumental={}, n_sources={}, "
+            + "melody1=F0Data('times', 'frequencies', confidence'), "
+            + "melody2=F0Data('times', 'frequencies', confidence'), "
+            + "melody3=F0Data('times', 'frequencies', confidence'))"
+        )
         return repr_string.format(
             self.track_id,
             self.audio_path,
@@ -118,18 +120,21 @@ class Track(object):
 
     @utils.cached_property
     def melody1(self):
-        return _load_melody(os.path.join(
-            self._data_home, self._track_paths['melody1'][0]))
+        return _load_melody(
+            os.path.join(self._data_home, self._track_paths['melody1'][0])
+        )
 
     @utils.cached_property
     def melody2(self):
-        return _load_melody(os.path.join(
-            self._data_home, self._track_paths['melody2'][0]))
+        return _load_melody(
+            os.path.join(self._data_home, self._track_paths['melody2'][0])
+        )
 
     @utils.cached_property
     def melody3(self):
-        return _load_melody3(os.path.join(
-            self._data_home, self._track_paths['melody3'][0]))
+        return _load_melody3(
+            os.path.join(self._data_home, self._track_paths['melody3'][0])
+        )
 
     @property
     def audio(self):
@@ -157,7 +162,9 @@ def download(data_home=None):
         Once downloaded, unzip the file MedleyDB-Melody.zip
         and copy the result to:
         {data_home}
-    """.format(data_home=data_home)
+    """.format(
+        data_home=data_home
+    )
 
     download_utils.downloader(info_message=info_message)
 
@@ -258,9 +265,7 @@ def _reload_metadata(data_home):
 
 
 def _load_metadata(data_home):
-    metadata_path = os.path.join(
-        data_home, 'medleydb_melody_metadata.json'
-    )
+    metadata_path = os.path.join(data_home, 'medleydb_melody_metadata.json')
 
     if not os.path.exists(metadata_path):
         print("Warning: metadata file {} not found.".format(metadata_path))

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -55,6 +55,7 @@ class Track(object):
         pitch (PitchData): pitch annotation
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
             raise ValueError(
@@ -79,20 +80,21 @@ class Track(object):
                 'instrument': None,
                 'artist': None,
                 'title': None,
-                'genre': None
+                'genre': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
         self.instrument = self._track_metadata['instrument']
         self.artist = self._track_metadata['artist']
         self.title = self._track_metadata['title']
         self.genre = self._track_metadata['genre']
 
     def __repr__(self):
-        repr_string = "MedleyDb-Pitch Track(track_id={}, audio_path={}, " + \
-            "artist={}, title={}, genre={}, instrument={}, " + \
-            "pitch=PitchData('times', 'pitches', 'confidence'))"
+        repr_string = (
+            "MedleyDb-Pitch Track(track_id={}, audio_path={}, "
+            + "artist={}, title={}, genre={}, instrument={}, "
+            + "pitch=PitchData('times', 'pitches', 'confidence'))"
+        )
         return repr_string.format(
             self.track_id,
             self.audio_path,
@@ -104,8 +106,7 @@ class Track(object):
 
     @utils.cached_property
     def pitch(self):
-        return _load_pitch(os.path.join(
-            self._data_home, self._track_paths['pitch'][0]))
+        return _load_pitch(os.path.join(self._data_home, self._track_paths['pitch'][0]))
 
     @property
     def audio(self):
@@ -133,7 +134,9 @@ def download(data_home=None):
         Once downloaded, unzip the file MedleyDB-Pitch.zip
         and copy the result to:
         {data_home}
-    """.format(data_home=data_home)
+    """.format(
+        data_home=data_home
+    )
 
     download.downloaderdownloader(info_message=info_message)
 
@@ -215,9 +218,7 @@ def _reload_metadata(data_home):
 
 
 def _load_metadata(data_home):
-    metadata_path = os.path.join(
-        data_home, 'medleydb_pitch_metadata.json'
-    )
+    metadata_path = os.path.join(data_home, 'medleydb_pitch_metadata.json')
 
     if not os.path.exists(metadata_path):
         print("Warning: metadata file {} not found.".format(metadata_path))

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -67,6 +67,7 @@ class Track(object):
         melody (F0Data): melody annotation
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
             raise ValueError('{} is not a valid track ID in Orchset'.format(track_id))
@@ -101,14 +102,17 @@ class Track(object):
             }
 
         self.audio_path_mono = os.path.join(
-            self._data_home, self._track_paths['audio_mono'][0])
+            self._data_home, self._track_paths['audio_mono'][0]
+        )
         self.audio_path_stereo = os.path.join(
-            self._data_home, self._track_paths['audio_stereo'][0])
+            self._data_home, self._track_paths['audio_stereo'][0]
+        )
         self.composer = self._track_metadata['composer']
         self.work = self._track_metadata['work']
         self.excerpt = self._track_metadata['excerpt']
-        self.predominant_melodic_instruments = \
-            self._track_metadata['predominant_melodic_instruments-normalized']
+        self.predominant_melodic_instruments = self._track_metadata[
+            'predominant_melodic_instruments-normalized'
+        ]
         self.alternating_melody = self._track_metadata['alternating_melody']
         self.contains_winds = self._track_metadata['contains_winds']
         self.contains_strings = self._track_metadata['contains_strings']
@@ -118,12 +122,14 @@ class Track(object):
         self.only_brass = self._track_metadata['only_brass']
 
     def __repr__(self):
-        repr_string = "Orchset Track(track_id={}, audio_path_stereo={}, " + \
-            "audio_path_mono={}, composer={}, work={}, excerpt={}, " + \
-            "predominant_melodic_instruments={}, alternating_melody={}, " + \
-            "contains_winds={}, contains_strings={}, contains_brass={}, " + \
-            "only_strings={}, only_winds={}, only_brass={}, " + \
-            "melody=F0Data('times', 'frequencies', 'confidence'))"
+        repr_string = (
+            "Orchset Track(track_id={}, audio_path_stereo={}, "
+            + "audio_path_mono={}, composer={}, work={}, excerpt={}, "
+            + "predominant_melodic_instruments={}, alternating_melody={}, "
+            + "contains_winds={}, contains_strings={}, contains_brass={}, "
+            + "only_strings={}, only_winds={}, only_brass={}, "
+            + "melody=F0Data('times', 'frequencies', 'confidence'))"
+        )
         return repr_string.format(
             self.track_id,
             self.audio_path_stereo,
@@ -143,8 +149,9 @@ class Track(object):
 
     @utils.cached_property
     def melody(self):
-        return _load_melody(os.path.join(
-            self._data_home, self._track_paths['melody'][0]))
+        return _load_melody(
+            os.path.join(self._data_home, self._track_paths['melody'][0])
+        )
 
     @property
     def audio_mono(self):
@@ -168,7 +175,8 @@ def download(data_home=None, force_overwrite=False):
         data_home = utils.get_default_dataset_path(DATASET_DIR)
 
     download_utils.downloader(
-        data_home, zip_downloads=[REMOTE], force_overwrite=force_overwrite)
+        data_home, zip_downloads=[REMOTE], force_overwrite=force_overwrite
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -245,8 +253,7 @@ def _load_melody(melody_path):
 def _load_metadata(data_home):
 
     predominant_inst_path = os.path.join(
-        data_home,
-        'Orchset - Predominant Melodic Instruments.csv',
+        data_home, 'Orchset - Predominant Melodic Instruments.csv'
     )
 
     if not os.path.exists(predominant_inst_path):

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -14,22 +14,27 @@ METADATA = None
 METADATA_REMOTE = download_utils.RemoteFileMetadata(
     filename='rwc-c.csv',
     url='https://github.com/magdalenafuentes/metadata/archive/master.zip',
-    checksum='7dbe87fedbaaa1f348625a2af1d78030')
+    checksum='7dbe87fedbaaa1f348625a2af1d78030',
+)
 DATASET_DIR = 'RWC-Classical'
 ANNOTATIONS_REMOTE_1 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-C-2001.BEAT.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-C-2001.BEAT.zip',
-    checksum='e8ee05854833cbf5eb7280663f71c29b')
+    checksum='e8ee05854833cbf5eb7280663f71c29b',
+)
 ANNOTATIONS_REMOTE_2 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-C-2001.CHORUS.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-C-2001.CHORUS.zip',
-    checksum='f77bd527510376f59f5a2eed8fd7feb3')
+    checksum='f77bd527510376f59f5a2eed8fd7feb3',
+)
 
 
 class Track(object):
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
-            raise ValueError('{} is not a valid track ID in RWC-Classical'.format(track_id))
+            raise ValueError(
+                '{} is not a valid track ID in RWC-Classical'.format(track_id)
+            )
 
         self.track_id = track_id
 
@@ -56,8 +61,7 @@ class Track(object):
                 'category': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
 
         self.piece_number = self._track_metadata['piece_number']
         self.suffix = self._track_metadata['suffix']
@@ -69,26 +73,35 @@ class Track(object):
         self.category = self._track_metadata['category']
 
     def __repr__(self):
-        repr_string = "RWC-Classical Track(track_id={}, audio_path={}, " + \
-            "piece_number={}, suffix={}, track_number={}, title={}, composer={}, " + \
-            "artist={}, duration_sec={}, category={}" + \
-            "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-            "beats=BeatData('beat_times', 'beat_positions'))"
+        repr_string = (
+            "RWC-Classical Track(track_id={}, audio_path={}, "
+            + "piece_number={}, suffix={}, track_number={}, title={}, composer={}, "
+            + "artist={}, duration_sec={}, category={}"
+            + "sections=SectionData('start_times', 'end_times', 'sections'), "
+            + "beats=BeatData('beat_times', 'beat_positions'))"
+        )
         return repr_string.format(
-            self.track_id, self.audio_path, self.piece_number, self.suffix,
-            self.track_number, self.title, self.composer, self.artist,
-            self.duration_sec, self.category
+            self.track_id,
+            self.audio_path,
+            self.piece_number,
+            self.suffix,
+            self.track_number,
+            self.title,
+            self.composer,
+            self.artist,
+            self.duration_sec,
+            self.category,
         )
 
     @utils.cached_property
     def sections(self):
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['sections'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['sections'][0])
+        )
 
     @utils.cached_property
     def beats(self):
-        return _load_beats(os.path.join(
-            self._data_home, self._track_paths['beats'][0]))
+        return _load_beats(os.path.join(self._data_home, self._track_paths['beats'][0]))
 
     @property
     def audio(self):
@@ -101,8 +114,11 @@ def download(data_home=None, force_overwrite=False):
         data_home = utils.get_default_dataset_path(DATASET_DIR)
 
     annotations_path = os.path.join(data_home, 'annotations')
-    download_utils.downloader(annotations_path, force_overwrite=force_overwrite,
-                              zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2])
+    download_utils.downloader(
+        annotations_path,
+        force_overwrite=force_overwrite,
+        zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2],
+    )
 
     info_message = """
         Unfortunately the audio files of the RWC-Jazz dataset are not available
@@ -113,10 +129,16 @@ def download(data_home=None, force_overwrite=False):
                 > audio/rwc-c-m0i with i in [1 .. 6]
                 > metadata-master/
         and copy the RWC-Classical folder to {}
-    """.format(data_home)
+    """.format(
+        data_home
+    )
 
-    download_utils.downloader(data_home, zip_downloads=[METADATA_REMOTE],
-                              info_message=info_message, force_overwrite=force_overwrite)
+    download_utils.downloader(
+        data_home,
+        zip_downloads=[METADATA_REMOTE],
+        info_message=info_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -180,11 +202,11 @@ def _load_sections(sections_path):
     secs = []  # section labels
 
     with open(sections_path, 'r') as fhandle:
-            reader = csv.reader(fhandle, delimiter='\t')
-            for line in reader:
-                begs.append(float(line[0]) / 100.0)
-                ends.append(float(line[1]) / 100.0)
-                secs.append(line[2])
+        reader = csv.reader(fhandle, delimiter='\t')
+        for line in reader:
+            begs.append(float(line[0]) / 100.0)
+            ends.append(float(line[1]) / 100.0)
+            secs.append(line[2])
 
     return utils.SectionData(np.array(begs), np.array(ends), np.array(secs))
 
@@ -211,7 +233,9 @@ def _position_in_bar(beat_positions, beat_times):
     if not downbeat_positions[0] == 0:
         timesig_next_bar = beat_positions_corrected[downbeat_positions[1] - 1]
         for b in range(1, downbeat_positions[0] + 1):
-            beat_positions_corrected[downbeat_positions[0] - b] = timesig_next_bar - b + 1
+            beat_positions_corrected[downbeat_positions[0] - b] = (
+                timesig_next_bar - b + 1
+            )
 
     return beat_positions_corrected, beat_times_corrected
 
@@ -219,7 +243,7 @@ def _position_in_bar(beat_positions, beat_times):
 def _load_beats(beats_path):
     if not os.path.exists(beats_path):
         return None
-    beat_times = []   # timestamps of beat interval beginnings
+    beat_times = []  # timestamps of beat interval beginnings
     beat_positions = []  # beat position inside the bar
 
     with open(beats_path, 'r') as fhandle:
@@ -228,7 +252,8 @@ def _load_beats(beats_path):
             beat_times.append(float(line[0]) / 100.0)
             beat_positions.append(int(line[2]))
     beat_positions, beat_times = _position_in_bar(
-        np.array(beat_positions), np.array(beat_times))
+        np.array(beat_positions), np.array(beat_times)
+    )
 
     return utils.BeatData(beat_times, beat_positions)
 
@@ -256,7 +281,7 @@ def _load_metadata(data_home):
         if line[0] == 'Piece No.':
             continue
         p = '00' + line[0].split('.')[1][1:]
-        track_id = 'RM-C{}'.format(p[len(p) - 3:])
+        track_id = 'RM-C{}'.format(p[len(p) - 3 :])
 
         metadata_index[track_id] = {
             'piece_number': line[0],

--- a/mirdata/rwc_genre.py
+++ b/mirdata/rwc_genre.py
@@ -16,16 +16,19 @@ METADATA = None
 METADATA_REMOTE = download_utils.RemoteFileMetadata(
     filename='rwc-g.csv',
     url='https://github.com/magdalenafuentes/metadata/archive/master.zip',
-    checksum='7dbe87fedbaaa1f348625a2af1d78030')
+    checksum='7dbe87fedbaaa1f348625a2af1d78030',
+)
 DATASET_DIR = 'RWC-Genre'
 ANNOTATIONS_REMOTE_1 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-G-2001.BEAT.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-G-2001.BEAT.zip',
-    checksum='66427ce5f4485088c6d9bc5f7394f65f')
-ANNOTATIONS_REMOTE_2 =  download_utils.RemoteFileMetadata(
+    checksum='66427ce5f4485088c6d9bc5f7394f65f',
+)
+ANNOTATIONS_REMOTE_2 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-G-2001.CHORUS.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-G-2001.CHORUS.zip',
-    checksum='e9fe612a0ddc7a83f3c1d17fb5fec32a')
+    checksum='e9fe612a0ddc7a83f3c1d17fb5fec32a',
+)
 
 
 class Track(object):
@@ -59,8 +62,7 @@ class Track(object):
                 'duration_sec': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
 
         self.piece_number = self._track_metadata['piece_number']
         self.suffix = self._track_metadata['suffix']
@@ -73,27 +75,37 @@ class Track(object):
         self.duration_sec = self._track_metadata['duration_sec']
 
     def __repr__(self):
-        repr_string = "RWC-Genre Track(track_id={}, audio_path={}, " + \
-            "piece_number={}, suffix={}, track_number={}, category={}, " + \
-            "sub_category={}, title={}, composer={}, " + \
-            "artist={}, duration_sec={}, " + \
-            "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-            "beats=BeatData('beat_times', 'beat_positions'))"
+        repr_string = (
+            "RWC-Genre Track(track_id={}, audio_path={}, "
+            + "piece_number={}, suffix={}, track_number={}, category={}, "
+            + "sub_category={}, title={}, composer={}, "
+            + "artist={}, duration_sec={}, "
+            + "sections=SectionData('start_times', 'end_times', 'sections'), "
+            + "beats=BeatData('beat_times', 'beat_positions'))"
+        )
         return repr_string.format(
-            self.track_id, self.audio_path, self.piece_number, self.suffix,
-            self.track_number, self.category, self.sub_category, self.title,
-            self.composer, self.artist, self.duration_sec
+            self.track_id,
+            self.audio_path,
+            self.piece_number,
+            self.suffix,
+            self.track_number,
+            self.category,
+            self.sub_category,
+            self.title,
+            self.composer,
+            self.artist,
+            self.duration_sec,
         )
 
     @utils.cached_property
     def sections(self):
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['sections'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['sections'][0])
+        )
 
     @utils.cached_property
     def beats(self):
-        return _load_beats(os.path.join(
-            self._data_home, self._track_paths['beats'][0]))
+        return _load_beats(os.path.join(self._data_home, self._track_paths['beats'][0]))
 
     @property
     def audio(self):
@@ -107,8 +119,11 @@ def download(data_home=None, force_overwrite=False):
 
     annotations_path = os.path.join(data_home, 'annotations')
 
-    download_utils.downloader(annotations_path, force_overwrite=force_overwrite,
-                              zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2])
+    download_utils.downloader(
+        annotations_path,
+        force_overwrite=force_overwrite,
+        zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2],
+    )
 
     info_message = """
         Unfortunately the audio files of the RWC-Genre dataset are not available
@@ -119,10 +134,16 @@ def download(data_home=None, force_overwrite=False):
                 > audio/rwc-g-m0i with i in [1 .. 8]
                 > metadata-master/
         and copy the RWC-Genre folder to {}
-    """.format(data_home)
+    """.format(
+        data_home
+    )
 
-    download_utils.downloader(data_home, zip_downloads=[METADATA_REMOTE],
-                              info_message=info_message, force_overwrite=force_overwrite)
+    download_utils.downloader(
+        data_home,
+        zip_downloads=[METADATA_REMOTE],
+        info_message=info_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -202,7 +223,7 @@ def _load_metadata(data_home):
             continue
 
         p = '00' + line[0].split('.')[1][1:]
-        track_id = 'RM-G{}'.format(p[len(p) - 3:])
+        track_id = 'RM-G{}'.format(p[len(p) - 3 :])
         metadata_index[track_id] = {
             'piece_number': line[0],
             'suffix': line[1],

--- a/mirdata/rwc_jazz.py
+++ b/mirdata/rwc_jazz.py
@@ -16,16 +16,19 @@ METADATA = None
 METADATA_REMOTE = download_utils.RemoteFileMetadata(
     filename='rwc-j.csv',
     url='https://github.com/magdalenafuentes/metadata/archive/master.zip',
-    checksum='7dbe87fedbaaa1f348625a2af1d78030')
+    checksum='7dbe87fedbaaa1f348625a2af1d78030',
+)
 DATASET_DIR = 'RWC-Jazz'
 ANNOTATIONS_REMOTE_1 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-J-2001.BEAT.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-J-2001.BEAT.zip',
-    checksum='b483853da05d0fff3992879f7729bcb4')
-ANNOTATIONS_REMOTE_2 =  download_utils.RemoteFileMetadata(
+    checksum='b483853da05d0fff3992879f7729bcb4',
+)
+ANNOTATIONS_REMOTE_2 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-J-2001.CHORUS.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-J-2001.CHORUS.zip',
-    checksum='44afcf7f193d7e48a7d99e7a6f3ed39d')
+    checksum='44afcf7f193d7e48a7d99e7a6f3ed39d',
+)
 
 
 class Track(object):
@@ -58,8 +61,7 @@ class Track(object):
                 'instruments': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
 
         self.piece_number = self._track_metadata['piece_number']
         self.suffix = self._track_metadata['suffix']
@@ -71,26 +73,35 @@ class Track(object):
         self.instruments = self._track_metadata['instruments']
 
     def __repr__(self):
-        repr_string = "RWC-Jazz Track(track_id={}, audio_path={}, " + \
-            "piece_number={}, suffix={}, track_number={}, title={}, " + \
-            "artist={}, duration_sec={}, variation={}, instruments={}, " + \
-            "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-            "beats=BeatData('beat_times', 'beat_positions'))"
+        repr_string = (
+            "RWC-Jazz Track(track_id={}, audio_path={}, "
+            + "piece_number={}, suffix={}, track_number={}, title={}, "
+            + "artist={}, duration_sec={}, variation={}, instruments={}, "
+            + "sections=SectionData('start_times', 'end_times', 'sections'), "
+            + "beats=BeatData('beat_times', 'beat_positions'))"
+        )
         return repr_string.format(
-            self.track_id, self.audio_path, self.piece_number, self.suffix,
-            self.track_number, self.title, self.artist, self.duration_sec,
-            self.variation, self.instruments
+            self.track_id,
+            self.audio_path,
+            self.piece_number,
+            self.suffix,
+            self.track_number,
+            self.title,
+            self.artist,
+            self.duration_sec,
+            self.variation,
+            self.instruments,
         )
 
     @utils.cached_property
     def sections(self):
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['sections'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['sections'][0])
+        )
 
     @utils.cached_property
     def beats(self):
-        return _load_beats(os.path.join(
-            self._data_home, self._track_paths['beats'][0]))
+        return _load_beats(os.path.join(self._data_home, self._track_paths['beats'][0]))
 
     @property
     def audio(self):
@@ -104,8 +115,11 @@ def download(data_home=None, force_overwrite=False):
 
     annotations_path = os.path.join(data_home, 'annotations')
 
-    download_utils.downloader(annotations_path, force_overwrite=force_overwrite,
-                              zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2])
+    download_utils.downloader(
+        annotations_path,
+        force_overwrite=force_overwrite,
+        zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2],
+    )
 
     info_message = """
         Unfortunately the audio files of the RWC-Jazz dataset are not available
@@ -116,11 +130,16 @@ def download(data_home=None, force_overwrite=False):
                 > audio/rwc-j-m0i with i in [1 .. 4]
                 > metadata-master/
         and copy the RWC-Jazz folder to {}
-    """.format(data_home)
+    """.format(
+        data_home
+    )
 
-    download_utils.downloader(data_home, zip_downloads=[METADATA_REMOTE],
-                              info_message=info_message, force_overwrite=force_overwrite)
-
+    download_utils.downloader(
+        data_home,
+        zip_downloads=[METADATA_REMOTE],
+        info_message=info_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -199,7 +218,7 @@ def _load_metadata(data_home):
         if line[0] == 'Piece No.':
             continue
         p = '00' + line[0].split('.')[1][1:]
-        track_id = 'RM-J{}'.format(p[len(p) - 3:])
+        track_id = 'RM-J{}'.format(p[len(p) - 3 :])
 
         metadata_index[track_id] = {
             'piece_number': line[0],

--- a/mirdata/rwc_popular.py
+++ b/mirdata/rwc_popular.py
@@ -17,34 +17,37 @@ METADATA = None
 METADATA_REMOTE = download_utils.RemoteFileMetadata(
     filename='rwc-p.csv',
     url='https://github.com/magdalenafuentes/metadata/archive/master.zip',
-    checksum='7dbe87fedbaaa1f348625a2af1d78030')
+    checksum='7dbe87fedbaaa1f348625a2af1d78030',
+)
 DATASET_DIR = 'RWC-Popular'
 ANNOTATIONS_REMOTE_1 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-P-2001.BEAT.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-P-2001.BEAT.zip',
-    checksum='3858aa989535bd7196b3cd07b512b5b6'
+    checksum='3858aa989535bd7196b3cd07b512b5b6',
 )
 ANNOTATIONS_REMOTE_2 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-P-2001.CHORUS.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-P-2001.CHORUS.zip',
-    checksum='f76b3a32701fbd9bf78baa608f692a77'
+    checksum='f76b3a32701fbd9bf78baa608f692a77',
 )
 ANNOTATIONS_REMOTE_3 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-P-2001.CHORD.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-P-2001.CHORD.zip',
-    checksum='68379c88bc8ec3f1907b32a3579197c5'
+    checksum='68379c88bc8ec3f1907b32a3579197c5',
 )
 ANNOTATIONS_REMOTE_4 = download_utils.RemoteFileMetadata(
     filename='AIST.RWC-MDB-P-2001.VOCA_INST.zip',
     url='https://staff.aist.go.jp/m.goto/RWC-MDB/AIST-Annotation/AIST.RWC-MDB-P-2001.VOCA_INST.zip',
-    checksum='47ded648a496407ef49dba9c8bf80e87'
+    checksum='47ded648a496407ef49dba9c8bf80e87',
 )
 
 
 class Track(object):
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
-            raise ValueError('{} is not a valid track ID in RWC-Popular'.format(track_id))
+            raise ValueError(
+                '{} is not a valid track ID in RWC-Popular'.format(track_id)
+            )
 
         self.track_id = track_id
 
@@ -74,8 +77,7 @@ class Track(object):
                 'drum_information': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
 
         self.piece_number = self._track_metadata['piece_number']
         self.suffix = self._track_metadata['suffix']
@@ -89,37 +91,50 @@ class Track(object):
         self.drum_information = self._track_metadata['drum_information']
 
     def __repr__(self):
-        repr_string = "RWC-Popular Track(track_id={}, audio_path={}, " + \
-            "piece_number={}, suffix={}, track_number={}, title={}, " + \
-            "artist={}, singer_information={}, duration_sec={}, " + \
-            "tempo={}, instruments={}, drum_information={}, " + \
-            "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-            "beats=BeatData('beat_times', 'beat_positions'))"
+        repr_string = (
+            "RWC-Popular Track(track_id={}, audio_path={}, "
+            + "piece_number={}, suffix={}, track_number={}, title={}, "
+            + "artist={}, singer_information={}, duration_sec={}, "
+            + "tempo={}, instruments={}, drum_information={}, "
+            + "sections=SectionData('start_times', 'end_times', 'sections'), "
+            + "beats=BeatData('beat_times', 'beat_positions'))"
+        )
         return repr_string.format(
-            self.track_id, self.audio_path, self.piece_number, self.suffix,
-            self.track_number, self.title, self.artist, self.singer_information,
-            self.duration_sec, self.tempo, self.instruments, self.drum_information
+            self.track_id,
+            self.audio_path,
+            self.piece_number,
+            self.suffix,
+            self.track_number,
+            self.title,
+            self.artist,
+            self.singer_information,
+            self.duration_sec,
+            self.tempo,
+            self.instruments,
+            self.drum_information,
         )
 
     @utils.cached_property
     def sections(self):
-        return _load_sections(os.path.join(
-                self._data_home, self._track_paths['sections'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['sections'][0])
+        )
 
     @utils.cached_property
     def beats(self):
-        return _load_beats(os.path.join(
-                self._data_home, self._track_paths['beats'][0]))
+        return _load_beats(os.path.join(self._data_home, self._track_paths['beats'][0]))
 
     @utils.cached_property
     def chords(self):
-        return _load_chords(os.path.join(
-                self._data_home, self._track_paths['chords'][0]))
+        return _load_chords(
+            os.path.join(self._data_home, self._track_paths['chords'][0])
+        )
 
     @utils.cached_property
     def vocal_instrument_activity(self):
-        return _load_voca_inst(os.path.join(
-                self._data_home, self._track_paths['voca_inst'][0]))
+        return _load_voca_inst(
+            os.path.join(self._data_home, self._track_paths['voca_inst'][0])
+        )
 
     @property
     def audio(self):
@@ -135,9 +150,13 @@ def download(data_home=None, force_overwrite=False):
 
     download_utils.downloader(
         annotations_path,
-        zip_downloads=[ANNOTATIONS_REMOTE_1, ANNOTATIONS_REMOTE_2,
-                       ANNOTATIONS_REMOTE_3, ANNOTATIONS_REMOTE_4],
-        force_overwrite=force_overwrite
+        zip_downloads=[
+            ANNOTATIONS_REMOTE_1,
+            ANNOTATIONS_REMOTE_2,
+            ANNOTATIONS_REMOTE_3,
+            ANNOTATIONS_REMOTE_4,
+        ],
+        force_overwrite=force_overwrite,
     )
 
     info_message = """
@@ -149,10 +168,16 @@ def download(data_home=None, force_overwrite=False):
                 > audio/rwc-p-m0i with i in [1 .. 7]
                 > metadata-master/
         and copy the RWC-Popular folder to {}
-    """.format(data_home)
+    """.format(
+        data_home
+    )
 
-    download_utils.downloader(data_home, zip_downloads=[METADATA_REMOTE],
-                              info_message=info_message, force_overwrite=force_overwrite)
+    download_utils.downloader(
+        data_home,
+        zip_downloads=[METADATA_REMOTE],
+        info_message=info_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -217,11 +242,11 @@ def _load_chords(chords_path):
 
     if os.path.exists(chords_path):
         with open(chords_path, 'r') as fhandle:
-                reader = csv.reader(fhandle, delimiter='\t')
-                for line in reader:
-                    begs.append(float(line[0]))
-                    ends.append(float(line[1]))
-                    chords.append(line[2])
+            reader = csv.reader(fhandle, delimiter='\t')
+            for line in reader:
+                begs.append(float(line[0]))
+                ends.append(float(line[1]))
+                chords.append(line[2])
 
     return utils.ChordData(np.array(begs), np.array(ends), np.array(chords))
 
@@ -273,7 +298,7 @@ def _load_metadata(data_home):
         if line[0] == 'Piece No.':
             continue
         p = '00' + line[0].split('.')[1][1:]
-        track_id = 'RM-P{}'.format(p[len(p) - 3:])
+        track_id = 'RM-P{}'.format(p[len(p) - 3 :])
 
         metadata_index[track_id] = {
             'piece_number': line[0],

--- a/mirdata/salami.py
+++ b/mirdata/salami.py
@@ -65,6 +65,7 @@ class Track(object):
 
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in INDEX:
             raise ValueError('{} is not a valid track ID in Salami'.format(track_id))
@@ -97,8 +98,7 @@ class Track(object):
                 'genre': None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, self._track_paths['audio'][0])
+        self.audio_path = os.path.join(self._data_home, self._track_paths['audio'][0])
 
         self.source = self._track_metadata['source']
         self.annotator_1_id = self._track_metadata['annotator_1_id']
@@ -112,14 +112,16 @@ class Track(object):
         self.genre = self._track_metadata['genre']
 
     def __repr__(self):
-        repr_string = "Salami Track(track_id={}, audio_path={}, source={}, " + \
-            "title={}, artist={}, duration_sec={}, annotator_1_id={}, " + \
-            "annotator_2_id={}, annotator_1_time={}, annotator_2_time={}, " + \
-            "broad_genre={}, genre={}, " + \
-            "sections_annotator_1_uppercase=SectionData('start_times', 'end_times', 'sections'), " + \
-            "sections_annotator_1_lowercase=SectionData('start_times', 'end_times', 'sections'), " + \
-            "sections_annotator_2_uppercase=SectionData('start_times', 'end_times', 'sections'), " + \
-            "sections_annotator_2_lowercase=SectionData('start_times', 'end_times', 'sections')"
+        repr_string = (
+            "Salami Track(track_id={}, audio_path={}, source={}, "
+            + "title={}, artist={}, duration_sec={}, annotator_1_id={}, "
+            + "annotator_2_id={}, annotator_1_time={}, annotator_2_time={}, "
+            + "broad_genre={}, genre={}, "
+            + "sections_annotator_1_uppercase=SectionData('start_times', 'end_times', 'sections'), "
+            + "sections_annotator_1_lowercase=SectionData('start_times', 'end_times', 'sections'), "
+            + "sections_annotator_2_uppercase=SectionData('start_times', 'end_times', 'sections'), "
+            + "sections_annotator_2_lowercase=SectionData('start_times', 'end_times', 'sections')"
+        )
         return repr_string.format(
             self.track_id,
             self.audio_path,
@@ -139,29 +141,33 @@ class Track(object):
     def sections_annotator_1_uppercase(self):
         if self._track_paths['annotator_1_uppercase'][0] is None:
             return None
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['annotator_1_uppercase'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['annotator_1_uppercase'][0])
+        )
 
     @utils.cached_property
     def sections_annotator_1_lowercase(self):
         if self._track_paths['annotator_1_lowercase'][0] is None:
             return None
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['annotator_1_lowercase'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['annotator_1_lowercase'][0])
+        )
 
     @utils.cached_property
     def sections_annotator_2_uppercase(self):
         if self._track_paths['annotator_2_uppercase'][0] is None:
             return None
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['annotator_2_uppercase'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['annotator_2_uppercase'][0])
+        )
 
     @utils.cached_property
     def sections_annotator_2_lowercase(self):
         if self._track_paths['annotator_2_lowercase'][0] is None:
             return None
-        return _load_sections(os.path.join(
-            self._data_home, self._track_paths['annotator_2_lowercase'][0]))
+        return _load_sections(
+            os.path.join(self._data_home, self._track_paths['annotator_2_lowercase'][0])
+        )
 
     @property
     def audio(self):
@@ -190,10 +196,16 @@ def download(data_home=None, force_overwrite=False):
                 > salami-data-public-master/
                 > audio/
         and copy the Salami folder to {}
-    """.format(data_home)
+    """.format(
+        data_home
+    )
 
-    download_utils.downloader(data_home, zip_downloads=[ANNOTATIONS_REMOTE],
-                              info_message=info_message, force_overwrite=force_overwrite)
+    download_utils.downloader(
+        data_home,
+        zip_downloads=[ANNOTATIONS_REMOTE],
+        info_message=info_message,
+        force_overwrite=force_overwrite,
+    )
 
 
 def validate(data_home=None, silence=False):
@@ -276,10 +288,7 @@ def _load_sections(sections_path):
 def _load_metadata(data_home):
 
     metadata_path = os.path.join(
-        data_home,
-        os.path.join(
-            'salami-data-public-master', 'metadata', 'metadata.csv'
-        ),
+        data_home, os.path.join('salami-data-public-master', 'metadata', 'metadata.csv')
     )
 
     if not os.path.exists(metadata_path):

--- a/scripts/make_beatles_index.py
+++ b/scripts/make_beatles_index.py
@@ -42,16 +42,24 @@ def make_beatles_index(data_path):
             if 'ttl' in t:
                 totfiles.append(t)
 
-                track_id = '{}{}'.format(os.path.basename(c).split('_')[0][:2],
-                                         os.path.basename(t).split('_')[0])
+                track_id = '{}{}'.format(
+                    os.path.basename(c).split('_')[0][:2],
+                    os.path.basename(t).split('_')[0],
+                )
                 if 'CD' in t:
-                    track_id = '10{}{}'.format(os.path.basename(c).split('_')[0][-1],
-                                               os.path.basename(t).split('_')[2][:2])
+                    track_id = '10{}{}'.format(
+                        os.path.basename(c).split('_')[0][-1],
+                        os.path.basename(t).split('_')[2][:2],
+                    )
                 track_ids.append(track_id)
 
                 # checksum
-                audio_checksum = md5(os.path.join(audio_dir, c, '{}.wav'.format(t[:-4])))
-                audio_path = '{}/{}'.format('audio', os.path.join(c, '{}.wav'.format(t[:-4])))
+                audio_checksum = md5(
+                    os.path.join(audio_dir, c, '{}.wav'.format(t[:-4]))
+                )
+                audio_path = '{}/{}'.format(
+                    'audio', os.path.join(c, '{}.wav'.format(t[:-4]))
+                )
 
                 annot_checksum, annot_rels = [], []
 
@@ -65,33 +73,21 @@ def make_beatles_index(data_path):
 
                     if os.path.exists(os.path.join(annot_path, annot_file)):
                         annot_checksum.append(md5(os.path.join(annot_path, annot_file)))
-                        annot_rels.append(os.path.join('annotations', annot_type,
-                                                       'The Beatles', c, annot_file))
+                        annot_rels.append(
+                            os.path.join(
+                                'annotations', annot_type, 'The Beatles', c, annot_file
+                            )
+                        )
                     else:
                         annot_checksum.append(None)
                         annot_rels.append(None)
 
                 beatles_index[track_id] = {
-                    'audio': (
-                        audio_path,
-                        audio_checksum
-                    ),
-                    'beat': (
-                        annot_rels[0],
-                        annot_checksum[0]
-                    ),
-                    'chords': (
-                        annot_rels[1],
-                        annot_checksum[1]
-                    ),
-                    'keys': (
-                        annot_rels[2],
-                        annot_checksum[2]
-                    ),
-                    'sections': (
-                        annot_rels[3],
-                        annot_checksum[3]
-                    )
+                    'audio': (audio_path, audio_checksum),
+                    'beat': (annot_rels[0], annot_checksum[0]),
+                    'chords': (annot_rels[1], annot_checksum[1]),
+                    'keys': (annot_rels[2], annot_checksum[2]),
+                    'sections': (annot_rels[3], annot_checksum[3]),
                 }
     with open(BEATLES_INDEX_PATH, 'w') as fhandle:
         json.dump(beatles_index, fhandle, indent=2)
@@ -102,10 +98,9 @@ def main(args):
 
 
 if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(
-        description='Make Beatles index file.')
-    PARSER.add_argument('beatles_data_path',
-                        type=str,
-                        help='Path to Beatles data folder.')
+    PARSER = argparse.ArgumentParser(description='Make Beatles index file.')
+    PARSER.add_argument(
+        'beatles_data_path', type=str, help='Path to Beatles data folder.'
+    )
 
     main(PARSER.parse_args())

--- a/scripts/make_ikala_index.py
+++ b/scripts/make_ikala_index.py
@@ -31,31 +31,24 @@ def md5(file_path):
 def make_ikala_index(ikala_data_path):
     lyrics_dir = os.path.join(ikala_data_path, 'Lyrics')
     lyrics_files = glob.glob(os.path.join(lyrics_dir, '*.lab'))
-    track_ids = sorted(
-        [os.path.basename(f).split('.')[0] for f in lyrics_files])
+    track_ids = sorted([os.path.basename(f).split('.')[0] for f in lyrics_files])
 
     ikala_index = {}
     for track_id in track_ids:
-        audio_checksum = md5(os.path.join(
-            ikala_data_path, 'Wavfile/{}.wav'.format(track_id)))
-        pitch_checksum = md5(os.path.join(
-            ikala_data_path, 'PitchLabel/{}.pv'.format(track_id)))
-        lyrics_checksum = md5(os.path.join(
-            ikala_data_path, 'Lyrics/{}.lab'.format(track_id)))
+        audio_checksum = md5(
+            os.path.join(ikala_data_path, 'Wavfile/{}.wav'.format(track_id))
+        )
+        pitch_checksum = md5(
+            os.path.join(ikala_data_path, 'PitchLabel/{}.pv'.format(track_id))
+        )
+        lyrics_checksum = md5(
+            os.path.join(ikala_data_path, 'Lyrics/{}.lab'.format(track_id))
+        )
 
         ikala_index[track_id] = {
-            'audio': (
-                'Wavfile/{}.wav'.format(track_id),
-                audio_checksum
-            ),
-            'pitch': (
-                'PitchLabel/{}.pv'.format(track_id),
-                pitch_checksum
-            ),
-            'lyrics': (
-                'Lyrics/{}.lab'.format(track_id),
-                lyrics_checksum
-            )
+            'audio': ('Wavfile/{}.wav'.format(track_id), audio_checksum),
+            'pitch': ('PitchLabel/{}.pv'.format(track_id), pitch_checksum),
+            'lyrics': ('Lyrics/{}.lab'.format(track_id), lyrics_checksum),
         }
 
     with open(IKALA_INDEX_PATH, 'w') as fhandle:
@@ -67,10 +60,7 @@ def main(args):
 
 
 if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(
-        description='Make IKala index file.')
-    PARSER.add_argument('ikala_data_path',
-                        type=str,
-                        help='Path to IKala data folder.')
+    PARSER = argparse.ArgumentParser(description='Make IKala index file.')
+    PARSER.add_argument('ikala_data_path', type=str, help='Path to IKala data folder.')
 
     main(PARSER.parse_args())

--- a/scripts/make_medleydb_melody_index.py
+++ b/scripts/make_medleydb_melody_index.py
@@ -4,8 +4,7 @@ import json
 import os
 
 
-MEDLEYDB_MELODY_INDEX_PATH = \
-    '../mirdata/indexes/medleydb_melody_index.json'
+MEDLEYDB_MELODY_INDEX_PATH = '../mirdata/indexes/medleydb_melody_index.json'
 
 
 def md5(file_path):
@@ -34,7 +33,8 @@ def strip_first_dir(full_path):
 
 def make_medleydb_melody_index(data_path):
     metadata_path = os.path.join(
-        data_path, 'MedleyDB-Melody', 'medleydb_melody_metadata.json')
+        data_path, 'MedleyDB-Melody', 'medleydb_melody_metadata.json'
+    )
     with open(metadata_path, 'r') as fhandle:
         metadata = json.load(fhandle)
 
@@ -42,36 +42,27 @@ def make_medleydb_melody_index(data_path):
     for trackid in metadata.keys():
         audio_path = os.path.join(data_path, metadata[trackid]['audio_path'])
         audio_checksum = md5(audio_path)
-        local_mel1_path = os.path.join(
-            data_path, metadata[trackid]['melody1_path']
-        )
+        local_mel1_path = os.path.join(data_path, metadata[trackid]['melody1_path'])
         mel1_checksum = md5(local_mel1_path)
-        local_mel2_path = os.path.join(
-            data_path, metadata[trackid]['melody2_path']
-        )
+        local_mel2_path = os.path.join(data_path, metadata[trackid]['melody2_path'])
         mel2_checksum = md5(local_mel2_path)
-        local_mel3_path = os.path.join(
-            data_path, metadata[trackid]['melody3_path']
-        )
+        local_mel3_path = os.path.join(data_path, metadata[trackid]['melody3_path'])
         mel3_checksum = md5(local_mel3_path)
 
         melody_index[trackid] = {
-            'audio': (
-                strip_first_dir(metadata[trackid]['audio_path']),
-                audio_checksum
-            ),
+            'audio': (strip_first_dir(metadata[trackid]['audio_path']), audio_checksum),
             'melody1': (
                 strip_first_dir(metadata[trackid]['melody1_path']),
-                mel1_checksum
+                mel1_checksum,
             ),
             'melody2': (
                 strip_first_dir(metadata[trackid]['melody2_path']),
-                mel2_checksum
+                mel2_checksum,
             ),
             'melody3': (
                 strip_first_dir(metadata[trackid]['melody3_path']),
-                mel3_checksum
-            )
+                mel3_checksum,
+            ),
         }
 
     with open(MEDLEYDB_MELODY_INDEX_PATH, 'w') as fhandle:
@@ -83,10 +74,9 @@ def main(args):
 
 
 if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(
-        description='Make MedleyDB-Melody index file.')
-    PARSER.add_argument('mdb_melody_data_path',
-                        type=str,
-                        help='Path to MedleyDB-Melody data folder.')
+    PARSER = argparse.ArgumentParser(description='Make MedleyDB-Melody index file.')
+    PARSER.add_argument(
+        'mdb_melody_data_path', type=str, help='Path to MedleyDB-Melody data folder.'
+    )
 
     main(PARSER.parse_args())

--- a/scripts/make_medleydb_pitch_index.py
+++ b/scripts/make_medleydb_pitch_index.py
@@ -4,8 +4,7 @@ import json
 import os
 
 
-MEDLEYDB_PITCH_INDEX_PATH = \
-    '../mirdata/indexes/medleydb_pitch_index.json'
+MEDLEYDB_PITCH_INDEX_PATH = '../mirdata/indexes/medleydb_pitch_index.json'
 
 
 def md5(file_path):
@@ -34,7 +33,8 @@ def strip_first_dir(full_path):
 
 def make_medleydb_pitch_index(data_path):
     metadata_path = os.path.join(
-        data_path, 'MedleyDB-Pitch', 'medleydb_pitch_metadata.json')
+        data_path, 'MedleyDB-Pitch', 'medleydb_pitch_metadata.json'
+    )
     with open(metadata_path, 'r') as fhandle:
         metadata = json.load(fhandle)
 
@@ -42,21 +42,13 @@ def make_medleydb_pitch_index(data_path):
     for trackid in metadata.keys():
         audio_path = os.path.join(data_path, metadata[trackid]['audio_path'])
         audio_checksum = md5(audio_path)
-        local_pitch_path = os.path.join(
-            data_path, metadata[trackid]['pitch_path']
-        )
+        local_pitch_path = os.path.join(data_path, metadata[trackid]['pitch_path'])
         pitch_checksum = md5(local_pitch_path)
 
         fullid = os.path.basename(audio_path).split('.')[0]
         pitch_index[fullid] = {
-            'audio': (
-                strip_first_dir(metadata[trackid]['audio_path']),
-                audio_checksum
-            ),
-            'pitch': (
-                strip_first_dir(metadata[trackid]['pitch_path']),
-                pitch_checksum
-            )
+            'audio': (strip_first_dir(metadata[trackid]['audio_path']), audio_checksum),
+            'pitch': (strip_first_dir(metadata[trackid]['pitch_path']), pitch_checksum),
         }
 
     with open(MEDLEYDB_PITCH_INDEX_PATH, 'w') as fhandle:
@@ -68,10 +60,9 @@ def main(args):
 
 
 if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(
-        description='Make MedleyDB-Pitch index file.')
-    PARSER.add_argument('mdb_pitch_data_path',
-                        type=str,
-                        help='Path to MedleyDB-Pitch data folder.')
+    PARSER = argparse.ArgumentParser(description='Make MedleyDB-Pitch index file.')
+    PARSER.add_argument(
+        'mdb_pitch_data_path', type=str, help='Path to MedleyDB-Pitch data folder.'
+    )
 
     main(PARSER.parse_args())

--- a/scripts/make_orchset_index.py
+++ b/scripts/make_orchset_index.py
@@ -29,33 +29,29 @@ def md5(file_path):
 
 def make_orchset_index(data_path):
 
-    mono_audio_files = sorted(glob.glob(
-        os.path.join(data_path, 'audio', 'mono', '*.wav')))
+    mono_audio_files = sorted(
+        glob.glob(os.path.join(data_path, 'audio', 'mono', '*.wav'))
+    )
 
     index = {}
     for audio_path in mono_audio_files:
         track_id = os.path.basename(audio_path).split('.')[0]
 
-        audio_stereo_checksum = md5(os.path.join(
-            data_path, 'audio', 'stereo', '{}.wav'.format(track_id)))
-        audio_mono_checksum = md5(os.path.join(
-            data_path, 'audio', 'mono', '{}.wav'.format(track_id)))
-        melody_checksum = md5(os.path.join(
-            data_path, 'GT', '{}.mel'.format(track_id)))
+        audio_stereo_checksum = md5(
+            os.path.join(data_path, 'audio', 'stereo', '{}.wav'.format(track_id))
+        )
+        audio_mono_checksum = md5(
+            os.path.join(data_path, 'audio', 'mono', '{}.wav'.format(track_id))
+        )
+        melody_checksum = md5(os.path.join(data_path, 'GT', '{}.mel'.format(track_id)))
 
         index[track_id] = {
             'audio_stereo': (
                 'audio/stereo/{}.wav'.format(track_id),
-                audio_stereo_checksum
+                audio_stereo_checksum,
             ),
-            'audio_mono': (
-                'audio/mono/{}.wav'.format(track_id),
-                audio_mono_checksum
-            ),
-            'melody': (
-                'GT/{}.mel'.format(track_id),
-                melody_checksum
-            )
+            'audio_mono': ('audio/mono/{}.wav'.format(track_id), audio_mono_checksum),
+            'melody': ('GT/{}.mel'.format(track_id), melody_checksum),
         }
 
     with open(ORCHSET_INDEX_PATH, 'w') as fhandle:
@@ -67,10 +63,9 @@ def main(args):
 
 
 if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(
-        description='Make Orchset index file.')
-    PARSER.add_argument('orchset_data_path',
-                        type=str,
-                        help='Path to Orchset data folder.')
+    PARSER = argparse.ArgumentParser(description='Make Orchset index file.')
+    PARSER.add_argument(
+        'orchset_data_path', type=str, help='Path to Orchset data folder.'
+    )
 
     main(PARSER.parse_args())

--- a/scripts/make_rwc_classical_index.py
+++ b/scripts/make_rwc_classical_index.py
@@ -32,8 +32,9 @@ def make_rwc_classical_index(data_path):
     annotations_dir = os.path.join(data_path, 'RWC-Classical', 'annotations')
     metadata_dir = os.path.join(data_path, 'RWC-Classical', 'metadata-master')
     audio_dir = os.path.join(data_path, 'RWC-Classical', 'audio')
-    annotations_files = os.listdir(os.path.join(annotations_dir,
-                                                'AIST.RWC-MDB-C-2001.CHORUS'))
+    annotations_files = os.listdir(
+        os.path.join(annotations_dir, 'AIST.RWC-MDB-C-2001.CHORUS')
+    )
     metadata_file = os.path.join(metadata_dir, 'rwc-c.csv')
     with open(metadata_file, 'r', encoding='utf-8') as fhandle:
         dialect = csv.Sniffer().sniff(fhandle.read(1024))
@@ -45,7 +46,7 @@ def make_rwc_classical_index(data_path):
         for line in reader:
             if not line[0] == "Piece No.":
                 p = '00' + line[0].split('.')[1][1:]
-                piece.append(p[len(p)-3:])
+                piece.append(p[len(p) - 3 :])
                 suffix.append(line[1][1:])
                 track.append(line[2][-2:])
 
@@ -53,8 +54,12 @@ def make_rwc_classical_index(data_path):
     mapping_folder = {p: s for p, s in zip(piece, suffix)}
 
     track_ids = sorted(
-        [os.path.basename(f).split('.')[0] for f in annotations_files
-         if not f == 'README.TXT'])
+        [
+            os.path.basename(f).split('.')[0]
+            for f in annotations_files
+            if not f == 'README.TXT'
+        ]
+    )
 
     rwc_classical_index = {}
     for track_id in track_ids:
@@ -62,38 +67,45 @@ def make_rwc_classical_index(data_path):
         audio_folder = 'rwc-c-m{}'.format(mapping_folder[track_id[4:7]])
         audio_path = os.path.join(audio_dir, audio_folder)
         audio_track = str(int(mapping_track[track_id[4:7]]))
-        audio_checksum = md5(os.path.join(audio_path,
-                                          "{}.wav".format(audio_track)))
+        audio_checksum = md5(os.path.join(audio_path, "{}.wav".format(audio_track)))
         annot_checksum = []
         annot_rels = []
 
         for f in ['CHORUS', 'BEAT']:
-            if os.path.exists(os.path.join(annotations_dir,
-                                           'AIST.RWC-MDB-C-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))):
-                annot_checksum.append(md5(os.path.join(annotations_dir,
-                                                       'AIST.RWC-MDB-C-2001.{}'.format(f),
-                                                       '{}.{}.TXT'.format(track_id, f))))
-                annot_rels.append(os.path.join('annotations',
-                                               'AIST.RWC-MDB-C-2001.{}'.format(f),
-                                               '{}.{}.TXT'.format(track_id, f)))
+            if os.path.exists(
+                os.path.join(
+                    annotations_dir,
+                    'AIST.RWC-MDB-C-2001.{}'.format(f),
+                    '{}.{}.TXT'.format(track_id, f),
+                )
+            ):
+                annot_checksum.append(
+                    md5(
+                        os.path.join(
+                            annotations_dir,
+                            'AIST.RWC-MDB-C-2001.{}'.format(f),
+                            '{}.{}.TXT'.format(track_id, f),
+                        )
+                    )
+                )
+                annot_rels.append(
+                    os.path.join(
+                        'annotations',
+                        'AIST.RWC-MDB-C-2001.{}'.format(f),
+                        '{}.{}.TXT'.format(track_id, f),
+                    )
+                )
             else:
                 annot_checksum.append(None)
                 annot_rels.append(None)
 
         rwc_classical_index[track_id[:7]] = {
             'audio': (
-                os.path.join('audio', audio_folder,
-                             "{}.wav".format(audio_track)),
-                audio_checksum
+                os.path.join('audio', audio_folder, "{}.wav".format(audio_track)),
+                audio_checksum,
             ),
-            'sections': (
-                annot_rels[0],
-                annot_checksum[0]
-            ),
-            'beats': (
-                annot_rels[1],
-                annot_checksum[1]
-            )
+            'sections': (annot_rels[0], annot_checksum[0]),
+            'beats': (annot_rels[1], annot_checksum[1]),
         }
 
     with open(RWC_CLASSICAL_INDEX_PATH, 'w') as fhandle:
@@ -105,10 +117,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser(
-        description="Make RWC-Classical index file.")
-    PARSER.add_argument("rwc_classical_data_path",
-                        type=str,
-                        help="Path to RWC-Classical data folder.")
+    PARSER = argparse.ArgumentParser(description="Make RWC-Classical index file.")
+    PARSER.add_argument(
+        "rwc_classical_data_path", type=str, help="Path to RWC-Classical data folder."
+    )
 
     main(PARSER.parse_args())

--- a/scripts/make_rwc_genre_index.py
+++ b/scripts/make_rwc_genre_index.py
@@ -32,8 +32,9 @@ def make_rwc_genre_index(data_path):
     annotations_dir = os.path.join(data_path, 'RWC-Genre', 'annotations')
     metadata_dir = os.path.join(data_path, 'RWC-Genre', 'metadata-master')
     audio_dir = os.path.join(data_path, 'RWC-Genre', 'audio')
-    annotations_files = os.listdir(os.path.join(annotations_dir,
-                                                'AIST.RWC-MDB-G-2001.CHORUS'))
+    annotations_files = os.listdir(
+        os.path.join(annotations_dir, 'AIST.RWC-MDB-G-2001.CHORUS')
+    )
     metadata_file = os.path.join(metadata_dir, 'rwc-g.csv')
     with open(metadata_file, 'r', encoding='utf-8') as fhandle:
         dialect = csv.Sniffer().sniff(fhandle.read(1024))
@@ -43,22 +44,26 @@ def make_rwc_genre_index(data_path):
         suffix = []
         track = []
         for line in reader:
-            if not line[0]=="Piece No.":
+            if not line[0] == "Piece No.":
                 p = '00' + line[0].split('.')[1][1:]
-                piece.append(p[len(p)-3:])
+                piece.append(p[len(p) - 3 :])
                 suffix.append(line[1][1:])
                 track.append(line[2][-2:])
 
-    mapping_track = {p: t for p,t in zip(piece, track)}
+    mapping_track = {p: t for p, t in zip(piece, track)}
     mapping_folder = {p: s for p, s in zip(piece, suffix)}
 
     track_ids = sorted(
-        [os.path.basename(f).split('.')[0] for f in annotations_files
-         if not f == 'README.TXT'])
+        [
+            os.path.basename(f).split('.')[0]
+            for f in annotations_files
+            if not f == 'README.TXT'
+        ]
+    )
 
     rwc_genre_index = {}
     # skipping for now the missing audio files
-    skip = ['RM-G09{}'.format(i) for i in range(1,10)] + ['RM-G100']
+    skip = ['RM-G09{}'.format(i) for i in range(1, 10)] + ['RM-G100']
     for track_id in track_ids:
         if not track_id in skip:
             # audio
@@ -66,36 +71,45 @@ def make_rwc_genre_index(data_path):
             audio_path = os.path.join(audio_dir, audio_folder)
             audio_track = str(int(mapping_track[track_id[4:7]]))
             # Skip audio checksums now, missing rwc-g-m09
-            audio_checksum = md5(os.path.join(audio_path,
-                                              "{}.wav".format(audio_track)))
+            audio_checksum = md5(os.path.join(audio_path, "{}.wav".format(audio_track)))
             annot_checksum = []
             annot_rels = []
 
             for f in ['CHORUS', 'BEAT']:
-                if os.path.exists(os.path.join(annotations_dir,
-                                               'AIST.RWC-MDB-G-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))):
-                    annot_checksum.append(md5(os.path.join(annotations_dir,
-                                               'AIST.RWC-MDB-G-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))))
-                    annot_rels.append(os.path.join('annotations',
-                                               'AIST.RWC-MDB-G-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f)))
+                if os.path.exists(
+                    os.path.join(
+                        annotations_dir,
+                        'AIST.RWC-MDB-G-2001.{}'.format(f),
+                        '{}.{}.TXT'.format(track_id, f),
+                    )
+                ):
+                    annot_checksum.append(
+                        md5(
+                            os.path.join(
+                                annotations_dir,
+                                'AIST.RWC-MDB-G-2001.{}'.format(f),
+                                '{}.{}.TXT'.format(track_id, f),
+                            )
+                        )
+                    )
+                    annot_rels.append(
+                        os.path.join(
+                            'annotations',
+                            'AIST.RWC-MDB-G-2001.{}'.format(f),
+                            '{}.{}.TXT'.format(track_id, f),
+                        )
+                    )
                 else:
                     annot_checksum.append(None)
                     annot_rels.append(None)
 
             rwc_genre_index[track_id[:7]] = {
                 'audio': (
-                    os.path.join('audio', audio_folder,
-                                 "{}.wav".format(audio_track)),
-                    audio_checksum
+                    os.path.join('audio', audio_folder, "{}.wav".format(audio_track)),
+                    audio_checksum,
                 ),
-                'sections': (
-                    annot_rels[0],
-                    annot_checksum[0]
-                ),
-                'beats': (
-                    annot_rels[1],
-                    annot_checksum[1]
-                )
+                'sections': (annot_rels[0], annot_checksum[0]),
+                'beats': (annot_rels[1], annot_checksum[1]),
             }
 
     with open(RWC_GENRE_INDEX_PATH, 'w') as fhandle:
@@ -107,11 +121,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser(
-        description="Make RWC-Genre index file.")
-    PARSER.add_argument("rwc_genre_data_path",
-                        type=str,
-                        help="Path to RWC-Genre data folder.")
+    PARSER = argparse.ArgumentParser(description="Make RWC-Genre index file.")
+    PARSER.add_argument(
+        "rwc_genre_data_path", type=str, help="Path to RWC-Genre data folder."
+    )
 
     main(PARSER.parse_args())
-

--- a/scripts/make_rwc_jazz_index.py
+++ b/scripts/make_rwc_jazz_index.py
@@ -32,8 +32,9 @@ def make_rwc_jazz_index(data_path):
     annotations_dir = os.path.join(data_path, 'RWC-Jazz', 'annotations')
     metadata_dir = os.path.join(data_path, 'RWC-Jazz', 'metadata-master')
     audio_dir = os.path.join(data_path, 'RWC-Jazz', 'audio')
-    annotations_files = os.listdir(os.path.join(annotations_dir,
-                                                'AIST.RWC-MDB-J-2001.CHORUS'))
+    annotations_files = os.listdir(
+        os.path.join(annotations_dir, 'AIST.RWC-MDB-J-2001.CHORUS')
+    )
     metadata_file = os.path.join(metadata_dir, 'rwc-j.csv')
     with open(metadata_file, 'r', encoding='utf-8') as fhandle:
         dialect = csv.Sniffer().sniff(fhandle.read(1024))
@@ -43,18 +44,22 @@ def make_rwc_jazz_index(data_path):
         suffix = []
         track = []
         for line in reader:
-            if not line[0]=="Piece No.":
+            if not line[0] == "Piece No.":
                 p = '00' + line[0].split('.')[1][1:]
-                piece.append(p[len(p)-3:])
+                piece.append(p[len(p) - 3 :])
                 suffix.append(line[1][1:])
                 track.append(line[2][-2:])
 
-    mapping_track = {p: t for p,t in zip(piece, track)}
+    mapping_track = {p: t for p, t in zip(piece, track)}
     mapping_folder = {p: s for p, s in zip(piece, suffix)}
 
     track_ids = sorted(
-        [os.path.basename(f).split('.')[0] for f in annotations_files
-         if not f == 'README.TXT'])
+        [
+            os.path.basename(f).split('.')[0]
+            for f in annotations_files
+            if not f == 'README.TXT'
+        ]
+    )
 
     rwc_jazz_index = {}
     for track_id in track_ids:
@@ -62,36 +67,45 @@ def make_rwc_jazz_index(data_path):
         audio_folder = 'rwc-j-m{}'.format(mapping_folder[track_id[4:]])
         audio_path = os.path.join(audio_dir, audio_folder)
         audio_track = str(int(mapping_track[track_id[4:]]))
-        audio_checksum = md5(os.path.join(audio_path,
-                                          "{}.wav".format(audio_track)))
+        audio_checksum = md5(os.path.join(audio_path, "{}.wav".format(audio_track)))
         annot_checksum = []
         annot_rels = []
 
         for f in ['CHORUS', 'BEAT']:
-            if os.path.exists(os.path.join(annotations_dir,
-                                           'AIST.RWC-MDB-J-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))):
-                annot_checksum.append(md5(os.path.join(annotations_dir,
-                                           'AIST.RWC-MDB-J-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))))
-                annot_rels.append(os.path.join('annotations',
-                                           'AIST.RWC-MDB-J-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f)))
+            if os.path.exists(
+                os.path.join(
+                    annotations_dir,
+                    'AIST.RWC-MDB-J-2001.{}'.format(f),
+                    '{}.{}.TXT'.format(track_id, f),
+                )
+            ):
+                annot_checksum.append(
+                    md5(
+                        os.path.join(
+                            annotations_dir,
+                            'AIST.RWC-MDB-J-2001.{}'.format(f),
+                            '{}.{}.TXT'.format(track_id, f),
+                        )
+                    )
+                )
+                annot_rels.append(
+                    os.path.join(
+                        'annotations',
+                        'AIST.RWC-MDB-J-2001.{}'.format(f),
+                        '{}.{}.TXT'.format(track_id, f),
+                    )
+                )
             else:
                 annot_checksum.append(None)
                 annot_rels.append(None)
 
         rwc_jazz_index[track_id] = {
             'audio': (
-                os.path.join('audio', audio_folder,
-                             "{}.wav".format(audio_track)),
-                audio_checksum
+                os.path.join('audio', audio_folder, "{}.wav".format(audio_track)),
+                audio_checksum,
             ),
-            'sections': (
-                annot_rels[0],
-                annot_checksum[0]
-            ),
-            'beats': (
-                annot_rels[1],
-                annot_checksum[1]
-            )
+            'sections': (annot_rels[0], annot_checksum[0]),
+            'beats': (annot_rels[1], annot_checksum[1]),
         }
 
     with open(RWC_JAZZ_INDEX_PATH, 'w') as fhandle:
@@ -103,11 +117,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser(
-        description="Make RWC-Jazz index file.")
-    PARSER.add_argument("rwc_jazz_data_path",
-                        type=str,
-                        help="Path to RWC-Jazz data folder.")
+    PARSER = argparse.ArgumentParser(description="Make RWC-Jazz index file.")
+    PARSER.add_argument(
+        "rwc_jazz_data_path", type=str, help="Path to RWC-Jazz data folder."
+    )
 
     main(PARSER.parse_args())
-

--- a/scripts/make_rwc_popular_index.py
+++ b/scripts/make_rwc_popular_index.py
@@ -33,8 +33,9 @@ def make_rwc_popular_index(data_path):
     annotations_dir = os.path.join(data_path, 'RWC-Popular', 'annotations')
     metadata_dir = os.path.join(data_path, 'RWC-Popular', 'metadata-master')
     audio_dir = os.path.join(data_path, 'RWC-Popular', 'audio')
-    annotations_files = os.listdir(os.path.join(annotations_dir,
-                                                'AIST.RWC-MDB-P-2001.CHORUS'))
+    annotations_files = os.listdir(
+        os.path.join(annotations_dir, 'AIST.RWC-MDB-P-2001.CHORUS')
+    )
     metadata_file = os.path.join(metadata_dir, 'rwc-p.csv')
     with open(metadata_file, 'r', encoding='utf-8') as fhandle:
         dialect = csv.Sniffer().sniff(fhandle.read(1024))
@@ -44,18 +45,22 @@ def make_rwc_popular_index(data_path):
         suffix = []
         track = []
         for line in reader:
-            if not line[0]=="Piece No.":
+            if not line[0] == "Piece No.":
                 p = '00' + line[0].split('.')[1][1:]
-                piece.append(p[len(p)-3:])
+                piece.append(p[len(p) - 3 :])
                 suffix.append(line[1][1:])
                 track.append(line[2][-2:])
 
-    mapping_track = {p: t for p,t in zip(piece, track)}
+    mapping_track = {p: t for p, t in zip(piece, track)}
     mapping_folder = {p: s for p, s in zip(piece, suffix)}
 
     track_ids = sorted(
-        [os.path.basename(f).split('.')[0] for f in annotations_files
-         if not f == 'README.TXT'])
+        [
+            os.path.basename(f).split('.')[0]
+            for f in annotations_files
+            if not f == 'README.TXT'
+        ]
+    )
 
     rwc_popular_index = {}
     for track_id in track_ids:
@@ -63,65 +68,90 @@ def make_rwc_popular_index(data_path):
         audio_folder = 'rwc-p-m{}'.format(mapping_folder[track_id[4:]])
         audio_path = os.path.join(audio_dir, audio_folder)
         audio_track = str(int(mapping_track[track_id[4:]]))
-        audio_checksum = md5(os.path.join(audio_path,
-                                          "{}.wav".format(audio_track)))
+        audio_checksum = md5(os.path.join(audio_path, "{}.wav".format(audio_track)))
         annot_checksum = []
         annot_rels = []
 
         for f in ['CHORUS', 'BEAT', 'CHORD', 'VOCA_INST']:
             if f is 'CHORD':
-                if os.path.exists(os.path.join(annotations_dir,
-                                               'AIST.RWC-MDB-P-2001.{}'.format(f), 'RWC_Pop_Chords',
-                                               'N{}-M{}-T{}.lab'.format(track_id[-3:],
-                                                mapping_folder[track_id[-3:]],
-                                                mapping_track[track_id[-3:]]))):
-                    annot_checksum.append(md5(os.path.join(annotations_dir,
-                                               'AIST.RWC-MDB-P-2001.{}'.format(f), 'RWC_Pop_Chords',
-                                               'N{}-M{}-T{}.lab'.format(track_id[-3:],
-                                                mapping_folder[track_id[-3:]],
-                                                mapping_track[track_id[-3:]]))))
-                    annot_rels.append(os.path.join('annotations',
-                                               'AIST.RWC-MDB-P-2001.{}'.format(f), 'RWC_Pop_Chords',
-                                               'N{}-M{}-T{}.lab'.format(track_id[-3:],
-                                                mapping_folder[track_id[-3:]],
-                                                mapping_track[track_id[-3:]])))
+                if os.path.exists(
+                    os.path.join(
+                        annotations_dir,
+                        'AIST.RWC-MDB-P-2001.{}'.format(f),
+                        'RWC_Pop_Chords',
+                        'N{}-M{}-T{}.lab'.format(
+                            track_id[-3:],
+                            mapping_folder[track_id[-3:]],
+                            mapping_track[track_id[-3:]],
+                        ),
+                    )
+                ):
+                    annot_checksum.append(
+                        md5(
+                            os.path.join(
+                                annotations_dir,
+                                'AIST.RWC-MDB-P-2001.{}'.format(f),
+                                'RWC_Pop_Chords',
+                                'N{}-M{}-T{}.lab'.format(
+                                    track_id[-3:],
+                                    mapping_folder[track_id[-3:]],
+                                    mapping_track[track_id[-3:]],
+                                ),
+                            )
+                        )
+                    )
+                    annot_rels.append(
+                        os.path.join(
+                            'annotations',
+                            'AIST.RWC-MDB-P-2001.{}'.format(f),
+                            'RWC_Pop_Chords',
+                            'N{}-M{}-T{}.lab'.format(
+                                track_id[-3:],
+                                mapping_folder[track_id[-3:]],
+                                mapping_track[track_id[-3:]],
+                            ),
+                        )
+                    )
                 else:
                     annot_checksum.append(None)
                     annot_rels.append(None)
             else:
-                if os.path.exists(os.path.join(annotations_dir,
-                                               'AIST.RWC-MDB-P-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))):
-                    annot_checksum.append(md5(os.path.join(annotations_dir,
-                                               'AIST.RWC-MDB-P-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f))))
-                    annot_rels.append(os.path.join('annotations',
-                                               'AIST.RWC-MDB-P-2001.{}'.format(f), '{}.{}.TXT'.format(track_id, f)))
+                if os.path.exists(
+                    os.path.join(
+                        annotations_dir,
+                        'AIST.RWC-MDB-P-2001.{}'.format(f),
+                        '{}.{}.TXT'.format(track_id, f),
+                    )
+                ):
+                    annot_checksum.append(
+                        md5(
+                            os.path.join(
+                                annotations_dir,
+                                'AIST.RWC-MDB-P-2001.{}'.format(f),
+                                '{}.{}.TXT'.format(track_id, f),
+                            )
+                        )
+                    )
+                    annot_rels.append(
+                        os.path.join(
+                            'annotations',
+                            'AIST.RWC-MDB-P-2001.{}'.format(f),
+                            '{}.{}.TXT'.format(track_id, f),
+                        )
+                    )
                 else:
                     annot_checksum.append(None)
                     annot_rels.append(None)
 
         rwc_popular_index[track_id] = {
             'audio': (
-                os.path.join('audio', audio_folder,
-                             "{}.wav".format(audio_track)),
-                audio_checksum
+                os.path.join('audio', audio_folder, "{}.wav".format(audio_track)),
+                audio_checksum,
             ),
-            'sections': (
-                annot_rels[0],
-                annot_checksum[0]
-            ),
-            'beats': (
-                annot_rels[1],
-                annot_checksum[1]
-            ),
-            'chords': (
-                annot_rels[2],
-                annot_checksum[2]
-            ),
-            'voca_inst': (
-                annot_rels[3],
-                annot_checksum[3]
-            )
-
+            'sections': (annot_rels[0], annot_checksum[0]),
+            'beats': (annot_rels[1], annot_checksum[1]),
+            'chords': (annot_rels[2], annot_checksum[2]),
+            'voca_inst': (annot_rels[3], annot_checksum[3]),
         }
 
     with open(RWC_POPULAR_INDEX_PATH, 'w') as fhandle:
@@ -133,11 +163,9 @@ def main(args):
 
 
 if __name__ == "__main__":
-    PARSER = argparse.ArgumentParser(
-        description="Make RWC-Popular index file.")
-    PARSER.add_argument("rwc_popular_data_path",
-                        type=str,
-                        help="Path to RWC-Popular data folder.")
+    PARSER = argparse.ArgumentParser(description="Make RWC-Popular index file.")
+    PARSER.add_argument(
+        "rwc_popular_data_path", type=str, help="Path to RWC-Popular data folder."
+    )
 
     main(PARSER.parse_args())
-

--- a/scripts/make_salami_index.py
+++ b/scripts/make_salami_index.py
@@ -28,12 +28,12 @@ def md5(file_path):
 
 
 def make_salami_index(data_path):
-    annotations_dir = os.path.join(data_path, 'Salami', 'salami-data-public-master',
-                                   'annotations')
+    annotations_dir = os.path.join(
+        data_path, 'Salami', 'salami-data-public-master', 'annotations'
+    )
     audio_dir = os.path.join(data_path, 'Salami', 'audio')
     annotations_files = os.listdir(annotations_dir)
-    track_ids = sorted(
-        [os.path.basename(f).split('.')[0] for f in annotations_files])
+    track_ids = sorted([os.path.basename(f).split('.')[0] for f in annotations_files])
 
     salami_index = {}
     for track_id in track_ids:
@@ -44,38 +44,43 @@ def make_salami_index(data_path):
         # using existing annotations (version 2.0)
         for f in ['uppercase.txt', 'lowercase.txt']:
             for a in ['1', '2']:
-                if os.path.exists(os.path.join(annotations_dir, track_id, 'parsed',
-                                               'textfile{}_{}'.format(a, f))):
-                    annot_checksum.append(md5(os.path.join(annotations_dir, track_id,
-                                                           'parsed', 'textfile'+a+'_'+f)))
-                    annot_rels.append(os.path.join('salami-data-public-master',
-                                                   'annotations', track_id, 'parsed',
-                                                   'textfile{}_{}'.format(a, f)))
+                if os.path.exists(
+                    os.path.join(
+                        annotations_dir,
+                        track_id,
+                        'parsed',
+                        'textfile{}_{}'.format(a, f),
+                    )
+                ):
+                    annot_checksum.append(
+                        md5(
+                            os.path.join(
+                                annotations_dir,
+                                track_id,
+                                'parsed',
+                                'textfile' + a + '_' + f,
+                            )
+                        )
+                    )
+                    annot_rels.append(
+                        os.path.join(
+                            'salami-data-public-master',
+                            'annotations',
+                            track_id,
+                            'parsed',
+                            'textfile{}_{}'.format(a, f),
+                        )
+                    )
                 else:
                     annot_checksum.append(None)
                     annot_rels.append(None)
 
         salami_index[track_id] = {
-            'audio': (
-                os.path.join('audio', '{}.mp3'.format(track_id)),
-                audio_checksum
-            ),
-            'annotator_1_uppercase': (
-                annot_rels[0],
-                annot_checksum[0]
-            ),
-            'annotator_1_lowercase': (
-                annot_rels[2],
-                annot_checksum[2]
-            ),
-            'annotator_2_uppercase': (
-                annot_rels[1],
-                annot_checksum[1]
-            ),
-            'annotator_2_lowercase': (
-                annot_rels[3],
-                annot_checksum[3]
-            )
+            'audio': (os.path.join('audio', '{}.mp3'.format(track_id)), audio_checksum),
+            'annotator_1_uppercase': (annot_rels[0], annot_checksum[0]),
+            'annotator_1_lowercase': (annot_rels[2], annot_checksum[2]),
+            'annotator_2_uppercase': (annot_rels[1], annot_checksum[1]),
+            'annotator_2_lowercase': (annot_rels[3], annot_checksum[3]),
         }
 
     with open(SALAMI_INDEX_PATH, 'w') as fhandle:
@@ -87,10 +92,9 @@ def main(args):
 
 
 if __name__ == '__main__':
-    PARSER = argparse.ArgumentParser(
-        description='Make Salami index file.')
-    PARSER.add_argument('salami_data_path',
-                        type=str,
-                        help='Path to Salami data folder.')
+    PARSER = argparse.ArgumentParser(description='Make Salami index file.')
+    PARSER.add_argument(
+        'salami_data_path', type=str, help='Path to Salami data folder.'
+    )
 
     main(PARSER.parse_args())

--- a/setup.py
+++ b/setup.py
@@ -18,12 +18,7 @@ if __name__ == '__main__':
         long_description="""Common loaders for MIR datasets.""",
         keywords='mir dataset loader audio',
         license='BSD-3-Clause',
-        install_requires=[
-            'tqdm',
-            'librosa < 0.7.0',
-            'numpy>=1.16',
-            'six',
-        ],
+        install_requires=['tqdm', 'librosa < 0.7.0', 'numpy>=1.16', 'six'],
         extras_require={
             'tests': [
                 'pytest>=4.4.0',
@@ -39,7 +34,7 @@ if __name__ == '__main__':
                 'sphinx',
                 'sphinxcontrib-napoleon',
                 'sphinx_rtd_theme',
-                'numpydoc'
+                'numpydoc',
             ],
-        }
+        },
     )

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -6,8 +6,8 @@ import numpy as np
 import pytest
 
 from mirdata import beatles, utils
-from tests.test_utils import (mock_validated, mock_validator, DEFAULT_DATA_HOME)
-from tests.test_download_utils import (mock_file, mock_untar)
+from tests.test_utils import mock_validated, mock_validator, DEFAULT_DATA_HOME
+from tests.test_download_utils import mock_file, mock_untar
 
 
 def test_track():
@@ -26,27 +26,30 @@ def test_track():
     assert track._track_paths == {
         'audio': [
             'audio/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav',
-            '1b57c2f78ae0f19eed1ae7fbf747e12d'
+            '1b57c2f78ae0f19eed1ae7fbf747e12d',
         ],
         'beat': [
             'annotations/beat/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.txt',
-            'f698ad2d802bf62fe10f59ea8b4af9f6'
+            'f698ad2d802bf62fe10f59ea8b4af9f6',
         ],
         'chords': [
             'annotations/chordlab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
-            '24f12726a510c0321aa06cac95f27915'
+            '24f12726a510c0321aa06cac95f27915',
         ],
         'keys': [
             'annotations/keylab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
-            'ca194503b783ed20521a1429411f3094'
+            'ca194503b783ed20521a1429411f3094',
         ],
         'sections': [
             'annotations/seglab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
-            '509125d527dae09cdee832fc0a6e0580'
-        ]
+            '509125d527dae09cdee832fc0a6e0580',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/Beatles/' + \
-        'audio/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/Beatles/'
+        + 'audio/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav'
+    )
     assert track.title == '11_-_Do_You_Want_To_Know_A_Secret'
     assert type(track.beats) == utils.BeatData
     assert type(track.chords) == utils.ChordData
@@ -55,22 +58,23 @@ def test_track():
 
     audio, sr = track.audio
     assert sr == 44100
-    assert audio.shape == (44100 * 2, )
+    assert audio.shape == (44100 * 2,)
 
-    repr_string = "Beatles Track(track_id=0111, " + \
-        "audio_path=tests/resources/mir_datasets/Beatles/audio/" + \
-        "01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav, " + \
-        "title=11_-_Do_You_Want_To_Know_A_Secret, " + \
-        "beats=BeatData('beat_times, 'beat_positions'), " + \
-        "chords=ChordData('start_times', 'end_times', 'chords'), " + \
-        "key=KeyData('start_times', 'end_times', 'keys'), " + \
-        "sections=SectionData('start_times', 'end_times', 'sections'))"
+    repr_string = (
+        "Beatles Track(track_id=0111, "
+        + "audio_path=tests/resources/mir_datasets/Beatles/audio/"
+        + "01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav, "
+        + "title=11_-_Do_You_Want_To_Know_A_Secret, "
+        + "beats=BeatData('beat_times, 'beat_positions'), "
+        + "chords=ChordData('start_times', 'end_times', 'chords'), "
+        + "key=KeyData('start_times', 'end_times', 'keys'), "
+        + "sections=SectionData('start_times', 'end_times', 'sections'))"
+    )
     assert track.__repr__() == repr_string
 
     track = beatles.Track('10212')
     assert track.beats == None
     assert track.key == None
-
 
 
 def test_track_ids():
@@ -91,18 +95,21 @@ def test_load():
 
 
 def test_load_beats():
-    beats_path = 'tests/resources/mir_datasets/Beatles/annotations/beat/' + \
-        'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.txt'
+    beats_path = (
+        'tests/resources/mir_datasets/Beatles/annotations/beat/'
+        + 'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.txt'
+    )
     beat_data = beatles._load_beats(beats_path)
 
     assert type(beat_data) == utils.BeatData
     assert type(beat_data.beat_times) == np.ndarray
     assert type(beat_data.beat_positions) == np.ndarray
 
-    assert np.array_equal(beat_data.beat_times, np.array(
-        [13.249, 13.959, 14.416, 14.965, 15.453, 15.929, 16.428]))
-    assert np.array_equal(beat_data.beat_positions, np.array(
-        [2, 3, 4, 1, 2, 3, 4]))
+    assert np.array_equal(
+        beat_data.beat_times,
+        np.array([13.249, 13.959, 14.416, 14.965, 15.453, 15.929, 16.428]),
+    )
+    assert np.array_equal(beat_data.beat_positions, np.array([2, 3, 4, 1, 2, 3, 4]))
 
     # load a file which doesn't exist
     beat_none = beatles._load_beats('fake/file/path')
@@ -110,8 +117,10 @@ def test_load_beats():
 
 
 def test_load_chords():
-    chords_path = 'tests/resources/mir_datasets/Beatles/annotations/chordlab/' + \
-        'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab'
+    chords_path = (
+        'tests/resources/mir_datasets/Beatles/annotations/chordlab/'
+        + 'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab'
+    )
     chord_data = beatles._load_chords(chords_path)
 
     assert type(chord_data) == utils.ChordData
@@ -119,12 +128,13 @@ def test_load_chords():
     assert type(chord_data.end_times) == np.ndarray
     assert type(chord_data.chords) == np.ndarray
 
-    assert np.array_equal(chord_data.start_times, np.array(
-        [0.000000, 4.586464, 6.989730]))
-    assert np.array_equal(chord_data.end_times, np.array(
-        [0.497838, 6.989730, 9.985104]))
-    assert np.array_equal(chord_data.chords, np.array(
-        ['N', 'E:min', 'G']))
+    assert np.array_equal(
+        chord_data.start_times, np.array([0.000000, 4.586464, 6.989730])
+    )
+    assert np.array_equal(
+        chord_data.end_times, np.array([0.497838, 6.989730, 9.985104])
+    )
+    assert np.array_equal(chord_data.chords, np.array(['N', 'E:min', 'G']))
 
     # load a file which doesn't exist
     chord_none = beatles._load_chords('fake/file/path')
@@ -132,8 +142,10 @@ def test_load_chords():
 
 
 def test_load_key():
-    key_path = 'tests/resources/mir_datasets/Beatles/annotations/keylab/' + \
-        'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab'
+    key_path = (
+        'tests/resources/mir_datasets/Beatles/annotations/keylab/'
+        + 'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab'
+    )
     key_data = beatles._load_key(key_path)
 
     assert type(key_data) == utils.KeyData
@@ -149,8 +161,10 @@ def test_load_key():
 
 
 def test_load_sections():
-    sections_path = 'tests/resources/mir_datasets/Beatles/annotations/seglab/' + \
-        'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab'
+    sections_path = (
+        'tests/resources/mir_datasets/Beatles/annotations/seglab/'
+        + 'The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab'
+    )
     section_data = beatles._load_sections(sections_path)
 
     assert type(section_data) == utils.SectionData
@@ -158,12 +172,9 @@ def test_load_sections():
     assert type(section_data.end_times) == np.ndarray
     assert type(section_data.sections) == np.ndarray
 
-    assert np.array_equal(section_data.start_times, np.array(
-        [0.000000, 0.465]))
-    assert np.array_equal(section_data.end_times, np.array(
-        [0.465, 14.931]))
-    assert np.array_equal(section_data.sections, np.array(
-        ['silence', 'intro']))
+    assert np.array_equal(section_data.start_times, np.array([0.000000, 0.465]))
+    assert np.array_equal(section_data.end_times, np.array([0.465, 14.931]))
+    assert np.array_equal(section_data.sections, np.array(['silence', 'intro']))
 
     # load a file which doesn't exist
     section_none = beatles._load_sections('fake/file/path')

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -128,6 +128,7 @@ def test_download_zip_file(mocker, mock_file, mock_unzip):
     mock_file.assert_called_once_with("a", "b", True)
     mock_unzip.assert_called_once_with("foo", "b", cleanup=False)
 
+
 def test_download_tar_file(mocker, mock_file, mock_untar):
     mock_file.return_value = "foo"
     download_utils.download_tar_file("a", "b", True)

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -26,21 +26,14 @@ def test_track():
     assert track.track_id == '10161_chorus'
     assert track._data_home == data_home
     assert track._track_paths == {
-        'audio': [
-            'Wavfile/10161_chorus.wav',
-            '278ae003cb0d323e99b9a643c0f2eeda'
-        ],
-        'pitch': [
-            'PitchLabel/10161_chorus.pv',
-            '0d93a011a9e668fd80673049089bbb14'
-        ],
-        'lyrics': [
-            'Lyrics/10161_chorus.lab',
-            '79bbeb72b422056fd43be4e8d63319ce'
-        ]
+        'audio': ['Wavfile/10161_chorus.wav', '278ae003cb0d323e99b9a643c0f2eeda'],
+        'pitch': ['PitchLabel/10161_chorus.pv', '0d93a011a9e668fd80673049089bbb14'],
+        'lyrics': ['Lyrics/10161_chorus.lab', '79bbeb72b422056fd43be4e8d63319ce'],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/iKala/' + \
-        'Wavfile/10161_chorus.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/iKala/' + 'Wavfile/10161_chorus.wav'
+    )
     assert track.song_id == '10161'
     assert track.section == 'chorus'
     assert track.singer_id == '1'
@@ -52,11 +45,11 @@ def test_track():
     # test audio loading functions
     vocal, sr_vocal = track.vocal_audio
     assert sr_vocal == 44100
-    assert vocal.shape == (44100 * 2, )
+    assert vocal.shape == (44100 * 2,)
 
     instrumental, sr_instrumental = track.instrumental_audio
     assert sr_instrumental == 44100
-    assert instrumental.shape == (44100 * 2, )
+    assert instrumental.shape == (44100 * 2,)
 
     # make sure we loaded the correct channels to vocal/instrumental
     # (in this example, the first quarter second has only instrumentals)
@@ -64,15 +57,17 @@ def test_track():
 
     mix, sr_mix = track.mix_audio
     assert sr_mix == 44100
-    assert mix.shape == (44100 * 2, )
+    assert mix.shape == (44100 * 2,)
     assert np.array_equal(mix, instrumental + vocal)
 
-    repr_string = "iKala Track(track_id=10161_chorus, " + \
-        "audio_path=tests/resources/mir_datasets/iKala/Wavfile/" + \
-        "10161_chorus.wav, song_id=10161, section=chorus, singer_id=1, " + \
-        "f0=F0Data('times', 'frequencies', 'confidence'), " + \
-        "lyrics=LyricData('start_times', 'end_times', 'lyrics', " + \
-        "'pronounciations'))"
+    repr_string = (
+        "iKala Track(track_id=10161_chorus, "
+        + "audio_path=tests/resources/mir_datasets/iKala/Wavfile/"
+        + "10161_chorus.wav, song_id=10161, section=chorus, singer_id=1, "
+        + "f0=F0Data('times', 'frequencies', 'confidence'), "
+        + "lyrics=LyricData('start_times', 'end_times', 'lyrics', "
+        + "'pronounciations'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -119,7 +114,7 @@ def test_load_lyrics():
     lyrics_path_simple = 'tests/resources/mir_datasets/iKala/Lyrics/10161_chorus.lab'
     lyrics_data_simple = ikala._load_lyrics(lyrics_path_simple)
 
-    #check types
+    # check types
     assert type(lyrics_data_simple) is utils.LyricData
     assert type(lyrics_data_simple.start_times) is np.ndarray
     assert type(lyrics_data_simple.end_times) is np.ndarray
@@ -147,7 +142,9 @@ def test_load_lyrics():
     assert np.array_equal(lyrics_data_pronun.start_times, np.array([0.021, 0.571]))
     assert np.array_equal(lyrics_data_pronun.end_times, np.array([0.189, 1.415]))
     assert np.array_equal(lyrics_data_pronun.lyrics, np.array(['ASDF', 'EVERYBODY']))
-    assert np.array_equal(lyrics_data_pronun.pronounciations, np.array(['t i au', None]))
+    assert np.array_equal(
+        lyrics_data_pronun.pronounciations, np.array(['t i au', None])
+    )
 
     # load a file which doesn't exist
     lyrics_data_none = ikala._load_lyrics('fake/path')

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -13,7 +13,9 @@ from tests.test_utils import mock_validated, mock_validator, DEFAULT_DATA_HOME
 def test_track():
     # test data home None
     track_default = medleydb_melody.Track('MusicDelta_Beethoven')
-    assert track_default._data_home == os.path.join(DEFAULT_DATA_HOME, 'MedleyDB-Melody')
+    assert track_default._data_home == os.path.join(
+        DEFAULT_DATA_HOME, 'MedleyDB-Melody'
+    )
 
     data_home = 'tests/resources/mir_datasets/MedleyDB-Melody'
 
@@ -28,23 +30,26 @@ def test_track():
     assert track._track_paths == {
         'audio': [
             'audio/MusicDelta_Beethoven_MIX.wav',
-            '4c6081420a506b438a851c2807fc28ea'
+            '4c6081420a506b438a851c2807fc28ea',
         ],
         'melody1': [
             'melody1/MusicDelta_Beethoven_MELODY1.csv',
-            '67dca3f4a9bf0517dd8a1287d091791e'
+            '67dca3f4a9bf0517dd8a1287d091791e',
         ],
         'melody2': [
             'melody2/MusicDelta_Beethoven_MELODY2.csv',
-            '67dca3f4a9bf0517dd8a1287d091791e'
+            '67dca3f4a9bf0517dd8a1287d091791e',
         ],
         'melody3': [
             'melody3/MusicDelta_Beethoven_MELODY3.csv',
-            '340f647c4f12d7e1ecf2421d0dfd509f'
-        ]
+            '340f647c4f12d7e1ecf2421d0dfd509f',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/' + \
-        'MedleyDB-Melody/audio/MusicDelta_Beethoven_MIX.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/'
+        + 'MedleyDB-Melody/audio/MusicDelta_Beethoven_MIX.wav'
+    )
     assert track.artist == 'MusicDelta'
     assert track.title == 'Beethoven'
     assert track.genre == 'Classical'
@@ -58,15 +63,17 @@ def test_track():
 
     y, sr = track.audio
     assert sr == 44100
-    assert y.shape == (44100 * 2, )
+    assert y.shape == (44100 * 2,)
 
-    repr_string = "MedleyDb-Melody Track(track_id=MusicDelta_Beethoven, " + \
-        "audio_path=tests/resources/mir_datasets/MedleyDB-Melody/audio/" + \
-        "MusicDelta_Beethoven_MIX.wav, artist=MusicDelta, title=Beethoven," + \
-        " genre=Classical, is_excerpt=True, is_instrumental=True, " + \
-        "n_sources=18, melody1=F0Data('times', 'frequencies', confidence')," + \
-        " melody2=F0Data('times', 'frequencies', confidence'), " + \
-        "melody3=F0Data('times', 'frequencies', confidence'))"
+    repr_string = (
+        "MedleyDb-Melody Track(track_id=MusicDelta_Beethoven, "
+        + "audio_path=tests/resources/mir_datasets/MedleyDB-Melody/audio/"
+        + "MusicDelta_Beethoven_MIX.wav, artist=MusicDelta, title=Beethoven,"
+        + " genre=Classical, is_excerpt=True, is_instrumental=True, "
+        + "n_sources=18, melody1=F0Data('times', 'frequencies', confidence'),"
+        + " melody2=F0Data('times', 'frequencies', confidence'), "
+        + "melody3=F0Data('times', 'frequencies', confidence'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -79,7 +86,8 @@ def test_track_ids():
 def test_load():
     data_home = 'tests/resources/mir_datasets/MedleyDB-Melody'
     medleydb_melody_data = medleydb_melody.load(
-        data_home=data_home, silence_validator=True)
+        data_home=data_home, silence_validator=True
+    )
     assert type(medleydb_melody_data) is dict
     assert len(medleydb_melody_data.keys()) is 108
 
@@ -90,8 +98,10 @@ def test_load():
 
 def test_load_melody():
     # load a file which exists
-    melody_path = 'tests/resources/mir_datasets/MedleyDB-Melody/' + \
-        'melody1/MusicDelta_Beethoven_MELODY1.csv'
+    melody_path = (
+        'tests/resources/mir_datasets/MedleyDB-Melody/'
+        + 'melody1/MusicDelta_Beethoven_MELODY1.csv'
+    )
     melody_data = medleydb_melody._load_melody(melody_path)
 
     # check types
@@ -102,9 +112,9 @@ def test_load_melody():
 
     # check values
     assert np.array_equal(
-        melody_data.times, np.array([0.0058049886621315194, 0.052244897959183675]))
-    assert np.array_equal(
-        melody_data.frequencies, np.array([0.0, 965.99199999999996]))
+        melody_data.times, np.array([0.0058049886621315194, 0.052244897959183675])
+    )
+    assert np.array_equal(melody_data.frequencies, np.array([0.0, 965.99199999999996]))
     assert np.array_equal(melody_data.confidence, np.array([0.0, 1.0]))
 
     # load a file which doesn't exist
@@ -114,8 +124,10 @@ def test_load_melody():
 
 def test_load_melody3():
     # load a file which exists
-    melody_path = 'tests/resources/mir_datasets/MedleyDB-Melody/' + \
-        'melody3/MusicDelta_Beethoven_MELODY3.csv'
+    melody_path = (
+        'tests/resources/mir_datasets/MedleyDB-Melody/'
+        + 'melody3/MusicDelta_Beethoven_MELODY3.csv'
+    )
     melody_data = medleydb_melody._load_melody3(melody_path)
 
     # check types
@@ -125,22 +137,36 @@ def test_load_melody3():
     assert type(melody_data.confidence) is np.ndarray
 
     # check values
-    assert np.array_equal(melody_data.times, np.array([
-        0.046439909297052155,
-        0.052244897959183675,
-        0.1219047619047619
-    ]))
-    assert np.array_equal(melody_data.frequencies, np.array([
-        [0.0, 0.0, 497.01600000000002, 0.0, 0.0],
-        [965.99199999999996, 996.46799999999996, 497.10599999999999, 0.0, 0.0],
-        [987.32000000000005, 987.93200000000002, 495.46800000000002,
-            495.29899999999998, 242.98699999999999]
-    ]))
-    assert np.array_equal(melody_data.confidence, np.array([
-        [0.0, 0.0, 1.0, 0.0, 0.0],
-        [1.0, 1.0, 1.0, 0.0, 0.0],
-        [1.0, 1.0, 1.0, 1.0, 1.0]
-    ]))
+    assert np.array_equal(
+        melody_data.times,
+        np.array([0.046439909297052155, 0.052244897959183675, 0.1219047619047619]),
+    )
+    assert np.array_equal(
+        melody_data.frequencies,
+        np.array(
+            [
+                [0.0, 0.0, 497.01600000000002, 0.0, 0.0],
+                [965.99199999999996, 996.46799999999996, 497.10599999999999, 0.0, 0.0],
+                [
+                    987.32000000000005,
+                    987.93200000000002,
+                    495.46800000000002,
+                    495.29899999999998,
+                    242.98699999999999,
+                ],
+            ]
+        ),
+    )
+    assert np.array_equal(
+        melody_data.confidence,
+        np.array(
+            [
+                [0.0, 0.0, 1.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0],
+            ]
+        ),
+    )
 
     # load a file which doesn't exist
     melody_data_none = medleydb_melody._load_melody3('fake/file/path')
@@ -161,7 +187,7 @@ def test_load_metadata():
         'genre': 'Classical',
         'is_excerpt': True,
         'is_instrumental': True,
-        'n_sources': 18
+        'n_sources': 18,
     }
 
     metadata_none = medleydb_melody._load_metadata('asdf/asdf')

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -20,7 +20,8 @@ def test_track():
         medleydb_pitch.Track('asdfasdf', data_home=data_home)
 
     track = medleydb_pitch.Track(
-        'AClassicEducation_NightOwl_STEM_08', data_home=data_home)
+        'AClassicEducation_NightOwl_STEM_08', data_home=data_home
+    )
 
     # test attributes
     assert track.track_id == 'AClassicEducation_NightOwl_STEM_08'
@@ -28,15 +29,18 @@ def test_track():
     assert track._track_paths == {
         'audio': [
             'audio/AClassicEducation_NightOwl_STEM_08.wav',
-            '6cfb976517cf377863ba0ef6c66c6a07'
+            '6cfb976517cf377863ba0ef6c66c6a07',
         ],
         'pitch': [
             'pitch/AClassicEducation_NightOwl_STEM_08.csv',
-            '67009ae37766c37d3c29146bf763e06d'
-        ]
+            '67009ae37766c37d3c29146bf763e06d',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/' + \
-        'MedleyDB-Pitch/audio/AClassicEducation_NightOwl_STEM_08.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/'
+        + 'MedleyDB-Pitch/audio/AClassicEducation_NightOwl_STEM_08.wav'
+    )
     assert track.instrument == 'male singer'
     assert track.artist == 'AClassicEducation'
     assert track.title == 'NightOwl'
@@ -46,13 +50,15 @@ def test_track():
 
     y, sr = track.audio
     assert sr == 44100
-    assert y.shape == (44100 * 2, )
+    assert y.shape == (44100 * 2,)
 
-    repr_string = "MedleyDb-Pitch Track(track_id=AClassicEducation_NightOwl_STEM_08, " + \
-        "audio_path=tests/resources/mir_datasets/MedleyDB-Pitch/audio/" + \
-        "AClassicEducation_NightOwl_STEM_08.wav, " + \
-        "artist=AClassicEducation, title=NightOwl, genre=Singer/Songwriter, " + \
-        "instrument=male singer, pitch=PitchData('times', 'pitches', 'confidence'))"
+    repr_string = (
+        "MedleyDb-Pitch Track(track_id=AClassicEducation_NightOwl_STEM_08, "
+        + "audio_path=tests/resources/mir_datasets/MedleyDB-Pitch/audio/"
+        + "AClassicEducation_NightOwl_STEM_08.wav, "
+        + "artist=AClassicEducation, title=NightOwl, genre=Singer/Songwriter, "
+        + "instrument=male singer, pitch=PitchData('times', 'pitches', 'confidence'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -65,7 +71,8 @@ def test_track_ids():
 def test_load():
     data_home = 'tests/resources/mir_datasets/MedleyDB-Pitch'
     medleydb_pitch_data = medleydb_pitch.load(
-        data_home=data_home, silence_validator=True)
+        data_home=data_home, silence_validator=True
+    )
     assert type(medleydb_pitch_data) is dict
     assert len(medleydb_pitch_data.keys()) is 103
 
@@ -76,8 +83,10 @@ def test_load():
 
 def test_load_pitch():
     # load a file which exists
-    pitch_path = 'tests/resources/mir_datasets/MedleyDB-Pitch/' + \
-        'pitch/AClassicEducation_NightOwl_STEM_08.csv'
+    pitch_path = (
+        'tests/resources/mir_datasets/MedleyDB-Pitch/'
+        + 'pitch/AClassicEducation_NightOwl_STEM_08.csv'
+    )
     pitch_data = medleydb_pitch._load_pitch(pitch_path)
 
     # check types
@@ -88,9 +97,9 @@ def test_load_pitch():
 
     # check values
     assert np.array_equal(
-        pitch_data.times, np.array([0.06965986394557823, 0.07546485260770976]))
-    assert np.array_equal(
-        pitch_data.frequencies, np.array([0.0, 191.877]))
+        pitch_data.times, np.array([0.06965986394557823, 0.07546485260770976])
+    )
+    assert np.array_equal(pitch_data.frequencies, np.array([0.0, 191.877]))
     assert np.array_equal(pitch_data.confidence, np.array([0.0, 1.0]))
 
     # load a file which doesn't exist

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -28,21 +28,23 @@ def test_track():
     assert track._track_paths == {
         "audio_stereo": [
             "audio/stereo/Beethoven-S3-I-ex1.wav",
-            "f819c86bba06120a19bd495f819cd0ef"
+            "f819c86bba06120a19bd495f819cd0ef",
         ],
         "audio_mono": [
             "audio/mono/Beethoven-S3-I-ex1.wav",
-            "7bb7a2492dcf9e1eaad9e82f8550219a"
+            "7bb7a2492dcf9e1eaad9e82f8550219a",
         ],
-        "melody": [
-            "GT/Beethoven-S3-I-ex1.mel",
-            "8bbf6716337a2b5f7afcc611ad66e91a"
-        ]
+        "melody": ["GT/Beethoven-S3-I-ex1.mel", "8bbf6716337a2b5f7afcc611ad66e91a"],
     }
-    assert track.audio_path_mono == 'tests/resources/mir_datasets/' + \
-        'Orchset/audio/mono/Beethoven-S3-I-ex1.wav'
-    assert track.audio_path_stereo == 'tests/resources/mir_datasets/' + \
-        'Orchset/audio/stereo/Beethoven-S3-I-ex1.wav'
+    assert (
+        track.audio_path_mono
+        == 'tests/resources/mir_datasets/' + 'Orchset/audio/mono/Beethoven-S3-I-ex1.wav'
+    )
+    assert (
+        track.audio_path_stereo
+        == 'tests/resources/mir_datasets/'
+        + 'Orchset/audio/stereo/Beethoven-S3-I-ex1.wav'
+    )
     assert track.composer == 'Beethoven'
     assert track.work == 'S3-I'
     assert track.excerpt == '1'
@@ -59,21 +61,23 @@ def test_track():
 
     y_mono, sr_mono = track.audio_mono
     assert sr_mono == 44100
-    assert y_mono.shape == (44100 * 2, )
+    assert y_mono.shape == (44100 * 2,)
 
     y_stereo, sr_stereo = track.audio_stereo
     assert sr_stereo == 44100
     assert y_stereo.shape == (2, 44100 * 2)
 
-    repr_string = "Orchset Track(track_id=Beethoven-S3-I-ex1, " + \
-        "audio_path_stereo=tests/resources/mir_datasets/Orchset/audio/" + \
-        "stereo/Beethoven-S3-I-ex1.wav, " + \
-        "audio_path_mono=tests/resources/mir_datasets/Orchset/audio/" + \
-        "mono/Beethoven-S3-I-ex1.wav, composer=Beethoven, work=S3-I, " + \
-        "excerpt=1, predominant_melodic_instruments=['strings', 'winds'], " + \
-        "alternating_melody=True, contains_winds=True, contains_strings=True, " + \
-        "contains_brass=False, only_strings=False, only_winds=False, " + \
-        "only_brass=False, melody=F0Data('times', 'frequencies', 'confidence'))"
+    repr_string = (
+        "Orchset Track(track_id=Beethoven-S3-I-ex1, "
+        + "audio_path_stereo=tests/resources/mir_datasets/Orchset/audio/"
+        + "stereo/Beethoven-S3-I-ex1.wav, "
+        + "audio_path_mono=tests/resources/mir_datasets/Orchset/audio/"
+        + "mono/Beethoven-S3-I-ex1.wav, composer=Beethoven, work=S3-I, "
+        + "excerpt=1, predominant_melodic_instruments=['strings', 'winds'], "
+        + "alternating_melody=True, contains_winds=True, contains_strings=True, "
+        + "contains_brass=False, only_strings=False, only_winds=False, "
+        + "only_brass=False, melody=F0Data('times', 'frequencies', 'confidence'))"
+    )
     assert track.__repr__() == repr_string
 
 

--- a/tests/test_rwc_classical.py
+++ b/tests/test_rwc_classical.py
@@ -26,21 +26,20 @@ def test_track():
     assert track.track_id == 'RM-C003'
     assert track._data_home == data_home
     assert track._track_paths == {
-        'audio': [
-            'audio/rwc-c-m01/3.wav',
-            'a2f1accd0ae6ba4364069b3370a57578'
-        ],
+        'audio': ['audio/rwc-c-m01/3.wav', 'a2f1accd0ae6ba4364069b3370a57578'],
         'sections': [
             'annotations/AIST.RWC-MDB-C-2001.CHORUS/RM-C003.CHORUS.TXT',
-            '9805083e55f2547559ebdfa5f97ccb0e'
+            '9805083e55f2547559ebdfa5f97ccb0e',
         ],
         'beats': [
             'annotations/AIST.RWC-MDB-C-2001.BEAT/RM-C003.BEAT.TXT',
-            '3deaf6102c54c04596182ba904375e19'
-        ]
+            '3deaf6102c54c04596182ba904375e19',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/RWC-Classical/' + \
-        'audio/rwc-c-m01/3.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/RWC-Classical/' + 'audio/rwc-c-m01/3.wav'
+    )
     assert track.piece_number == 'No. 3'
     assert track.suffix == 'M01'
     assert track.track_number == 'Tr. 03'
@@ -57,15 +56,17 @@ def test_track():
     # test audio loading functions
     y, sr = track.audio
     assert sr == 44100
-    assert y.shape == (44100 * 2, )
+    assert y.shape == (44100 * 2,)
 
-    repr_string = "RWC-Classical Track(track_id=RM-C003, " + \
-        "audio_path=tests/resources/mir_datasets/RWC-Classical/audio/rwc-c-m01/3.wav, " + \
-        "piece_number=No. 3, suffix=M01, track_number=Tr. 03, " + \
-        "title=Symphony no.5 in C minor, op.67. 1st mvmt., composer=Beethoven, Ludwig van, " + \
-        "artist=Tokyo City Philharmonic Orchestra, duration_sec=7:15, category=Symphony" + \
-        "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-        "beats=BeatData('beat_times', 'beat_positions'))"
+    repr_string = (
+        "RWC-Classical Track(track_id=RM-C003, "
+        + "audio_path=tests/resources/mir_datasets/RWC-Classical/audio/rwc-c-m01/3.wav, "
+        + "piece_number=No. 3, suffix=M01, track_number=Tr. 03, "
+        + "title=Symphony no.5 in C minor, op.67. 1st mvmt., composer=Beethoven, Ludwig van, "
+        + "artist=Tokyo City Philharmonic Orchestra, duration_sec=7:15, category=Symphony"
+        + "sections=SectionData('start_times', 'end_times', 'sections'), "
+        + "beats=BeatData('beat_times', 'beat_positions'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -88,8 +89,10 @@ def test_load():
 
 def test_load_sections():
     # load a file which exists
-    section_path = 'tests/resources/mir_datasets/RWC-Classical/' + \
-        'annotations/AIST.RWC-MDB-C-2001.CHORUS/RM-C003.CHORUS.TXT'
+    section_path = (
+        'tests/resources/mir_datasets/RWC-Classical/'
+        + 'annotations/AIST.RWC-MDB-C-2001.CHORUS/RM-C003.CHORUS.TXT'
+    )
     section_data = rwc_classical._load_sections(section_path)
 
     # check types
@@ -114,7 +117,8 @@ def test_position_in_bar():
     fixed_positions1 = np.array([2, 1, 2, 1, 2, 1, 2, 1])
     fixed_times1 = np.array([1, 2, 3, 4, 5, 6, 7, 8])
     actual_positions1, actual_times1 = rwc_classical._position_in_bar(
-        beat_positions1, times1)
+        beat_positions1, times1
+    )
     assert np.array_equal(actual_positions1, fixed_positions1)
     assert np.array_equal(actual_times1, fixed_times1)
 
@@ -123,7 +127,8 @@ def test_position_in_bar():
     fixed_positions2 = np.array([2, 1, 2, 1, 2, 1, 2])
     fixed_times2 = np.array([2, 3, 4, 5, 6, 7, 8])
     actual_positions2, actual_times2 = rwc_classical._position_in_bar(
-        beat_positions2, times2)
+        beat_positions2, times2
+    )
     assert np.array_equal(actual_positions2, fixed_positions2)
     assert np.array_equal(actual_times2, fixed_times2)
 
@@ -132,7 +137,8 @@ def test_position_in_bar():
     fixed_positions3 = np.array([1, 2, 1, 2, 1, 2, 1, 2, 1])
     fixed_times3 = np.array([1, 2, 3, 4, 5, 6, 7, 8, 9])
     actual_positions3, actual_times3 = rwc_classical._position_in_bar(
-        beat_positions3, times3)
+        beat_positions3, times3
+    )
     assert np.array_equal(actual_positions3, fixed_positions3)
     assert np.array_equal(actual_times3, fixed_times3)
 
@@ -141,7 +147,8 @@ def test_position_in_bar():
     fixed_positions4 = np.array([1, 2, 3, 4, 1, 2, 3, 4])
     fixed_times4 = np.array([1, 2, 3, 4, 5, 6, 7, 8])
     actual_positions4, actual_times4 = rwc_classical._position_in_bar(
-        beat_positions4, times4)
+        beat_positions4, times4
+    )
     assert np.array_equal(actual_positions4, fixed_positions4)
     assert np.array_equal(actual_times4, fixed_times4)
 
@@ -150,14 +157,17 @@ def test_position_in_bar():
     fixed_positions5 = np.array([3, 4, 1, 2, 3, 4, 1])
     fixed_times5 = np.array([1, 2, 3, 4, 5, 6, 7])
     actual_positions5, actual_times5 = rwc_classical._position_in_bar(
-        beat_positions5, times5)
+        beat_positions5, times5
+    )
     assert np.array_equal(actual_positions5, fixed_positions5)
     assert np.array_equal(actual_times5, fixed_times5)
 
 
 def test_load_beats():
-    beats_path = 'tests/resources/mir_datasets/RWC-Classical/' + \
-        'annotations/AIST.RWC-MDB-C-2001.BEAT/RM-C003.BEAT.TXT'
+    beats_path = (
+        'tests/resources/mir_datasets/RWC-Classical/'
+        + 'annotations/AIST.RWC-MDB-C-2001.BEAT/RM-C003.BEAT.TXT'
+    )
     beat_data = rwc_classical._load_beats(beats_path)
 
     # check types
@@ -166,10 +176,10 @@ def test_load_beats():
     assert type(beat_data.beat_positions) is np.ndarray
 
     # check values
-    assert np.array_equal(beat_data.beat_times, np.array(
-        [1.65, 2.58, 2.95, 3.33, 3.71, 4.09, 5.18, 6.28]))
-    assert np.array_equal(beat_data.beat_positions, np.array(
-        [2, 1, 2, 1, 2, 1, 2, 1]))
+    assert np.array_equal(
+        beat_data.beat_times, np.array([1.65, 2.58, 2.95, 3.33, 3.71, 4.09, 5.18, 6.28])
+    )
+    assert np.array_equal(beat_data.beat_positions, np.array([2, 1, 2, 1, 2, 1, 2, 1]))
 
     # load a file which doesn't exist
     beats_data_none = rwc_classical._load_beats('fake/path')

--- a/tests/test_rwc_genre.py
+++ b/tests/test_rwc_genre.py
@@ -26,21 +26,20 @@ def test_track():
     assert track.track_id == 'RM-G002'
     assert track._data_home == data_home
     assert track._track_paths == {
-        'audio': [
-            'audio/rwc-g-m01/2.wav',
-            'bc17b325501ee23e5729202cc599d6e8'
-        ],
+        'audio': ['audio/rwc-g-m01/2.wav', 'bc17b325501ee23e5729202cc599d6e8'],
         'sections': [
             'annotations/AIST.RWC-MDB-G-2001.CHORUS/RM-G002.CHORUS.TXT',
-            '695fe2a90e8b5250f0570b968047b46f'
+            '695fe2a90e8b5250f0570b968047b46f',
         ],
         'beats': [
             'annotations/AIST.RWC-MDB-G-2001.BEAT/RM-G002.BEAT.TXT',
-            '62c5ec60312f41ba4d1e74d0b04c4e8f'
-        ]
+            '62c5ec60312f41ba4d1e74d0b04c4e8f',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/RWC-Genre/' + \
-        'audio/rwc-g-m01/2.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/RWC-Genre/' + 'audio/rwc-g-m01/2.wav'
+    )
     assert track.piece_number == 'No. 2'
     assert track.suffix == 'M01'
     assert track.track_number == 'Tr. 02'
@@ -58,15 +57,17 @@ def test_track():
     # test audio loading functions
     y, sr = track.audio
     assert sr == 44100
-    assert y.shape == (44100 * 2, )
+    assert y.shape == (44100 * 2,)
 
-    repr_string = "RWC-Genre Track(track_id=RM-G002, " + \
-        "audio_path=tests/resources/mir_datasets/RWC-Genre/audio/rwc-g-m01/2.wav, " + \
-        "piece_number=No. 2, suffix=M01, track_number=Tr. 02, category=Pop, " + \
-        "sub_category=Pop, title=Forget about It, composer=Shinya Iguchi, " + \
-        "artist=Shinya Iguchi (Male), duration_sec=04:22, " + \
-        "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-        "beats=BeatData('beat_times', 'beat_positions'))"
+    repr_string = (
+        "RWC-Genre Track(track_id=RM-G002, "
+        + "audio_path=tests/resources/mir_datasets/RWC-Genre/audio/rwc-g-m01/2.wav, "
+        + "piece_number=No. 2, suffix=M01, track_number=Tr. 02, category=Pop, "
+        + "sub_category=Pop, title=Forget about It, composer=Shinya Iguchi, "
+        + "artist=Shinya Iguchi (Male), duration_sec=04:22, "
+        + "sections=SectionData('start_times', 'end_times', 'sections'), "
+        + "beats=BeatData('beat_times', 'beat_positions'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -78,8 +79,7 @@ def test_track_ids():
 
 def test_load():
     data_home = 'tests/resources/mir_datasets/RWC-Genre'
-    rwc_genre_data = rwc_genre.load(
-        data_home=data_home, silence_validator=True)
+    rwc_genre_data = rwc_genre.load(data_home=data_home, silence_validator=True)
     assert type(rwc_genre_data) is dict
     assert len(rwc_genre_data.keys()) == 90  # missing 10 files
 
@@ -101,7 +101,7 @@ def test_load_metadata():
         'title': 'Forget about It',
         'composer': 'Shinya Iguchi',
         'artist': 'Shinya Iguchi (Male)',
-        'duration_sec': '04:22'
+        'duration_sec': '04:22',
     }
 
     metadata_none = rwc_genre._load_metadata('asdf/asdf')

--- a/tests/test_rwc_jazz.py
+++ b/tests/test_rwc_jazz.py
@@ -24,21 +24,20 @@ def test_track():
     assert track.track_id == 'RM-J004'
     assert track._data_home == data_home
     assert track._track_paths == {
-        'audio': [
-            'audio/rwc-j-m01/4.wav',
-            '7887ad17b7e4dcad9aa4605482e36cfa'
-        ],
+        'audio': ['audio/rwc-j-m01/4.wav', '7887ad17b7e4dcad9aa4605482e36cfa'],
         'sections': [
             'annotations/AIST.RWC-MDB-J-2001.CHORUS/RM-J004.CHORUS.TXT',
-            '59cd67199cce9da16283b85338e5a9af'
+            '59cd67199cce9da16283b85338e5a9af',
         ],
         'beats': [
             'annotations/AIST.RWC-MDB-J-2001.BEAT/RM-J004.BEAT.TXT',
-            'f3159206ae2f0aa86901248148f4021f'
-        ]
+            'f3159206ae2f0aa86901248148f4021f',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/RWC-Jazz/' + \
-        'audio/rwc-j-m01/4.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/RWC-Jazz/' + 'audio/rwc-j-m01/4.wav'
+    )
     assert track.piece_number == 'No. 4'
     assert track.suffix == 'M01'
     assert track.track_number == 'Tr. 04'
@@ -55,15 +54,17 @@ def test_track():
     # test audio loading functions
     y, sr = track.audio
     assert sr == 44100
-    assert y.shape == (44100 * 2, )
+    assert y.shape == (44100 * 2,)
 
-    repr_string = "RWC-Jazz Track(track_id=RM-J004, " + \
-            "audio_path=tests/resources/mir_datasets/RWC-Jazz/audio/rwc-j-m01/4.wav, " + \
-            "piece_number=No. 4, suffix=M01, track_number=Tr. 04, " + \
-            "title=Crescent Serenade (Piano Solo), artist=Makoto Nakamura, " + \
-            "duration_sec=02:47, variation=Instrumentation 1, instruments=Pf, " + \
-            "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-            "beats=BeatData('beat_times', 'beat_positions'))"
+    repr_string = (
+        "RWC-Jazz Track(track_id=RM-J004, "
+        + "audio_path=tests/resources/mir_datasets/RWC-Jazz/audio/rwc-j-m01/4.wav, "
+        + "piece_number=No. 4, suffix=M01, track_number=Tr. 04, "
+        + "title=Crescent Serenade (Piano Solo), artist=Makoto Nakamura, "
+        + "duration_sec=02:47, variation=Instrumentation 1, instruments=Pf, "
+        + "sections=SectionData('start_times', 'end_times', 'sections'), "
+        + "beats=BeatData('beat_times', 'beat_positions'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -75,8 +76,7 @@ def test_track_ids():
 
 def test_load():
     data_home = 'tests/resources/mir_datasets/RWC-Jazz'
-    rwc_jazz_data = rwc_jazz.load(
-        data_home=data_home, silence_validator=True)
+    rwc_jazz_data = rwc_jazz.load(data_home=data_home, silence_validator=True)
     assert type(rwc_jazz_data) is dict
     assert len(rwc_jazz_data.keys()) == 50
 
@@ -97,7 +97,7 @@ def test_load_metadata():
         'artist': 'Makoto Nakamura',
         'duration_sec': '02:47',
         'variation': 'Instrumentation 1',
-        'instruments': 'Pf'
+        'instruments': 'Pf',
     }
 
     metadata_none = rwc_jazz._load_metadata('asdf/asdf')

--- a/tests/test_rwc_popular.py
+++ b/tests/test_rwc_popular.py
@@ -25,29 +25,28 @@ def test_track():
     assert track.track_id == 'RM-P001'
     assert track._data_home == data_home
     assert track._track_paths == {
-        'audio': [
-            'audio/rwc-p-m01/1.wav',
-            '110ac7edb20dbe9a75ffe81b2bfeecef'
-        ],
+        'audio': ['audio/rwc-p-m01/1.wav', '110ac7edb20dbe9a75ffe81b2bfeecef'],
         'sections': [
             'annotations/AIST.RWC-MDB-P-2001.CHORUS/RM-P001.CHORUS.TXT',
-            '2d735867d44c4f8677b48746b5eb324d'
+            '2d735867d44c4f8677b48746b5eb324d',
         ],
         'beats': [
             'annotations/AIST.RWC-MDB-P-2001.BEAT/RM-P001.BEAT.TXT',
-            '523231aebfea1cc62bad575cda3f704b'
+            '523231aebfea1cc62bad575cda3f704b',
         ],
         'chords': [
             'annotations/AIST.RWC-MDB-P-2001.CHORD/RWC_Pop_Chords/N001-M01-T01.lab',
-            '2a8b1d320bb88f710be3bff4339db99b'
+            '2a8b1d320bb88f710be3bff4339db99b',
         ],
         'voca_inst': [
             'annotations/AIST.RWC-MDB-P-2001.VOCA_INST/RM-P001.VOCA_INST.TXT',
-            'f3ee36598a8bb9e367d25e0ff99850c7'
-        ]
+            'f3ee36598a8bb9e367d25e0ff99850c7',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/RWC-Popular/' + \
-        'audio/rwc-p-m01/1.wav'
+    assert (
+        track.audio_path
+        == 'tests/resources/mir_datasets/RWC-Popular/' + 'audio/rwc-p-m01/1.wav'
+    )
     assert track.piece_number == 'No. 1'
     assert track.suffix == 'M01'
     assert track.track_number == 'Tr. 01'
@@ -68,15 +67,17 @@ def test_track():
     # test audio loading functions
     y, sr = track.audio
     assert sr == 44100
-    assert y.shape == (44100 * 2, )
+    assert y.shape == (44100 * 2,)
 
-    repr_string = "RWC-Popular Track(track_id=RM-P001, " + \
-        "audio_path=tests/resources/mir_datasets/RWC-Popular/audio/rwc-p-m01/1.wav, " + \
-        "piece_number=No. 1, suffix=M01, track_number=Tr. 01, title=Eien no replica, " + \
-        "artist=Kazuo Nishi, singer_information=Male, duration_sec=03:29, " + \
-        "tempo=135, instruments=Gt, drum_information=Drum sequences, " + \
-        "sections=SectionData('start_times', 'end_times', 'sections'), " + \
-        "beats=BeatData('beat_times', 'beat_positions'))"
+    repr_string = (
+        "RWC-Popular Track(track_id=RM-P001, "
+        + "audio_path=tests/resources/mir_datasets/RWC-Popular/audio/rwc-p-m01/1.wav, "
+        + "piece_number=No. 1, suffix=M01, track_number=Tr. 01, title=Eien no replica, "
+        + "artist=Kazuo Nishi, singer_information=Male, duration_sec=03:29, "
+        + "tempo=135, instruments=Gt, drum_information=Drum sequences, "
+        + "sections=SectionData('start_times', 'end_times', 'sections'), "
+        + "beats=BeatData('beat_times', 'beat_positions'))"
+    )
     assert track.__repr__() == repr_string
 
 
@@ -88,8 +89,7 @@ def test_track_ids():
 
 def test_load():
     data_home = 'tests/resources/mir_datasets/RWC-Popular'
-    rwc_popular_data = rwc_popular.load(
-        data_home=data_home, silence_validator=True)
+    rwc_popular_data = rwc_popular.load(data_home=data_home, silence_validator=True)
     assert type(rwc_popular_data) is dict
     assert len(rwc_popular_data.keys()) == 100
 
@@ -99,8 +99,10 @@ def test_load():
 
 
 def test_load_chords():
-    chords_path = 'tests/resources/mir_datasets/RWC-Popular/' + \
-        'annotations/AIST.RWC-MDB-P-2001.CHORD/RWC_Pop_Chords/N001-M01-T01.lab'
+    chords_path = (
+        'tests/resources/mir_datasets/RWC-Popular/'
+        + 'annotations/AIST.RWC-MDB-P-2001.CHORD/RWC_Pop_Chords/N001-M01-T01.lab'
+    )
     chord_data = rwc_popular._load_chords(chords_path)
 
     # check types
@@ -110,12 +112,15 @@ def test_load_chords():
     assert type(chord_data.chords) is np.ndarray
 
     # check values
-    assert np.array_equal(chord_data.start_times, np.array(
-        [0.000, 0.104, 3.646, 43.992, 44.494]))
-    assert np.array_equal(chord_data.end_times, np.array(
-        [0.104, 1.858, 5.387, 44.494, 47.636]))
-    assert np.array_equal(chord_data.chords, np.array(
-        ['N', 'Ab:min', 'E:maj', 'Bb:maj(*3)', 'C:min7']))
+    assert np.array_equal(
+        chord_data.start_times, np.array([0.000, 0.104, 3.646, 43.992, 44.494])
+    )
+    assert np.array_equal(
+        chord_data.end_times, np.array([0.104, 1.858, 5.387, 44.494, 47.636])
+    )
+    assert np.array_equal(
+        chord_data.chords, np.array(['N', 'Ab:min', 'E:maj', 'Bb:maj(*3)', 'C:min7'])
+    )
 
     # load a file which doesn't exist
     chord_data_none = rwc_popular._load_chords('fake/path')
@@ -123,8 +128,10 @@ def test_load_chords():
 
 
 def test_load_voca_inst():
-    vocinst_path = 'tests/resources/mir_datasets/RWC-Popular/' + \
-        'annotations/AIST.RWC-MDB-P-2001.VOCA_INST/RM-P001.VOCA_INST.TXT'
+    vocinst_path = (
+        'tests/resources/mir_datasets/RWC-Popular/'
+        + 'annotations/AIST.RWC-MDB-P-2001.VOCA_INST/RM-P001.VOCA_INST.TXT'
+    )
     vocinst_data = rwc_popular._load_voca_inst(vocinst_path)
 
     # check types
@@ -134,14 +141,42 @@ def test_load_voca_inst():
     assert type(vocinst_data.event) is np.ndarray
 
     # check values
-    assert np.array_equal(vocinst_data.start_times, np.array(
-        [0.000, 10.293061224, 11.883492063, 12.087845804, 13.587460317,
-         13.819387755, 20.668707482, 20.832653061]))
-    assert np.array_equal(vocinst_data.end_times, np.array(
-        [10.293061224, 11.883492063, 12.087845804, 13.587460317,
-         13.819387755, 20.668707482, 20.832653061, 26.465306122]))
-    assert np.array_equal(vocinst_data.event, np.array(
-        ['b', 'm:withm', 'b', 'm:withm', 'b', 'm:withm', 'b', 's:electricguitar']))
+    assert np.array_equal(
+        vocinst_data.start_times,
+        np.array(
+            [
+                0.000,
+                10.293061224,
+                11.883492063,
+                12.087845804,
+                13.587460317,
+                13.819387755,
+                20.668707482,
+                20.832653061,
+            ]
+        ),
+    )
+    assert np.array_equal(
+        vocinst_data.end_times,
+        np.array(
+            [
+                10.293061224,
+                11.883492063,
+                12.087845804,
+                13.587460317,
+                13.819387755,
+                20.668707482,
+                20.832653061,
+                26.465306122,
+            ]
+        ),
+    )
+    assert np.array_equal(
+        vocinst_data.event,
+        np.array(
+            ['b', 'm:withm', 'b', 'm:withm', 'b', 'm:withm', 'b', 's:electricguitar']
+        ),
+    )
 
     # load a file which doesn't exist
     vocainst_data_none = rwc_popular._load_voca_inst('fake/path')
@@ -162,7 +197,7 @@ def test_load_metadata():
         'duration_sec': '03:29',
         'tempo': '135',
         'instruments': 'Gt',
-        'drum_information': 'Drum sequences'
+        'drum_information': 'Drum sequences',
     }
 
     metadata_none = rwc_popular._load_metadata('asdf/asdf')

--- a/tests/test_salami.py
+++ b/tests/test_salami.py
@@ -4,8 +4,8 @@ import numpy as np
 import os
 import pytest
 from mirdata import salami, utils
-from tests.test_utils import (mock_validator, DEFAULT_DATA_HOME)
-from tests.test_download_utils import (mock_file, mock_unzip)
+from tests.test_utils import mock_validator, DEFAULT_DATA_HOME
+from tests.test_download_utils import mock_file, mock_unzip
 
 
 def test_track():
@@ -25,29 +25,25 @@ def test_track():
     assert track.track_id == '2'
     assert track._data_home == data_home
     assert track._track_paths == {
-        'audio': [
-            'audio/2.mp3',
-            '76789a17bda0dd4d1d7e77424099c814'
-        ],
+        'audio': ['audio/2.mp3', '76789a17bda0dd4d1d7e77424099c814'],
         'annotator_1_uppercase': [
             'salami-data-public-master/annotations/2/parsed/textfile1_uppercase.txt',
-            '54ba0804f720d85d195dcd7ffaec0794'
+            '54ba0804f720d85d195dcd7ffaec0794',
         ],
         'annotator_1_lowercase': [
             'salami-data-public-master/annotations/2/parsed/textfile1_lowercase.txt',
-            '30ff127ff68c61039b94a44ab6ddda34'
+            '30ff127ff68c61039b94a44ab6ddda34',
         ],
         'annotator_2_uppercase': [
             'salami-data-public-master/annotations/2/parsed/textfile2_uppercase.txt',
-            'e9dca8577f028d3505ff1e5801397b2f'
+            'e9dca8577f028d3505ff1e5801397b2f',
         ],
         'annotator_2_lowercase': [
             'salami-data-public-master/annotations/2/parsed/textfile2_lowercase.txt',
-            '546a783c7b8bf96f2d718c7a4f114699'
-        ]
+            '546a783c7b8bf96f2d718c7a4f114699',
+        ],
     }
-    assert track.audio_path == 'tests/resources/mir_datasets/Salami/' + \
-        'audio/2.mp3'
+    assert track.audio_path == 'tests/resources/mir_datasets/Salami/' + 'audio/2.mp3'
 
     assert track.source == 'Codaich'
     assert track.annotator_1_id == '5'
@@ -71,16 +67,18 @@ def test_track():
     # assert sr == 44100
     # assert y.shape == (89856, )
 
-    repr_string = "Salami Track(track_id=2, " + \
-        "audio_path=tests/resources/mir_datasets/Salami/audio/2.mp3, " + \
-        "source=Codaich, title=For_God_And_Country, " + \
-        "artist=The_Smashing_Pumpkins, duration_sec=264, annotator_1_id=5, " + \
-        "annotator_2_id=8, annotator_1_time=37, annotator_2_time=45, " + \
-        "broad_genre=popular, genre=Alternative_Pop___Rock, " + \
-        "sections_annotator_1_uppercase=SectionData('start_times', 'end_times', 'sections'), " + \
-        "sections_annotator_1_lowercase=SectionData('start_times', 'end_times', 'sections'), " + \
-        "sections_annotator_2_uppercase=SectionData('start_times', 'end_times', 'sections'), " + \
-        "sections_annotator_2_lowercase=SectionData('start_times', 'end_times', 'sections')"
+    repr_string = (
+        "Salami Track(track_id=2, "
+        + "audio_path=tests/resources/mir_datasets/Salami/audio/2.mp3, "
+        + "source=Codaich, title=For_God_And_Country, "
+        + "artist=The_Smashing_Pumpkins, duration_sec=264, annotator_1_id=5, "
+        + "annotator_2_id=8, annotator_1_time=37, annotator_2_time=45, "
+        + "broad_genre=popular, genre=Alternative_Pop___Rock, "
+        + "sections_annotator_1_uppercase=SectionData('start_times', 'end_times', 'sections'), "
+        + "sections_annotator_1_lowercase=SectionData('start_times', 'end_times', 'sections'), "
+        + "sections_annotator_2_uppercase=SectionData('start_times', 'end_times', 'sections'), "
+        + "sections_annotator_2_lowercase=SectionData('start_times', 'end_times', 'sections')"
+    )
     assert track.__repr__() == repr_string
 
     # Test file with missing annotations
@@ -101,58 +99,46 @@ def test_track():
     assert track._data_home == data_home
 
     assert track._track_paths == {
-        'audio': [
-            'audio/192.mp3',
-            'd954d5dc9f17d66155d3310d838756b8'
-        ],
+        'audio': ['audio/192.mp3', 'd954d5dc9f17d66155d3310d838756b8'],
         'annotator_1_uppercase': [
             'salami-data-public-master/annotations/192/parsed/textfile1_uppercase.txt',
-            '4d268cfd27fe011dbe579f25f8d125ce'
+            '4d268cfd27fe011dbe579f25f8d125ce',
         ],
         'annotator_1_lowercase': [
             'salami-data-public-master/annotations/192/parsed/textfile1_lowercase.txt',
-            '6640237e7844d0d9d37bf21cf96a2690'
+            '6640237e7844d0d9d37bf21cf96a2690',
         ],
-        'annotator_2_uppercase': [
-            None, None
-        ],
-        'annotator_2_lowercase': [
-            None, None
-        ]}
+        'annotator_2_uppercase': [None, None],
+        'annotator_2_lowercase': [None, None],
+    }
 
     # test that cached properties don't fail and have the expected type
     assert type(track.sections_annotator_1_uppercase) is utils.SectionData
     assert type(track.sections_annotator_1_lowercase) is utils.SectionData
-    assert track.sections_annotator_2_uppercase  is None
+    assert track.sections_annotator_2_uppercase is None
     assert track.sections_annotator_2_lowercase is None
 
     # Test file with missing annotations
     track = salami.Track('1015', data_home=data_home)
 
     assert track._track_paths == {
-        'audio': [
-            'audio/1015.mp3',
-            '811a4a6b46f0c15a61bfb299b21ebdc4'
-        ],
-        'annotator_1_uppercase': [
-            None, None
-        ],
-        'annotator_1_lowercase': [
-            None, None
-        ],
+        'audio': ['audio/1015.mp3', '811a4a6b46f0c15a61bfb299b21ebdc4'],
+        'annotator_1_uppercase': [None, None],
+        'annotator_1_lowercase': [None, None],
         'annotator_2_uppercase': [
             'salami-data-public-master/annotations/1015/parsed/textfile2_uppercase.txt',
-            'e4a268342a45fdffd8ec9c3b8287ad8b'
+            'e4a268342a45fdffd8ec9c3b8287ad8b',
         ],
         'annotator_2_lowercase': [
             'salami-data-public-master/annotations/1015/parsed/textfile2_lowercase.txt',
-            '201642fcea4a27c60f7b48de46a82234'
-        ]}
+            '201642fcea4a27c60f7b48de46a82234',
+        ],
+    }
 
     # test that cached properties don't fail and have the expected type
     assert track.sections_annotator_1_uppercase is None
     assert track.sections_annotator_1_lowercase is None
-    assert type(track.sections_annotator_2_uppercase)  is utils.SectionData
+    assert type(track.sections_annotator_2_uppercase) is utils.SectionData
     assert type(track.sections_annotator_2_lowercase) is utils.SectionData
 
 
@@ -176,8 +162,10 @@ def test_load():
 
 def test_load_sections():
     # load a file which exists
-    sections_path = 'tests/resources/mir_datasets/Salami/' + \
-        'salami-data-public-master/annotations/2/parsed/textfile1_uppercase.txt'
+    sections_path = (
+        'tests/resources/mir_datasets/Salami/'
+        + 'salami-data-public-master/annotations/2/parsed/textfile1_uppercase.txt'
+    )
     section_data = salami._load_sections(sections_path)
 
     # check types
@@ -187,12 +175,17 @@ def test_load_sections():
     assert type(section_data.sections) is np.ndarray
 
     # check valuess
-    assert np.array_equal(section_data.start_times, np.array(
-        [0.0, 0.464399092, 14.379863945, 263.205419501]))
-    assert np.array_equal(section_data.end_times, np.array(
-        [0.464399092, 14.379863945, 263.205419501, 264.885215419]))
-    assert np.array_equal(section_data.sections, np.array(
-        ['Silence', 'A', 'B', 'Silence']))
+    assert np.array_equal(
+        section_data.start_times,
+        np.array([0.0, 0.464399092, 14.379863945, 263.205419501]),
+    )
+    assert np.array_equal(
+        section_data.end_times,
+        np.array([0.464399092, 14.379863945, 263.205419501, 264.885215419]),
+    )
+    assert np.array_equal(
+        section_data.sections, np.array(['Silence', 'A', 'B', 'Silence'])
+    )
 
     # load a file which doesn't exist
     section_data_none = salami._load_sections('fake/file/path')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -36,38 +36,51 @@ def test_md5(mocker):
 
     expected_checksum = '6dc00d1bac757abe4ea83308dde68aab'
 
-    mocker.patch('%s.open' % builtin_module_name, new=mocker.mock_open(read_data=audio_file))
+    mocker.patch(
+        '%s.open' % builtin_module_name, new=mocker.mock_open(read_data=audio_file)
+    )
 
     md5_checksum = utils.md5('test_file_path')
     assert expected_checksum == md5_checksum
 
 
-@pytest.mark.parametrize('test_index,expected_missing,expected_inv_checksum', [
-    ('test_index_valid.json', {}, {}),
-    ('test_index_missing_file.json', {'10161_chorus': ['tests/resources/10162_chorus.wav']}, {}),
-    ('test_index_invalid_checksum.json', {}, {'10161_chorus': ['tests/resources/10161_chorus.wav']}),
-])
-def test_check_index(test_index,
-                     expected_missing,
-                     expected_inv_checksum):
+@pytest.mark.parametrize(
+    'test_index,expected_missing,expected_inv_checksum',
+    [
+        ('test_index_valid.json', {}, {}),
+        (
+            'test_index_missing_file.json',
+            {'10161_chorus': ['tests/resources/10162_chorus.wav']},
+            {},
+        ),
+        (
+            'test_index_invalid_checksum.json',
+            {},
+            {'10161_chorus': ['tests/resources/10161_chorus.wav']},
+        ),
+    ],
+)
+def test_check_index(test_index, expected_missing, expected_inv_checksum):
     index_path = os.path.join('tests/indexes', test_index)
     with open(index_path) as index_file:
         test_index = json.load(index_file)
 
-    missing_files, invalid_checksums = utils.check_index(test_index, 'tests/resources/', True)
+    missing_files, invalid_checksums = utils.check_index(
+        test_index, 'tests/resources/', True
+    )
 
     assert expected_missing == missing_files
     assert expected_inv_checksum == invalid_checksums
 
 
-@pytest.mark.parametrize('missing_files,invalid_checksums', [
-    ({'10161_chorus': ['tests/resources/10162_chorus.wav']}, {}),
-    ({}, {'10161_chorus': ['tests/resources/10161_chorus.wav']}),
-])
-def test_validator(mocker,
-                   mock_check_index,
-                   missing_files,
-                   invalid_checksums):
+@pytest.mark.parametrize(
+    'missing_files,invalid_checksums',
+    [
+        ({'10161_chorus': ['tests/resources/10162_chorus.wav']}, {}),
+        ({}, {'10161_chorus': ['tests/resources/10161_chorus.wav']}),
+    ],
+)
+def test_validator(mocker, mock_check_index, missing_files, invalid_checksums):
     mock_check_index.return_value = missing_files, invalid_checksums
 
     m, c = utils.validator('foo', 'bar', True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist = py27,py36,py37,black
 
-[testenv]
+[testenv:py27]
 passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST
 extras =
   tests
@@ -9,8 +9,24 @@ extras =
 commands =
   pytest --cov-report=xml --cov=mirdata {toxinidir}/tests/
 
-[black]
-basepython = py37
+[testenv:py36]
+passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST
+extras =
+  tests
+  docs
+commands =
+  pytest --cov-report=xml --cov=mirdata {toxinidir}/tests/
+
+[testenv:py37]
+passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST
+extras =
+  tests
+  docs
+commands =
+  pytest --cov-report=xml --cov=mirdata {toxinidir}/tests/
+
+[testenv:black]
+passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST
 deps = black
 commands =
-  black --check --skip-string-normalization {toxinidir}/mirdata
+  black --check --target-version py37 --skip-string-normalization {toxinidir}/mirdata


### PR DESCRIPTION
Hello @rabitt, @andreasjansson, and @drubinstein, this PR replaces #95, which had a terrible rebase.

Basically, Tox was not inheriting commands / running commands properly, and was thus never actually running `black` on CI.

I've made a more-verbose-but-working tox.ini, and runs `black -S`!