### PR TITLE
The __future__ is now

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,10 +133,10 @@ For more details, please visit: [website]
 
 # -- import whatever you need here
 
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
-import mirdata.track as track
-import mirdata.utils as utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = 'Example'
 # -- info for any files that need to be downloaded

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,16 +130,13 @@ For more details, please visit: [website]
 
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 # -- import whatever you need here
 
-import mirdata.track as track
-import mirdata.utils as utils
 import mirdata.download_utils as download_utils
 import mirdata.jams_utils as jams_utils
+import mirdata.track as track
+import mirdata.utils as utils
 
 DATASET_DIR = 'Example'
 # -- info for any files that need to be downloaded

--- a/mirdata/__init__.py
+++ b/mirdata/__init__.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from .version import version as __version__
 

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -6,15 +6,16 @@ annotations for 179 Beatles songs. Details can be found in http://matthiasmauch.
 http://isophonics.net/content/reference-annotations-beatles.
 
 """
+
 import csv
 import librosa
-import os
 import numpy as np
+import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = 'Beatles'
 ANNOTATIONS_REMOTE = download_utils.RemoteFileMetadata(

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -11,17 +11,18 @@ album covers, or links to video clips.
 For more details, please visit: https://github.com/gabolsgabs/DALI
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import json
 import gzip
-import pickle
-import os
 import librosa
 import logging
 import numpy as np
+import os
+import pickle
+
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 # this is the package, needed to load the annotations.
 # DALI-dataset is only installed if the user explicitly declares

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -5,16 +5,13 @@ Attributes:
     RemoteFileMetadata (namedtuple): It specifies the metadata of the remote file to download.
         The metadata consists of `filename`, `url`, `checksum`, and `destination_dir`.
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 from collections import namedtuple
 import os
-import tarfile
-import zipfile
 from tqdm import tqdm
 import urllib
+import tarfile
+import zipfile
 
 from mirdata.utils import md5
 

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -10,15 +10,12 @@ contains 10 genres, each represented by 100 tracks. The tracks are all
 22050 Hz mono 16-bit audio files in .wav format.
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
-import os
 import librosa
+import os
 
 from mirdata import download_utils
-import mirdata.track as track
+from mirdata import jams_utils
+from mirdata import track
 from mirdata import utils
 
 

--- a/mirdata/guitarset.py
+++ b/mirdata/guitarset.py
@@ -43,19 +43,17 @@ segmentation and root from the digital lead sheet annotation.
 For more details, please visit: http://github.com/marl/guitarset/
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
+import jams
+import librosa
+import logging
 import numpy as np
 import os
-import librosa
-import jams
-import logging
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
+
 
 DATASET_DIR = 'GuitarSet'
 

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -11,20 +11,17 @@ found under PitchLabel and Lyrics respectively.
 For more details, please visit: http://mac.citi.sinica.edu.tw/ikala/
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import csv
 import os
 import librosa
 import logging
 import numpy as np
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
+
 
 DATASET_DIR = 'iKala'
 TIME_STEP = 0.032  # seconds

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -1,12 +1,9 @@
 # -*- coding: utf-8 -*-
 """functions for converting mirdata annotations to jams format
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import jams
-import mirdata.utils as utils
+from mirdata import utils
 
 
 def jams_converter(

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -22,9 +22,6 @@ The Medley-solos-DB dataset is the dataset that is used in the benchmarks of
 musical instrument recognition in the publications of Lostanlen and Cella
 (ISMIR 2016) and Andén et al. (IEEE TSP 2019).
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import librosa

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -28,10 +28,10 @@ import librosa
 import logging
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = "Medley-solos-DB"
 ANNOTATION_REMOTE = download_utils.RemoteFileMetadata(

--- a/mirdata/medleydb_melody.py
+++ b/mirdata/medleydb_melody.py
@@ -10,9 +10,6 @@ evaluating automatic instrument recognition.
 For more details, please visit: https://medleydb.weebly.com
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import json
@@ -21,10 +18,10 @@ import logging
 import numpy as np
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = 'MedleyDB-Melody'
 

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -10,9 +10,6 @@ evaluating automatic instrument recognition.
 For more details, please visit: https://medleydb.weebly.com
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import csv
 import json
@@ -21,10 +18,10 @@ import logging
 import numpy as np
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = 'MedleyDB-Pitch'
 

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -9,9 +9,7 @@ annotation of the melody.
 For more details, please visit: https://zenodo.org/record/1289786#.XREpzaeZPx6
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+
 import csv
 import glob
 import librosa
@@ -20,10 +18,10 @@ import numpy as np
 import os
 import shutil
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 
 REMOTE = download_utils.RemoteFileMetadata(

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -17,10 +17,10 @@ import logging
 import numpy as np
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 METADATA_REMOTE = download_utils.RemoteFileMetadata(
     filename='rwc-c.csv',

--- a/mirdata/rwc_jazz.py
+++ b/mirdata/rwc_jazz.py
@@ -35,10 +35,10 @@ import csv
 import logging
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 # these functions are identical for all rwc datasets
 from mirdata.rwc_classical import (

--- a/mirdata/rwc_popular.py
+++ b/mirdata/rwc_popular.py
@@ -14,10 +14,10 @@ import logging
 import numpy as np
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 # these functions are identical for all rwc datasets
 from mirdata.rwc_classical import (

--- a/mirdata/salami.py
+++ b/mirdata/salami.py
@@ -17,10 +17,10 @@ import logging
 import numpy as np
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = 'Salami'
 ANNOTATIONS_REMOTE = download_utils.RemoteFileMetadata(

--- a/mirdata/tinysol.py
+++ b/mirdata/tinysol.py
@@ -41,19 +41,15 @@ have access to larger versions of SOL.
 For more details, please visit: https://www.orch-idea.org/
 """
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
 import csv
 import librosa
 import logging
 import os
 
-import mirdata.track as track
-import mirdata.utils as utils
-import mirdata.download_utils as download_utils
-import mirdata.jams_utils as jams_utils
+from mirdata import download_utils
+from mirdata import jams_utils
+from mirdata import track
+from mirdata import utils
 
 DATASET_DIR = "TinySOL"
 AUDIO_REMOTE = download_utils.RemoteFileMetadata(

--- a/mirdata/track.py
+++ b/mirdata/track.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 """track object utility functions
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+
 
 import types
 

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -21,9 +21,9 @@ Attributes:
     EventData (namedtuple): `start_times`, `end_times`, `event`
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
+
+
+
 
 from collections import namedtuple
 import hashlib

--- a/mirdata/utils.py
+++ b/mirdata/utils.py
@@ -23,8 +23,6 @@ Attributes:
 """
 
 
-
-
 from collections import namedtuple
 import hashlib
 import os

--- a/scripts/make_gtzan_genre_index.py
+++ b/scripts/make_gtzan_genre_index.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 import sys

--- a/scripts/print_track_docstring.py
+++ b/scripts/print_track_docstring.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import argparse
 import importlib

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_dali.py
+++ b/tests/test_dali.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 
 import numpy as np
 import DALI

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import os
 import sys

--- a/tests/test_gtzan_genre.py
+++ b/tests/test_gtzan_genre.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
 
 import os
 

--- a/tests/test_guitarset.py
+++ b/tests/test_guitarset.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 import jams

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 import pytest

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import importlib
 from inspect import signature

--- a/tests/test_medley_solos_db.py
+++ b/tests/test_medley_solos_db.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from mirdata import medley_solos_db
 from tests.test_utils import run_track_tests

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_rwc_classical.py
+++ b/tests/test_rwc_classical.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_rwc_jazz.py
+++ b/tests/test_rwc_jazz.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 from mirdata import rwc_jazz, utils
 from tests.test_utils import run_track_tests

--- a/tests/test_rwc_popular.py
+++ b/tests/test_rwc_popular.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_salami.py
+++ b/tests/test_salami.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 from mirdata import salami, utils

--- a/tests/test_tinysol.py
+++ b/tests/test_tinysol.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import numpy as np
 

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import sys
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
 
 import itertools
 import os


### PR DESCRIPTION
remove `__future__` imports, alphabetize imports

functionally equivalent to base branch

triaged for v0.2?

closes #208 