### PR TITLE
145 - Dali is now optional

### DIFF
--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -26,8 +26,19 @@ import pickle
 import os
 import librosa
 import logging
-import DALI  # this is the package, needed to load the annotations
 import numpy as np
+
+# this is the package, needed to load the annotations.
+# DALI-dataset is only installed if the user explicitly declares
+# they want dali when pip installing.
+try:
+    import DALI
+except ImportError as E:
+    logging.error(
+        'In order to use dali you must have dali-dataset installed. '
+        'Please reinstall mirdata using `pip install \'mirdata[dali]\''
+    )
+    raise
 
 import mirdata.utils as utils
 
@@ -297,7 +308,7 @@ def cite():
     cite_data = """
     ===========  MLA ===========
     Meseguer-Brocal, Gabriel, et al.
-    "DALI: a large Dataset of synchronized Audio, LyrIcs and notes, automatically created using teacher-student machine 
+    "DALI: a large Dataset of synchronized Audio, LyrIcs and notes, automatically created using teacher-student machine
     learning paradigm."
     In Proceedings of the 19th International Society for Music Information Retrieval Conference (ISMIR). 2018.
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,14 @@ if __name__ == '__main__':
         long_description="""Common loaders for MIR datasets.""",
         keywords='mir dataset loader audio',
         license='BSD-3-Clause',
-        install_requires=['tqdm', 'librosa >= 0.7.0', 'numpy>=1.16', 'six', 'jams', 'requests', 'dali-dataset'],
+        install_requires=[
+            'tqdm',
+            'librosa >= 0.7.0',
+            'numpy>=1.16',
+            'six',
+            'jams',
+            'requests',
+        ],
         extras_require={
             'tests': [
                 'pytest>=4.4.0',
@@ -32,5 +39,6 @@ if __name__ == '__main__':
                 'sphinx_rtd_theme',
                 'numpydoc',
             ],
+            'dali': ['DALI-dataset>=1.0.0'],
         },
     )

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 if __name__ == '__main__':
     setup(
         name='mirdata',
-        version='0.0.26',
+        version='0.0.27',
         description='Common loaders for MIR datasets.',
         url='https://github.com/mir-dataset-loaders/mirdata',
         packages=find_packages(exclude=['test', '*.test', '*.test.*']),


### PR DESCRIPTION
#145 

In order to install DALI, you now install by running 
`pip install mirdata[dali]`. It will not be installed by default.

@rabitt @magdalenafuentes where should I document this behavior since it's probably nontrivial for most people to know.