### PR TITLE
update loader docstrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,17 +102,11 @@ You can also remove any comments beginning with `# --`
 # -*- coding: utf-8 -*-
 """Example Dataset Loader
 
-[Description of the dataset]
+[Description of the dataset. Write about the number of files, origin of the
+music, genre, relevant papers, openness/license, creator, and annotation type.]
 
-[Link to any relevant websites]
+For more details, please visit: [website]
 
-Attributes:
-    DATASET_DIR (str): The directory name for Example dataset. Set to `'Example'`.
-
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a `Track` namedtuple.
-
-    DATA.metadata (dict): Dictionary of track metadata
 """
 
 from __future__ import absolute_import

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -4,17 +4,6 @@
 The Beatles Dataset includes beat and metric position, chord, key, and segmentation
 annotations for 179 Beatles songs. Details can be found in http://matthiasmauch.net/_pdf/mauch_omp_2009.pdf
 
-
-Attributes:
-    DATASET_DIR (str): The directory name for Beatles dataset. Set to `'Beatles'`.
-
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a jason data loaded from `index/`
-
-    ANNOTATIONS_REMOTE (RemoteFileMetadata (namedtuple)): metadata
-        of Beatles dataset. It includes the annotation file name, annotation
-        file url, and checksum of the file.
-
 """
 import csv
 import librosa

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -1,19 +1,14 @@
 # -*- coding: utf-8 -*-
 """DALI Dataset Loader
 
-DALI Dataset.
+DALI contains 5358 audio files with their time-aligned vocal melody.
+It also contains time-aligned lyrics at four levels of granularity: notes,
+words, lines, and paragraphs.
 
-Details can be found at https://github.com/gabolsgabs/DALI
+For each song, DALI also provides additional metadata: genre, language, musician,
+album covers, or links to video clips.
 
-Attributes:
-    DATASET_DIR (str): The directory name for DALI dataset. Set to `'DALI'`.
-
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a jason data loaded from `index/`
-
-    DATA.metadata (dict): #TODO
-
-
+For more details, please visit: https://github.com/gabolsgabs/DALI
 """
 
 from __future__ import absolute_import

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -7,7 +7,7 @@ P. Cook in IEEE Transactions on Audio and Speech Processing 2002.
 
 The dataset consists of 1000 audio tracks each 30 seconds long. It
 contains 10 genres, each represented by 100 tracks. The tracks are all
-22050Hz Mono 16-bit audio files in .wav format.
+22050 Hz mono 16-bit audio files in .wav format.
 """
 
 from __future__ import absolute_import

--- a/mirdata/guitarset.py
+++ b/mirdata/guitarset.py
@@ -1,32 +1,46 @@
 # -*- coding: utf-8 -*-
 """GuitarSet Loader
 
-Intr​oducing GuitarSet, a dataset that provides high quality guitar
-recordings alongside rich annotations and metadata.
-In particular, by recording guitars using a hexaphonic pickup, we
-are able to not only provide recordings of the individual strings
-but also to largely automate the expensive annotation process,
-therefore providing rich annotation.
-
-The dataset contains recordings of a variety of musical excerpts
+GuitarSet provides audio recordings of a variety of musical excerpts
 played on an acoustic guitar, along with time-aligned annotations
 including pitch contours, string and fret positions, chords, beats,
 downbeats, and keys.
 
-Details can be found at http://github.com/marl/guitarset/
+GuitarSet contains 360 excerpts that are close to 30 seconds in length.
+The 360 excerpts are the result of the following combinations:
+- 6 players
+- 2 versions: comping (harmonic accompaniment) and soloing (melodic improvisation)
+- 5 styles: Rock, Singer-Songwriter, Bossa Nova, Jazz, and Funk
+- 3 Progressions: 12 Bar Blues, Autumn Leaves, and Pachelbel Canon.
+- 2 Tempi: slow and fast.
 
-Attributes:
-    DATASET_DIR (str):
-        The directory name for GuitarSet. Set to `'GuitarSet'`.
+The tonality (key) of each excerpt is sampled uniformly at random.
 
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a `GuitarSet` namedtuple.
+GuitarSet was recorded with the help of a hexaphonic pickup, which outputs
+signals for each string separately, allowing automated note-level annotation.
+Excerpts are recorded with both the hexaphonic pickup and a Neumann U-87
+condenser microphone as reference.
+3 audio recordings are provided with each excerpt with the following suffix:
+- hex: original 6 channel wave file from hexaphonic pickup
+- hex_cln: hex wave files with interference removal applied
+- mic: monophonic recording from reference microphone
 
-    ANNOTATION_REMOTE (RemoteFileMetadata)
-    AUDIO_HEX_CLN_REMOTE (RemoteFileMetadata)
-    AUDIO_HEX_REMOTE (RemoteFileMetadata)
-    AUDIO_MIC_REMOTE (RemoteFileMetadata)
-    AUDIO_MIX_REMOTE (RemoteFileMetadata)
+Each of the 360 excerpts has an accompanying JAMS file which stores 16 annotations.
+Pitch:
+- 6 pitch_contour annotations (1 per string)
+- 6 midi_note annotations (1 per string)
+
+Beat and Tempo:
+- 1 beat_position annotation
+- 1 tempo annotation
+
+Chords:
+- 2 chord annotations: instructed and performed. The instructed chord annotation
+is a digital version of the lead sheet that's provided to the player, and the
+performed chord annotations are inferred from note annotations, using
+segmentation and root from the digital lead sheet annotation.
+
+For more details, please visit: http://github.com/marl/guitarset/
 """
 
 from __future__ import absolute_import

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -8,21 +8,7 @@ channels respectively and can be found under the Wavfile directory.
 In addition, the human-labeled pitch contours and timestamped lyrics can be
 found under PitchLabel and Lyrics respectively.
 
-Details can be found at http://mac.citi.sinica.edu.tw/ikala/
-
-
-Attributes:
-    DATASET_DIR (str): The directory name for iKala dataset. Set to `'iKala'`.
-
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a `IKalaTrack` namedtuple.
-
-    TIME_STEP (float): Time step unit (in second) (TODO: what is this? hop length? window?)
-
-    DATA.metadata (None): TODO
-
-    ID_MAPPING_URL (str): URL to get id-to-url mapping text file
-
+For more details, please visit: http://mac.citi.sinica.edu.tw/ikala/
 """
 
 from __future__ import absolute_import

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -21,15 +21,6 @@ Each of these clips contains a single instrument among a taxonomy of eight:
 The Medley-solos-DB dataset is the dataset that is used in the benchmarks of
 musical instrument recognition in the publications of Lostanlen and Cella
 (ISMIR 2016) and Andén et al. (IEEE TSP 2019).
-
-Attributes:
-    DATA.index (dict): {track_id: track_data}.
-        track_id is a JSON data loaded from 'index/'
-
-    DATASET_DIR (str): The directory name for Medley-solos-DB.
-        Set to `'Medley-solos-DB'`.
-
-    DATA.metadata (dict): The metadata of Medley-solos-DB.
 """
 from __future__ import absolute_import
 from __future__ import division

--- a/mirdata/medleydb_melody.py
+++ b/mirdata/medleydb_melody.py
@@ -7,17 +7,7 @@ addressing important shortcomings of existing collections. For each song
 we provide melody f0 annotations as well as instrument activations for
 evaluating automatic instrument recognition.
 
-Details can be found at https://medleydb.weebly.com
-
-
-Attributes:
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a jason data loaded from `index/`
-
-    DATASET_DIR (str): The directory name for MedleyDB melody dataset.
-        Set to `'MedleyDB-Melody'`.
-
-    DATA.metadata (None): TODO
+For more details, please visit: https://medleydb.weebly.com
 
 """
 from __future__ import absolute_import

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -7,15 +7,7 @@ addressing important shortcomings of existing collections. For each song
 we provide melody f0 annotations as well as instrument activations for
 evaluating automatic instrument recognition.
 
-Details can be found at https://medleydb.weebly.com
-
-
-Attributes:
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a jason data loaded from `index/`
-
-    DATASET_DIR (str): The directory name for MedleyDB melody dataset.
-        Set to `'MedleyDB-Pitch'`.
+For more details, please visit: https://medleydb.weebly.com
 
 """
 from __future__ import absolute_import

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -6,17 +6,7 @@ evaluation of melody extraction algorithms. This collection contains
 64 audio excerpts focused on symphonic music with their corresponding
 annotation of the melody.
 
-Details can be found at https://zenodo.org/record/1289786#.XREpzaeZPx6
-
-
-Attributes:
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a jason data loaded from `index/`
-
-    DIR (str): The directory name for ORCHSET.
-        Set to `'Orchset'`.
-
-    DATA.metadata
+For more details, please visit: https://zenodo.org/record/1289786#.XREpzaeZPx6
 
 """
 from __future__ import absolute_import

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -1,12 +1,15 @@
 # -*- coding: utf-8 -*-
 """RWC Classical Dataset Loader
 
-More details are on https://staff.aist.go.jp/m.goto/RWC-MDB/rwc-mdb-c.html .
+ The Classical Music Database consists of 50 pieces:
+* Symphonies: 4 pieces
+* Concerti: 2 pieces
+* Orchestral music: 4 pieces
+* Chamber music: 10 pieces
+* Solo performances: 24 pieces
+* Vocal performances: 6 pieces
 
-Attributes:
-    METADATA_REMOTE (RemoteFileMetadata): Metadata of the remote file
-    DATASET_DIR (str): The directory name for iKala dataset. Set to `'RWC-Classical'`.
-
+For more details, please visit: https://staff.aist.go.jp/m.goto/RWC-MDB/rwc-mdb-c.html
 """
 import csv
 import librosa

--- a/mirdata/rwc_jazz.py
+++ b/mirdata/rwc_jazz.py
@@ -1,10 +1,35 @@
 # -*- coding: utf-8 -*-
-"""RWC Jazz Dataset Loader
+"""RWC Jazz Dataset Loader.
 
-Attributes:
-    METADATA_REMOTE (RemoteFileMetadata): Metadata of the remote file
-    DATASET_DIR (str): The directory name for iKala dataset. Set to `'RWC-Jazz'`.
+The Jazz Music Database consists of 50 pieces:
 
+* Instrumentation variations: 35 pieces (5 pieces × 7 instrumentations).
+The instrumentation-variation pieces were recorded to obtain different versions
+of the same piece; i.e., different arrangements performed by different player
+instrumentations. Five standard-style jazz pieces were originally composed
+and then performed in modern-jazz style using the following seven instrumentations:
+1. Piano solo
+2. Guitar solo
+3. Duo: Vibraphone + Piano, Flute + Piano, and Piano + Bass
+4. Piano trio: Piano + Bass + Drums
+5. Piano trio + Trumpet or Tenor saxophone
+6. Octet: Piano trio + Guitar + Alto saxophone + Baritone saxophone + Tenor saxophone × 2
+7. Piano trio + Vibraphone or Flute
+
+* Style variations: 9 pieces
+The style-variation pieces were recorded to represent various styles of jazz.
+They include four well-known public-domain pieces and consist of
+1. Vocal jazz: 2 pieces (including "Aura Lee")
+2. Big band jazz: 2 pieces (including "The Entertainer")
+3. Modal jazz: 2 pieces
+4. Funky jazz: 2 pieces (including "Silent Night")
+5. Free jazz: 1 piece (including "Joyful, Joyful, We Adore Thee")
+Fusion (crossover): 6 pieces
+The fusion pieces were recorded to obtain music that combines elements of jazz
+with other styles such as popular, rock, and latin. They include music with an
+eighth-note feel, music with a sixteenth-note feel, and Latin jazz music.
+
+For more details, please visit: https://staff.aist.go.jp/m.goto/RWC-MDB/rwc-mdb-j.html
 """
 import csv
 import librosa

--- a/mirdata/rwc_popular.py
+++ b/mirdata/rwc_popular.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 """RWC Popular Dataset Loader
 
-Attributes:
-    METADATA_REMOTE (RemoteFileMetadata): Metadata of the remote file
-    DATASET_DIR (str): The directory name for iKala dataset. Set to `'RWC-Pop'`.
+The Popular Music Database consists of 100 songs — 20 songs with English lyrics
+performed in the style of popular music typical of songs on the American hit
+charts in the 1980s, and 80 songs with Japanese lyrics performed in the style of
+modern Japanese popular music typical of songs on the Japanese hit charts in
+the 1990s.
 
+For more details, please visit: https://staff.aist.go.jp/m.goto/RWC-MDB/rwc-mdb-p.html
 """
 import csv
 import logging

--- a/mirdata/salami.py
+++ b/mirdata/salami.py
@@ -1,25 +1,15 @@
 # -*- coding: utf-8 -*-
 """SALAMI Dataset Loader
 
-SALAMI Dataset.
+The SALAMI dataset contains Structural Annotations of a Large Amount of Music
+Information: the public portion contains over 2200 annotations of over 1300
+unique tracks.
 
-We are using the **corrected** version of the 2.0 annotations:
+NB: mirdata relies on the **corrected** version of the 2.0 annotations:
 Details can be found at https://github.com/bmcfee/salami-data-public/tree/hierarchy-corrections and
 https://github.com/DDMAL/salami-data-public/pull/15.
 
-Attributes:
-    DIR (str): The directory name for SALAMI dataset. Set to `'Salami'`.
-
-    DATA.index (dict): {track_id: track_data}.
-        track_data is a jason data loaded from `index/`
-
-    DATA.metadata (None): (todo?)
-
-    ANNOT_REMOTE (RemoteFileMetadata (namedtuple)): metadata
-        of SALAMI dataset. It includes the annotation file name, annotation
-        file url, and checksum of the file.
-
-
+For more details, please visit: https://github.com/DDMAL/salami-data-public
 """
 import csv
 import librosa

--- a/mirdata/tinysol.py
+++ b/mirdata/tinysol.py
@@ -37,16 +37,8 @@ their results in terms of average performance across folds.
 
 We encourage TinySOL users to subscribe to the Ircam Forum so that they can
 have access to larger versions of SOL.
-For more information, see https://www.orch-idea.org/
 
-Attributes:
-    DATA.index (dict): {track_id: track_data}.
-        track_id is a JSON data loaded from 'indexes/'
-
-    DATASET_DIR (str): The directory name for TinySOL.
-        Set to `'TinySOL'`.
-
-    DATA.metadata (dict): The metadata of TinySOL.
+For more details, please visit: https://www.orch-idea.org/
 """
 
 from __future__ import absolute_import


### PR DESCRIPTION
Fixes #191 

I removed the documentation for global variables, because they shouldn't be used nor modified by the user anyway.

I added more details, especially on RWC, DALI, and SALAMI.