### PR TITLE
gtzan_genre.Track.to_jams

### DIFF
--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -103,7 +103,11 @@ class Track(track.Track):
             section_data=[(self.sections, None)],
             chord_data=[(self.chords, None)],
             key_data=[(self.key, None)],
-            metadata={'artist': 'The Beatles', 'title': self.title},
+            metadata={
+                'artist': 'The Beatles',
+                'title': self.title,
+                'duration': librosa.get_duration(self.audio[0], self.audio[1])
+            },
         )
 
 

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -106,7 +106,7 @@ class Track(track.Track):
             metadata={
                 'artist': 'The Beatles',
                 'title': self.title,
-                'duration': librosa.get_duration(self.audio[0], self.audio[1])
+                'duration': librosa.get_duration(self.audio[0], self.audio[1]),
             },
         )
 

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -36,6 +36,17 @@ DATASET_REMOTE = download_utils.RemoteFileMetadata(
 
 DATA = utils.LargeData("gtzan_genre_index.json")
 
+VERSION = "1.0"
+
+ANNOTATION_RULES = """
+Unfortunately the database was collected gradually and very early on in my
+research so I have no titles.
+The files were collected in 2000-2001 from a variety of sources including
+personal CDs, radio, microphone recordings, in order to represent a variety of
+recording conditions. Nevetheless I have been providing it to researchers upon
+request mainly for comparison purposes etc. -- George Tzanetakis, 2005
+"""
+
 
 class Track(track.Track):
     """gtzan_genre Track class

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -78,7 +78,7 @@ class Track(track.Track):
 
 
 def load_audio(audio_path, sample_rate=22050):
-    """Load a GTzan audio file.
+    """Load a GTZAN audio file.
 
     Args:
         audio_path (str): path to audio file

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -14,8 +14,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import os
+import jams
 import librosa
+import os
 
 from mirdata import download_utils
 import mirdata.track as track

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -105,7 +105,10 @@ class Track(track.Track):
 
         # Encode genre annotation
         genre_ann = jams.Annotation(
-            namespace="gtzan", time=0, duration=30.0, annotation_metadata=ann_meta
+            namespace="tag_gtzan",
+            time=0,
+            duration=30.0,
+            annotation_metadata=ann_meta,
         )
         genre_ann.append(time=0, duration=30.0, confidence=0, value=self.genre)
         jam.annotations.append(genre_ann)

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -75,7 +75,7 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         return jams_utils.jams_converter(
-            tags_data=[(self.genre, 'gtzan-genre')],
+            tags_gtzan_data=[(self.genre, 'gtzan-genre')],
             metadata={
                 'title': "Unknown track",
                 'artist': "Unknown artist",

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -18,8 +18,9 @@ import jams
 import librosa
 import os
 
+import mirdata
 from mirdata import download_utils
-import mirdata.track as track
+from mirdata import track
 from mirdata import utils
 
 
@@ -106,10 +107,7 @@ class Track(track.Track):
 
         # Encode genre annotation
         genre_ann = jams.Annotation(
-            namespace="tag_gtzan",
-            time=0,
-            duration=30.0,
-            annotation_metadata=ann_meta,
+            namespace="tag_gtzan", time=0, duration=30.0, annotation_metadata=ann_meta
         )
         genre_ann.append(time=0, duration=30.0, confidence=0, value=self.genre)
         jam.annotations.append(genre_ann)

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -49,6 +49,7 @@ class Track(track.Track):
         track_id (str): track id
 
     """
+
     def __init__(self, track_id, data_home=None):
         if track_id not in DATA.index:
             raise ValueError(
@@ -80,7 +81,7 @@ class Track(track.Track):
                 'artist': "Unknown artist",
                 'release': "Unknown album",
                 'duration': 30.0,
-                'curator': 'George Tzanetakis'
+                'curator': 'George Tzanetakis',
             },
         )
 

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -93,9 +93,7 @@ class Track(track.Track):
 
         # Encode annotation metadata
         ann_meta = jams.AnnotationMetadata(
-            annotator={
-                "mirdata version": mirdata.__version__,
-            },
+            annotator={"mirdata version": mirdata.__version__},
             version=VERSION,
             corpus=DATASET_DIR,
             annotation_tools="MARSYAS",
@@ -107,10 +105,7 @@ class Track(track.Track):
 
         # Encode genre annotation
         genre_ann = jams.Annotation(
-            namespace="gtzan",
-            time=0,
-            duration=30.0,
-            annotation_metadata=ann_meta,
+            namespace="gtzan", time=0, duration=30.0, annotation_metadata=ann_meta
         )
         genre_ann.append(time=0, duration=30.0, confidence=0, value=self.genre)
         jam.annotations.append(genre_ann)

--- a/mirdata/gtzan_genre.py
+++ b/mirdata/gtzan_genre.py
@@ -73,8 +73,49 @@ class Track(track.Track):
         return load_audio(self.audio_path, sample_rate=22050)
 
     def to_jams(self):
-        """(Not Implemented) Jams: the track's data in jams format"""
-        raise NotImplementedError
+        """Jams: the track's data in jams format"""
+        # Initialize top-level JAMS container
+        jam = jams.JAMS()
+
+        # Encode title, artist, and release
+        jam.file_metadata.title = "Unknown track"
+        jam.file_metadata.artist = "Unknown artist"
+        jam.file_metadata.release = "Unknown album"
+
+        # Encode duration in seconds
+        jam.file_metadata.duration = 30.0
+
+        # Encode JAMS curator
+        curator = jams.Curator(name="George Tzanetakis", email="gtzan@cs.uvic.ca")
+
+        # Store mirdata metadata as JAMS identifiers
+        jam.file_metadata.identifiers = jams.Sandbox(**self.__dict__)
+
+        # Encode annotation metadata
+        ann_meta = jams.AnnotationMetadata(
+            annotator={
+                "mirdata version": mirdata.__version__,
+            },
+            version=VERSION,
+            corpus=DATASET_DIR,
+            annotation_tools="MARSYAS",
+            annotation_rules=ANNOTATION_RULES,
+            validation=DATASET_REMOTE,
+            data_source="George Tzanetakis",
+            curator=curator,
+        )
+
+        # Encode genre annotation
+        genre_ann = jams.Annotation(
+            namespace="gtzan",
+            time=0,
+            duration=30.0,
+            annotation_metadata=ann_meta,
+        )
+        genre_ann.append(time=0, duration=30.0, confidence=0, value=self.genre)
+        jam.annotations.append(genre_ann)
+
+        return jam
 
 
 def load_audio(audio_path, sample_rate=22050):

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -143,7 +143,7 @@ class Track(track.Track):
                 'singer_id': self.singer_id,
                 'track_id': self.track_id,
                 'song_id': self.song_id,
-                'duration': librosa.get_duration(self.mix_audio[0], self.mix_audio[1])
+                'duration': librosa.get_duration(self.mix_audio[0], self.mix_audio[1]),
             },
         )
 

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -143,6 +143,7 @@ class Track(track.Track):
                 'singer_id': self.singer_id,
                 'track_id': self.track_id,
                 'song_id': self.song_id,
+                'duration': librosa.get_duration(self.mix_audio[0], self.mix_audio[1])
             },
         )
 

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -18,6 +18,7 @@ def jams_converter(
     multi_section_data=None,
     key_data=None,
     lyrics_data=None,
+    tags_data=None,
     metadata=None,
 ):
 
@@ -44,6 +45,9 @@ def jams_converter(
         A list of tuples of (KeyData, str), where str describes the annotation.
     lyrics_data (list or None):
         A list of tuples of (LyricData, str), where str describes the annotation.
+    tags_data (list or None):
+        A list of tuples of (str, str), where the first srt is the tag and the second
+        is a descriptor of the annotation.
     metadata (dict or None):
         A dictionary containing the track metadata.
 
@@ -62,12 +66,13 @@ def jams_converter(
                 setattr(jam.file_metadata, key, metadata[key])
             else:
                 setattr(jam.sandbox, key, metadata[key])
+
     # beats
     if beat_data is not None:
-        if type(beat_data) != list:
+        if not isinstance(beat_data, list):
             raise TypeError('beat_data should be a list of tuples')
         for beats in beat_data:
-            if type(beats) != tuple:
+            if not isinstance(beats, tuple):
                 raise TypeError(
                     'beat_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(beats))
@@ -76,10 +81,10 @@ def jams_converter(
 
     # sections
     if section_data is not None:
-        if type(section_data) != list:
+        if not isinstance(section_data, list):
             raise TypeError('section_data should be a list of tuples')
         for sections in section_data:
-            if type(sections) != tuple:
+            if not isinstance(sections, tuple):
                 raise TypeError(
                     'section_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(sections))
@@ -88,15 +93,15 @@ def jams_converter(
 
     # multi-sections (sections with multiple levels)
     if multi_section_data is not None:
-        if type(multi_section_data) != list:
+        if not isinstance(multi_section_data, list):
             raise TypeError('multi_section_data should be a list of tuples')
         for sections in multi_section_data:
-            if type(sections) != tuple:
+            if not isinstance(sections, tuple):
                 raise TypeError(
                     'multi_section_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(sections))
                 )
-            if (type(sections[0]) != list) or (type(sections[0][0]) != tuple):
+            if not (isinstance(sections[0], list) and isinstance(sections[0][0], tuple)):
                 raise TypeError(
                     'tuples in multi_section_data should contain a '
                     + 'list of tuples, indicating annotations in the different '
@@ -107,10 +112,10 @@ def jams_converter(
 
     # chords
     if chord_data is not None:
-        if type(chord_data) != list:
+        if not isinstance(chord_data, list):
             raise TypeError('chord_data should be a list of tuples')
         for chords in chord_data:
-            if type(chords) != tuple:
+            if not isinstance(chords, tuple):
                 raise TypeError(
                     'chord_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(chords))
@@ -119,10 +124,10 @@ def jams_converter(
 
     # notes
     if note_data is not None:
-        if type(note_data) != list:
+        if not isinstance(note_data, list):
             raise TypeError('note_data should be a list of tuples')
         for notes in note_data:
-            if type(notes) != tuple:
+            if not isinstance(notes, tuple):
                 raise TypeError(
                     'note_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(notes))
@@ -131,10 +136,10 @@ def jams_converter(
 
     # keys
     if key_data is not None:
-        if type(key_data) != list:
+        if not isinstance(key_data, list):
             raise TypeError('key_data should be a list of tuples')
         for keys in key_data:
-            if type(keys) != tuple:
+            if not isinstance(keys, tuple):
                 raise TypeError(
                     'key_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(keys))
@@ -143,10 +148,10 @@ def jams_converter(
 
     # f0
     if f0_data is not None:
-        if type(f0_data) != list:
+        if not isinstance(f0_data, list):
             raise TypeError('f0_data should be a list of tuples')
         for f0s in f0_data:
-            if type(f0s) != tuple:
+            if not isinstance(f0s, tuple):
                 raise TypeError(
                     'f0_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(f0s))
@@ -155,15 +160,27 @@ def jams_converter(
 
     # lyrics
     if lyrics_data is not None:
-        if type(lyrics_data) != list:
+        if not isinstance(lyrics_data, list):
             raise TypeError('lyrics_data should be a list of tuples')
         for lyrics in lyrics_data:
-            if type(lyrics) != tuple:
+            if not isinstance(lyrics, tuple):
                 raise TypeError(
                     'lyrics_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(lyrics))
                 )
             jam.annotations.append(lyrics_to_jams(lyrics))
+
+    # tags
+    if tags_data is not None:
+        if not isinstance(tags_data, list):
+            raise TypeError('tags_data should be a list of tuples')
+        for tag in tags_data:
+            if not isinstance(tag, tuple):
+                raise TypeError(
+                    'tags_data should be a list of tuples, '
+                    + 'but contains a {} element'.format(type(tag))
+                )
+            jam.annotations.append(tag_gtzan_to_jams(tag))
 
     return jam
 
@@ -186,7 +203,7 @@ def beats_to_jams(beats):
     jannot_beat = jams.Annotation(namespace='beat')
     jannot_beat.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if beats[0] is not None:
-        if type(beats[0]) != utils.BeatData:
+        if not isinstance(beats[0], utils.BeatData):
             raise TypeError('Type should be BeatData.')
         for t, p in zip(beats[0].beat_times, beats[0].beat_positions):
             jannot_beat.append(time=t, duration=0.0, value=p)
@@ -212,7 +229,7 @@ def sections_to_jams(sections):
     jannot_seg = jams.Annotation(namespace='segment_open')
     jannot_seg.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if sections[0] is not None:
-        if type(sections[0]) != utils.SectionData:
+        if not isinstance(sections[0], utils.SectionData):
             raise TypeError('Type should be SectionData.')
         for inter, seg in zip(sections[0].intervals, sections[0].labels):
             jannot_seg.append(time=inter[0], duration=inter[1] - inter[0], value=seg)
@@ -238,7 +255,7 @@ def chords_to_jams(chords):
     jannot_chord = jams.Annotation(namespace='chord')
     jannot_chord.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if chords[0] is not None:
-        if type(chords[0]) != utils.ChordData:
+        if not isinstance(chords[0], utils.ChordData):
             raise TypeError('Type should be ChordData.')
         for beg, end, ch in zip(
             chords[0].intervals[:, 0], chords[0].intervals[:, 1], chords[0].labels
@@ -266,7 +283,7 @@ def notes_to_jams(notes):
     jannot_note = jams.Annotation(namespace='note_hz')
     jannot_note.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if notes[0] is not None:
-        if type(notes[0]) != utils.NoteData:
+        if not isinstance(notes[0], utils.NoteData):
             raise TypeError('Type should be NoteData.')
         for beg, end, n in zip(
             notes[0].intervals[:, 0], notes[0].intervals[:, 1], notes[0].notes
@@ -294,7 +311,7 @@ def keys_to_jams(keys):
     jannot_key = jams.Annotation(namespace='key_mode')
     jannot_key.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if keys[0] is not None:
-        if type(keys[0]) != utils.KeyData:
+        if not isinstance(keys[0], utils.KeyData):
             raise TypeError('Type should be KeyData.')
         for beg, end, key in zip(keys[0].start_times, keys[0].end_times, keys[0].keys):
             jannot_key.append(time=beg, duration=end - beg, value=key)
@@ -326,7 +343,7 @@ def multi_sections_to_jams(multi_sections):
     )
     for sections in multi_sections[0]:
         if sections[0] is not None:
-            if type(sections[0]) != utils.SectionData:
+            if not isinstance(sections[0], utils.SectionData):
                 raise TypeError('Type should be SectionData.')
             for inter, seg in zip(sections[0].intervals, sections[0].labels):
                 jannot_multi.append(
@@ -354,10 +371,14 @@ def f0s_to_jams(f0s):
     jannot_f0 = jams.Annotation(namespace='pitch_contour')
     jannot_f0.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if f0s[0] is not None:
-        if type(f0s[0]) != utils.F0Data:
+        if not isinstance(f0s[0], utils.F0Data):
             raise TypeError('Type should be F0Data.')
         for t, f, c in zip(f0s[0].times, f0s[0].frequencies, f0s[0].confidence):
-            jannot_f0.append(time=t, duration=0.0, value=f, confidence=c)
+            jannot_f0.append(
+                time=t, duration=0.0,
+                value={'index': 0, 'frequency': f, 'voiced': f > 0},
+                confidence=c
+            )
     if f0s[1] is not None:
         jannot_f0.sandbox = jams.Sandbox(name=f0s[1])
     return jannot_f0
@@ -380,7 +401,7 @@ def lyrics_to_jams(lyrics):
     jannot_lyric = jams.Annotation(namespace='lyrics')
     jannot_lyric.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
     if lyrics[0] is not None:
-        if type(lyrics[0]) != utils.LyricData:
+        if not isinstance(lyrics[0], utils.LyricData):
             raise TypeError('Type should be LyricData.')
         for beg, end, lyric in zip(
             lyrics[0].start_times, lyrics[0].end_times, lyrics[0].lyrics
@@ -389,3 +410,28 @@ def lyrics_to_jams(lyrics):
     if lyrics[1] is not None:
         jannot_lyric.sandbox = jams.Sandbox(name=lyrics[1])
     return jannot_lyric
+
+
+def tag_gtzan_to_jams(tags):
+    '''
+    Convert tag-gtzan annotations into jams format.
+
+    Parameters
+    ----------
+    tags: tuple
+        A tuple in the format (str, str), where the first str is the tag
+        and the second describes the annotation.
+
+    Returns
+    -------
+    jannot_tag_gtzan: JAM tag_gtzan annotation object.
+    '''
+    jannot_tag_gtzan = jams.Annotation(namespace='tag_gtzan')
+    jannot_tag_gtzan.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
+    if tags[0] is not None:
+        if not isinstance(tags[0], str):
+            raise TypeError('Type should be str.')
+        jannot_tag_gtzan.append(time=0.0, duration=0.0, value=tags[0])
+    if tags[1] is not None:
+        jannot_tag_gtzan.sandbox = jams.Sandbox(name=tags[1])
+    return jannot_tag_gtzan

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -101,7 +101,9 @@ def jams_converter(
                     'multi_section_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(sections))
                 )
-            if not (isinstance(sections[0], list) and isinstance(sections[0][0], tuple)):
+            if not (
+                isinstance(sections[0], list) and isinstance(sections[0][0], tuple)
+            ):
                 raise TypeError(
                     'tuples in multi_section_data should contain a '
                     + 'list of tuples, indicating annotations in the different '
@@ -375,9 +377,10 @@ def f0s_to_jams(f0s):
             raise TypeError('Type should be F0Data.')
         for t, f, c in zip(f0s[0].times, f0s[0].frequencies, f0s[0].confidence):
             jannot_f0.append(
-                time=t, duration=0.0,
+                time=t,
+                duration=0.0,
                 value={'index': 0, 'frequency': f, 'voiced': f > 0},
-                confidence=c
+                confidence=c,
             )
     if f0s[1] is not None:
         jannot_f0.sandbox = jams.Sandbox(name=f0s[1])
@@ -427,7 +430,9 @@ def tag_gtzan_to_jams(tags):
     jannot_tag_gtzan: JAM tag_gtzan annotation object.
     '''
     jannot_tag_gtzan = jams.Annotation(namespace='tag_gtzan')
-    jannot_tag_gtzan.annotation_metadata = jams.AnnotationMetadata(data_source='mirdata')
+    jannot_tag_gtzan.annotation_metadata = jams.AnnotationMetadata(
+        data_source='mirdata'
+    )
     if tags[0] is not None:
         if not isinstance(tags[0], str):
             raise TypeError('Type should be str.')

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -18,7 +18,7 @@ def jams_converter(
     multi_section_data=None,
     key_data=None,
     lyrics_data=None,
-    tags_data=None,
+    tags_gtzan_data=None,
     metadata=None,
 ):
 
@@ -45,7 +45,7 @@ def jams_converter(
         A list of tuples of (KeyData, str), where str describes the annotation.
     lyrics_data (list or None):
         A list of tuples of (LyricData, str), where str describes the annotation.
-    tags_data (list or None):
+    tags_gtzan_data (list or None):
         A list of tuples of (str, str), where the first srt is the tag and the second
         is a descriptor of the annotation.
     metadata (dict or None):
@@ -173,13 +173,13 @@ def jams_converter(
             jam.annotations.append(lyrics_to_jams(lyrics))
 
     # tags
-    if tags_data is not None:
-        if not isinstance(tags_data, list):
-            raise TypeError('tags_data should be a list of tuples')
-        for tag in tags_data:
+    if tags_gtzan_data is not None:
+        if not isinstance(tags_gtzan_data, list):
+            raise TypeError('tags_gtzan_data should be a list of tuples')
+        for tag in tags_gtzan_data:
             if not isinstance(tag, tuple):
                 raise TypeError(
-                    'tags_data should be a list of tuples, '
+                    'tags_gtzan_data should be a list of tuples, '
                     + 'but contains a {} element'.format(type(tag))
                 )
             jam.annotations.append(tag_gtzan_to_jams(tag))

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -138,7 +138,13 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        return jams_utils.jams_converter(metadata=self._track_metadata)
+        metadata = {
+            'duration': librosa.get_duration(self.audio[0], self.audio[1])
+        }
+        metadata.update(self._track_metadata)
+        return jams_utils.jams_converter(
+            metadata=metadata
+        )
 
 
 def load_audio(audio_path):

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -138,13 +138,9 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {
-            'duration': librosa.get_duration(self.audio[0], self.audio[1])
-        }
+        metadata = {'duration': librosa.get_duration(self.audio[0], self.audio[1])}
         metadata.update(self._track_metadata)
-        return jams_utils.jams_converter(
-            metadata=metadata
-        )
+        return jams_utils.jams_converter(metadata=metadata)
 
 
 def load_audio(audio_path):

--- a/mirdata/medleydb_melody.py
+++ b/mirdata/medleydb_melody.py
@@ -136,9 +136,11 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         # jams does not support multipitch, so we skip melody3
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
             f0_data=[(self.melody1, 'melody1'), (self.melody2, 'melody2')],
-            metadata=self._track_metadata,
+            metadata=metadata,
         )
 
 

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -109,8 +109,10 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
-            f0_data=[(self.pitch, None)], metadata=self._track_metadata
+            f0_data=[(self.pitch, 'annotated pitch')], metadata=metadata
         )
 
 

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -196,7 +196,9 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio_mono[0], self.audio_mono[1])
+        metadata['duration'] = librosa.get_duration(
+            self.audio_mono[0], self.audio_mono[1]
+        )
         return jams_utils.jams_converter(
             f0_data=[(self.melody, 'annotated melody')], metadata=metadata
         )

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -195,8 +195,10 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio_mono[0], self.audio_mono[1])
         return jams_utils.jams_converter(
-            f0_data=[(self.melody, None)], metadata=self._track_metadata
+            f0_data=[(self.melody, 'annotated melody')], metadata=metadata
         )
 
 

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -175,10 +175,12 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
-            metadata=self._track_metadata,
+            metadata=metadata,
         )
 
 

--- a/mirdata/rwc_jazz.py
+++ b/mirdata/rwc_jazz.py
@@ -32,6 +32,7 @@ eighth-note feel, music with a sixteenth-note feel, and Latin jazz music.
 For more details, please visit: https://staff.aist.go.jp/m.goto/RWC-MDB/rwc-mdb-j.html
 """
 import csv
+import librosa
 import logging
 import os
 
@@ -198,10 +199,12 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
-            metadata=self._track_metadata,
+            metadata=metadata,
         )
 
 

--- a/mirdata/rwc_popular.py
+++ b/mirdata/rwc_popular.py
@@ -10,6 +10,7 @@ the 1990s.
 For more details, please visit: https://staff.aist.go.jp/m.goto/RWC-MDB/rwc-mdb-p.html
 """
 import csv
+import librosa
 import logging
 import numpy as np
 import os
@@ -217,11 +218,13 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
             chord_data=[(self.chords, None)],
-            metadata=self._track_metadata,
+            metadata=metadata,
         )
 
 

--- a/mirdata/salami.py
+++ b/mirdata/salami.py
@@ -194,6 +194,8 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
             multi_section_data=[
                 (
@@ -211,7 +213,7 @@ class Track(track.Track):
                     'annotator_2',
                 ),
             ],
-            metadata=self._track_metadata,
+            metadata=metadata,
         )
 
 

--- a/mirdata/tinysol.py
+++ b/mirdata/tinysol.py
@@ -194,7 +194,9 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        return jams_utils.jams_converter(metadata=self._track_metadata)  # TODO PR #185
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
+        return jams_utils.jams_converter(metadata=metadata)  # TODO PR #185
 
 
 def load_audio(audio_path):

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -14,15 +14,15 @@ def test_track():
 
     expected_attributes = {
         'audio_path': 'tests/resources/mir_datasets/Beatles/'
-            + 'audio/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav',
+        + 'audio/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.wav',
         'beats_path': 'tests/resources/mir_datasets/Beatles/'
-            + 'annotations/beat/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.txt',
+        + 'annotations/beat/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.txt',
         'chords_path': 'tests/resources/mir_datasets/Beatles/'
-            + 'annotations/chordlab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
+        + 'annotations/chordlab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
         'keys_path': 'tests/resources/mir_datasets/Beatles/'
-            + 'annotations/keylab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
+        + 'annotations/keylab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
         'sections_path': 'tests/resources/mir_datasets/Beatles/'
-            + 'annotations/seglab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
+        + 'annotations/seglab/The Beatles/01_-_Please_Please_Me/11_-_Do_You_Want_To_Know_A_Secret.lab',
         'title': '11_-_Do_You_Want_To_Know_A_Secret',
         'track_id': '0111',
     }
@@ -31,7 +31,7 @@ def test_track():
         'beats': utils.BeatData,
         'chords': utils.ChordData,
         'key': utils.KeyData,
-        'sections': utils.SectionData
+        'sections': utils.SectionData,
     }
 
     run_track_tests(track, expected_attributes, expected_property_types)

--- a/tests/test_dali.py
+++ b/tests/test_dali.py
@@ -16,10 +16,10 @@ def test_track():
     expected_attributes = {
         'album': 'Mezmerize',
         'annotation_path': 'tests/resources/mir_datasets/DALI/'
-            + 'annotations/4b196e6c99574dd49ad00d56e132712b.gz',
+        + 'annotations/4b196e6c99574dd49ad00d56e132712b.gz',
         'artist': 'System Of A Down',
         'audio_path': 'tests/resources/mir_datasets/DALI/'
-            + 'audio/4b196e6c99574dd49ad00d56e132712b.mp3',
+        + 'audio/4b196e6c99574dd49ad00d56e132712b.mp3',
         'audio_url': 'zUzd9KyIDrM',
         'dataset_version': 1,
         'ground_truth': False,
@@ -37,7 +37,7 @@ def test_track():
         'words': utils.LyricData,
         'lines': utils.LyricData,
         'paragraphs': utils.LyricData,
-        'annotation_object': DALI.Annotations
+        'annotation_object': DALI.Annotations,
     }
 
     run_track_tests(track, expected_attributes, expected_property_types)

--- a/tests/test_gtzan_genre.py
+++ b/tests/test_gtzan_genre.py
@@ -26,7 +26,7 @@ def test_track():
     expected_attributes = {
         'genre': "country",
         'audio_path': "tests/resources/mir_datasets/GTZAN-Genre/"
-            + "gtzan_genre/genres/country/country.00000.wav",
+        + "gtzan_genre/genres/country/country.00000.wav",
         'track_id': "country.00000",
     }
     run_track_tests(track, expected_attributes, {})

--- a/tests/test_gtzan_genre.py
+++ b/tests/test_gtzan_genre.py
@@ -34,3 +34,15 @@ def test_track():
     audio, sr = track.audio
     assert sr == 22050
     assert audio.shape == (663300,)
+
+
+def test_to_jams():
+    default_trackid = "country.00000"
+    track = gtzan_genre.Track(default_trackid, data_home=TEST_DATA_HOME)
+    jam = track.to_jams()
+
+    # Validate GTZAN schema
+    assert jam.validate()
+
+    # Test the that the genre parser of mirdata is correct
+    assert jam.annotations["tag_gtzan"][0].data[0].value == "country"

--- a/tests/test_guitarset.py
+++ b/tests/test_guitarset.py
@@ -19,15 +19,15 @@ def test_track():
     expected_attributes = {
         'track_id': '03_BN3-119-G_solo',
         'audio_hex_cln_path': 'tests/resources/mir_datasets/GuitarSet/'
-            + 'audio_hex-pickup_debleeded/03_BN3-119-G_solo_hex_cln.wav',
+        + 'audio_hex-pickup_debleeded/03_BN3-119-G_solo_hex_cln.wav',
         'audio_hex_path': 'tests/resources/mir_datasets/GuitarSet/'
-            + 'audio_hex-pickup_original/03_BN3-119-G_solo_hex.wav',
+        + 'audio_hex-pickup_original/03_BN3-119-G_solo_hex.wav',
         'audio_mic_path': 'tests/resources/mir_datasets/GuitarSet/'
-            + 'audio_mono-mic/03_BN3-119-G_solo_mic.wav',
+        + 'audio_mono-mic/03_BN3-119-G_solo_mic.wav',
         'audio_mix_path': 'tests/resources/mir_datasets/GuitarSet/'
-            + 'audio_mono-pickup_mix/03_BN3-119-G_solo_mix.wav',
+        + 'audio_mono-pickup_mix/03_BN3-119-G_solo_mix.wav',
         'jams_path': 'tests/resources/mir_datasets/GuitarSet/'
-            + 'annotation/03_BN3-119-G_solo.jams',
+        + 'annotation/03_BN3-119-G_solo.jams',
         'player_id': '03',
         'tempo': 119,
         'mode': 'solo',

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -70,7 +70,10 @@ def test_to_jams():
     f0s = jam.search(namespace='pitch_contour')[0]['data']
     assert [f0.time for f0 in f0s] == [0.016, 0.048]
     assert [f0.duration for f0 in f0s] == [0.0, 0.0]
-    assert [f0.value for f0 in f0s] == [0.0, 260.946404518887]
+    assert [f0.value for f0 in f0s] == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 260.946404518887, 'index': 0, 'voiced': True}
+    ]
     assert [f0.confidence for f0 in f0s] == [0.0, 1.0]
 
 

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -15,7 +15,7 @@ def test_track():
     expected_attributes = {
         'track_id': '10161_chorus',
         'audio_path': 'tests/resources/mir_datasets/iKala/'
-            + 'Wavfile/10161_chorus.wav',
+        + 'Wavfile/10161_chorus.wav',
         'song_id': '10161',
         'section': 'chorus',
         'singer_id': '1',
@@ -23,10 +23,7 @@ def test_track():
         'lyrics_path': 'tests/resources/mir_datasets/iKala/Lyrics/10161_chorus.lab',
     }
 
-    expected_property_types = {
-        'f0': utils.F0Data,
-        'lyrics': utils.LyricData,
-    }
+    expected_property_types = {'f0': utils.F0Data, 'lyrics': utils.LyricData}
 
     assert track._track_paths == {
         'audio': ['Wavfile/10161_chorus.wav', '278ae003cb0d323e99b9a643c0f2eeda'],
@@ -72,7 +69,7 @@ def test_to_jams():
     assert [f0.duration for f0 in f0s] == [0.0, 0.0]
     assert [f0.value for f0 in f0s] == [
         {'frequency': 0.0, 'index': 0, 'voiced': False},
-        {'frequency': 260.946404518887, 'index': 0, 'voiced': True}
+        {'frequency': 260.946404518887, 'index': 0, 'voiced': True},
     ]
     assert [f0.confidence for f0 in f0s] == [0.0, 1.0]
 

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -978,17 +978,17 @@ def test_tags():
     tag_data3 = [('invalid', 'asdf')]
     tag_data4 = ('jazz', 'wrong format')
     tag_data5 = ['wrong format too']
-    jam1 = jams_utils.jams_converter(tags_data=tag_data1, metadata={'duration': 10.0})
+    jam1 = jams_utils.jams_converter(tags_gtzan_data=tag_data1, metadata={'duration': 10.0})
     assert jam1.validate()
-    jam2 = jams_utils.jams_converter(tags_data=tag_data2, metadata={'duration': 10.0})
+    jam2 = jams_utils.jams_converter(tags_gtzan_data=tag_data2, metadata={'duration': 10.0})
     assert jam2.validate()
-    jam3 = jams_utils.jams_converter(tags_data=tag_data3, metadata={'duration': 10.0})
+    jam3 = jams_utils.jams_converter(tags_gtzan_data=tag_data3, metadata={'duration': 10.0})
     with pytest.raises(jams.SchemaError):
         assert jam3.validate()
     with pytest.raises(TypeError):
-        jam4 = jams_utils.jams_converter(tags_data=tag_data4)
+        jam4 = jams_utils.jams_converter(tags_gtzan_data=tag_data4)
     with pytest.raises(TypeError):
-        jam5 = jams_utils.jams_converter(tags_data=tag_data5)
+        jam5 = jams_utils.jams_converter(tags_gtzan_data=tag_data5)
 
 
 def test_metadata():

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -202,7 +202,7 @@ def test_notes():
             utils.NoteData(
                 np.array([[0.0, 0.5, 1.0], [0.5, 1.0, 1.5]]).T,
                 np.array([1108.731, 1108.731, 1108.731]),
-                np.array([1, 1, 1])
+                np.array([1, 1, 1]),
             ),
             None,
         )
@@ -212,7 +212,7 @@ def test_notes():
             utils.NoteData(
                 np.array([[0.0, 0.8, 1.0], [0.5, 1.0, 1.5]]).T,
                 np.array([1108.731, 1108.731, 1108.731]),
-                np.array([1, 1, 1])
+                np.array([1, 1, 1]),
             ),
             'notes_2',
         )
@@ -222,7 +222,7 @@ def test_notes():
             utils.NoteData(
                 np.array([[0.0, 0.5, 1.0], [0.5, 1.0, 1.5]]).T,
                 np.array([1108.731, 1108.731, 1108.731]),
-                np.array([1, 1, 1])
+                np.array([1, 1, 1]),
             ),
             'notes_1',
         ),
@@ -230,7 +230,7 @@ def test_notes():
             utils.NoteData(
                 np.array([[0.0, 0.7, 1.0], [0.7, 1.0, 1.5]]).T,
                 np.array([1108.731, 1108.731, 1108.731]),
-                np.array([1, 1, 1])
+                np.array([1, 1, 1]),
             ),
             'notes_2',
         ),
@@ -239,7 +239,7 @@ def test_notes():
         utils.NoteData(
             np.array([[0.0, 0.5, 1.0], [0.5, 1.0, 1.5]]).T,
             np.array([1108.731, 1108.731, 1108.731]),
-            np.array([1, 1, 1])
+            np.array([1, 1, 1]),
         ),
         None,
     )
@@ -248,7 +248,7 @@ def test_notes():
             utils.NoteData(
                 np.array([[0.0, 0.5, 1.0], [0.5, 1.0, 1.5]]).T,
                 np.array([1108.731, 1108.731, 1108.731]),
-                np.array([1, 1, 1])
+                np.array([1, 1, 1]),
             ),
             None,
         ],
@@ -256,7 +256,7 @@ def test_notes():
             utils.NoteData(
                 np.array([[0.0, 0.8, 1.0], [0.5, 1.0, 1.5]]).T,
                 np.array([1108.731, 1108.731, 1108.731]),
-                np.array([1, 1, 1])
+                np.array([1, 1, 1]),
             ),
             'notes_2',
         ),
@@ -807,7 +807,7 @@ def test_f0s():
     assert duration == [0.0, 0.0]
     assert value == [
         {'frequency': 0.0, 'index': 0, 'voiced': False},
-        {'frequency': 260.9, 'index': 0, 'voiced': True}
+        {'frequency': 260.9, 'index': 0, 'voiced': True},
     ]
     assert confidence == [0.0, 1.0]
 
@@ -818,7 +818,7 @@ def test_f0s():
     assert duration == [0.0, 0.0]
     assert value == [
         {'frequency': 0.0, 'index': 0, 'voiced': False},
-        {'frequency': 260.9, 'index': 0, 'voiced': True}
+        {'frequency': 260.9, 'index': 0, 'voiced': True},
     ]
     assert confidence == [0.0, 1.0]
 
@@ -827,7 +827,7 @@ def test_f0s():
     assert duration == [0.0, 0.0]
     assert value == [
         {'frequency': 0.0, 'index': 0, 'voiced': False},
-        {'frequency': 230.5, 'index': 0, 'voiced': True}
+        {'frequency': 230.5, 'index': 0, 'voiced': True},
     ]
     assert confidence == [0.0, 1.0]
 

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -22,7 +22,6 @@ def get_jam_data(jam, namespace, annot_numb):
 
 
 def test_beats():
-
     beat_data_1 = [(utils.BeatData(np.array([0.2, 0.3]), np.array([1, 2])), None)]
     beat_data_2 = [(utils.BeatData(np.array([0.5, 0.7]), np.array([2, 3])), 'beats_2')]
     beat_data_3 = [
@@ -238,7 +237,7 @@ def test_notes():
     ]
     note_data_4 = (
         utils.NoteData(
-            np.array([[0.0, 0.5, 1.0], [0.5, 1.0, 1.5]]).T, 
+            np.array([[0.0, 0.5, 1.0], [0.5, 1.0, 1.5]]).T,
             np.array([1108.731, 1108.731, 1108.731]),
             np.array([1, 1, 1])
         ),
@@ -806,7 +805,10 @@ def test_f0s():
     time, duration, value, confidence = get_jam_data(jam_1, 'pitch_contour', 0)
     assert time == [0.016, 0.048]
     assert duration == [0.0, 0.0]
-    assert value == [0.0, 260.9]
+    assert value == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 260.9, 'index': 0, 'voiced': True}
+    ]
     assert confidence == [0.0, 1.0]
 
     assert jam_2.annotations[0]['sandbox']['name'] == 'f0s_1'
@@ -814,13 +816,19 @@ def test_f0s():
     time, duration, value, confidence = get_jam_data(jam_3, 'pitch_contour', 0)
     assert time == [0.016, 0.048]
     assert duration == [0.0, 0.0]
-    assert value == [0.0, 260.9]
+    assert value == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 260.9, 'index': 0, 'voiced': True}
+    ]
     assert confidence == [0.0, 1.0]
 
     time, duration, value, confidence = get_jam_data(jam_3, 'pitch_contour', 1)
     assert time == [0.003, 0.012]
     assert duration == [0.0, 0.0]
-    assert value == [0.0, 230.5]
+    assert value == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 230.5, 'index': 0, 'voiced': True}
+    ]
     assert confidence == [0.0, 1.0]
 
     time, duration, value, confidence = get_jam_data(jam_6, 'pitch_contour', 0)
@@ -962,6 +970,25 @@ def test_lyrics():
         jams_utils.jams_converter(lyrics_data=lyrics_data_5)
     with pytest.raises(TypeError):
         jams_utils.jams_converter(lyrics_data=lyrics_data_7)
+
+
+def test_tags():
+    tag_data1 = [('blues', 'I am a description')]
+    tag_data2 = [('disco', 'tag 1'), ('rock', 'tag 2')]
+    tag_data3 = [('invalid', 'asdf')]
+    tag_data4 = ('jazz', 'wrong format')
+    tag_data5 = ['wrong format too']
+    jam1 = jams_utils.jams_converter(tags_data=tag_data1, metadata={'duration': 10.0})
+    assert jam1.validate()
+    jam2 = jams_utils.jams_converter(tags_data=tag_data2, metadata={'duration': 10.0})
+    assert jam2.validate()
+    jam3 = jams_utils.jams_converter(tags_data=tag_data3, metadata={'duration': 10.0})
+    with pytest.raises(jams.SchemaError):
+        assert jam3.validate()
+    with pytest.raises(TypeError):
+        jam4 = jams_utils.jams_converter(tags_data=tag_data4)
+    with pytest.raises(TypeError):
+        jam5 = jams_utils.jams_converter(tags_data=tag_data5)
 
 
 def test_metadata():

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -82,7 +82,8 @@ def test_track():
 
         track_default = dataset.Track(trackid)
         assert track_default._data_home == os.path.join(
-            DEFAULT_DATA_HOME, dataset.DATASET_DIR)
+            DEFAULT_DATA_HOME, dataset.DATASET_DIR
+        )
 
         # test data home specified
         data_home = os.path.join(data_home_dir, dataset.DATASET_DIR)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -43,12 +43,12 @@ def test_download():
         assert params['data_home'].default is None
 
 
-# def test_validate():
-#     for dataset in DATASETS:
-#         data_home = os.path.join('tests/resources/mir_datasets', dataset.DATASET_DIR)
-#         dataset.validate(data_home=data_home)
-#         dataset.validate(data_home=data_home, silence=True)
-#         dataset.validate(data_home=None, silence=True)
+def test_validate():
+    for dataset in DATASETS:
+        data_home = os.path.join('tests/resources/mir_datasets', dataset.DATASET_DIR)
+        dataset.validate(data_home=data_home)
+        dataset.validate(data_home=data_home, silence=True)
+        dataset.validate(data_home=None, silence=True)
 
 
 def test_load_and_trackids():

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -13,6 +13,17 @@ import mirdata.track as track
 from tests.test_utils import DEFAULT_DATA_HOME
 
 DATASETS = [importlib.import_module("mirdata.{}".format(d)) for d in mirdata.__all__]
+CUSTOM_TEST_TRACKS = {
+    'beatles': '0111',
+    'guitarset': '03_BN3-119-G_solo',
+    'medley_solos_db': 'd07b1fc0-567d-52c2-fef4-239f31c9d40e',
+    'medleydb_melody': 'MusicDelta_Beethoven',
+    'rwc_classical': 'RM-C003',
+    'rwc_jazz': 'RM-J004',
+    'rwc_popular': 'RM-P001',
+    'salami': '2',
+    'tinysol': 'Fl-ord-C4-mf-N-T14d',
+}
 
 
 def test_cite():
@@ -32,12 +43,12 @@ def test_download():
         assert params['data_home'].default is None
 
 
-def test_validate():
-    for dataset in DATASETS:
-        data_home = os.path.join('tests/resources/mir_datasets', dataset.DATASET_DIR)
-        dataset.validate(data_home=data_home)
-        dataset.validate(data_home=data_home, silence=True)
-        dataset.validate(data_home=None, silence=True)
+# def test_validate():
+#     for dataset in DATASETS:
+#         data_home = os.path.join('tests/resources/mir_datasets', dataset.DATASET_DIR)
+#         dataset.validate(data_home=data_home)
+#         dataset.validate(data_home=data_home, silence=True)
+#         dataset.validate(data_home=None, silence=True)
 
 
 def test_load_and_trackids():
@@ -57,21 +68,37 @@ def test_load_and_trackids():
 
 
 def test_track():
-    for dataset in DATASETS:
-        print(str(dataset))
-        trackid = dataset.track_ids()[0]
+    jams_temporary_exceptions = ['dali']
+    data_home_dir = 'tests/resources/mir_datasets'
 
-        # test data home None
+    for dataset in DATASETS:
+        dataset_name = dataset.__name__.split('.')[1]
+        print(dataset_name)
+
+        if dataset_name in CUSTOM_TEST_TRACKS:
+            trackid = CUSTOM_TEST_TRACKS[dataset_name]
+        else:
+            trackid = dataset.track_ids()[0]
+
         track_default = dataset.Track(trackid)
         assert track_default._data_home == os.path.join(
             DEFAULT_DATA_HOME, dataset.DATASET_DIR)
 
-        assert isinstance(track_default, track.Track)
+        # test data home specified
+        data_home = os.path.join(data_home_dir, dataset.DATASET_DIR)
+        track_test = dataset.Track(trackid, data_home=data_home)
 
-        assert hasattr(track_default, 'to_jams')
+        assert isinstance(track_test, track.Track)
+
+        assert hasattr(track_test, 'to_jams')
+
+        if dataset_name not in jams_temporary_exceptions:
+            # Validate json schema
+            jam = track_test.to_jams()
+            assert jam.validate()
 
         # will fail if something goes wrong with __repr__
-        print(track_default)
+        print(track_test)
 
         with pytest.raises(ValueError):
             dataset.Track('~faketrackid~?!')

--- a/tests/test_medley_solos_db.py
+++ b/tests/test_medley_solos_db.py
@@ -13,11 +13,11 @@ def test_track():
     expected_attributes = {
         'track_id': 'd07b1fc0-567d-52c2-fef4-239f31c9d40e',
         'audio_path': 'tests/resources/mir_datasets/Medley-solos-DB/'
-            + 'audio/Medley-solos-DB_validation-3_d07b1fc0-567d-52c2-fef4-239f31c9d40e.wav',
+        + 'audio/Medley-solos-DB_validation-3_d07b1fc0-567d-52c2-fef4-239f31c9d40e.wav',
         'instrument': 'flute',
         'instrument_id': 3,
         'song_id': 210,
-        'subset': 'validation'
+        'subset': 'validation',
     }
 
     expected_property_types = {}

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -15,13 +15,13 @@ def test_track():
     expected_attributes = {
         'track_id': 'MusicDelta_Beethoven',
         'audio_path': 'tests/resources/mir_datasets/'
-            + 'MedleyDB-Melody/audio/MusicDelta_Beethoven_MIX.wav',
+        + 'MedleyDB-Melody/audio/MusicDelta_Beethoven_MIX.wav',
         'melody1_path': 'tests/resources/mir_datasets/'
-            + 'MedleyDB-Melody/melody1/MusicDelta_Beethoven_MELODY1.csv',
+        + 'MedleyDB-Melody/melody1/MusicDelta_Beethoven_MELODY1.csv',
         'melody2_path': 'tests/resources/mir_datasets/'
-            + 'MedleyDB-Melody/melody2/MusicDelta_Beethoven_MELODY2.csv',
+        + 'MedleyDB-Melody/melody2/MusicDelta_Beethoven_MELODY2.csv',
         'melody3_path': 'tests/resources/mir_datasets/'
-            + 'MedleyDB-Melody/melody3/MusicDelta_Beethoven_MELODY3.csv',
+        + 'MedleyDB-Melody/melody3/MusicDelta_Beethoven_MELODY3.csv',
         'artist': 'MusicDelta',
         'title': 'Beethoven',
         'genre': 'Classical',
@@ -33,7 +33,7 @@ def test_track():
     expected_property_types = {
         'melody1': utils.F0Data,
         'melody2': utils.F0Data,
-        'melody3': utils.MultipitchData
+        'melody3': utils.MultipitchData,
     }
 
     run_track_tests(track, expected_attributes, expected_property_types)

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -52,7 +52,10 @@ def test_to_jams():
     f0s = jam.search(namespace='pitch_contour')[1]['data']
     assert [f0.time for f0 in f0s] == [0.046439909297052155, 0.052244897959183675]
     assert [f0.duration for f0 in f0s] == [0.0, 0.0]
-    assert [f0.value for f0 in f0s] == [0.0, 965.992]
+    assert [f0.value for f0 in f0s] == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 965.992, 'index': 0, 'voiced': True},
+    ]
     assert [f0.confidence for f0 in f0s] == [0.0, 1.0]
 
     assert jam['file_metadata']['title'] == 'Beethoven'

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -15,18 +15,16 @@ def test_track():
     expected_attributes = {
         'track_id': 'AClassicEducation_NightOwl_STEM_08',
         'audio_path': 'tests/resources/mir_datasets/'
-            + 'MedleyDB-Pitch/audio/AClassicEducation_NightOwl_STEM_08.wav',
+        + 'MedleyDB-Pitch/audio/AClassicEducation_NightOwl_STEM_08.wav',
         'pitch_path': 'tests/resources/mir_datasets/'
-            + 'MedleyDB-Pitch/pitch/AClassicEducation_NightOwl_STEM_08.csv',
+        + 'MedleyDB-Pitch/pitch/AClassicEducation_NightOwl_STEM_08.csv',
         'instrument': 'male singer',
         'artist': 'AClassicEducation',
         'title': 'NightOwl',
-        'genre': 'Singer/Songwriter'
+        'genre': 'Singer/Songwriter',
     }
 
-    expected_property_types = {
-        'pitch': utils.F0Data,
-    }
+    expected_property_types = {'pitch': utils.F0Data}
 
     run_track_tests(track, expected_attributes, expected_property_types)
 

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -46,7 +46,10 @@ def test_to_jams():
     f0s = jam.search(namespace='pitch_contour')[0]['data']
     assert [f0.time for f0 in f0s] == [0.06965986394557823, 0.07546485260770976]
     assert [f0.duration for f0 in f0s] == [0.0, 0.0]
-    assert [f0.value for f0 in f0s] == [0.0, 191.877]
+    assert [f0.value for f0 in f0s] == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 191.877, 'index': 0, 'voiced': True},
+    ]
     assert [f0.confidence for f0 in f0s] == [0.0, 1.0]
 
     assert jam['file_metadata']['title'] == 'NightOwl'

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -57,7 +57,11 @@ def test_to_jams():
     f0s = jam.search(namespace='pitch_contour')[0]['data']
     assert [f0.time for f0 in f0s] == [0.0, 0.08, 0.09]
     assert [f0.duration for f0 in f0s] == [0.0, 0.0, 0.0]
-    assert [f0.value for f0 in f0s] == [0.0, 0.0, 622.254]
+    assert [f0.value for f0 in f0s] == [
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 0.0, 'index': 0, 'voiced': False},
+        {'frequency': 622.254, 'index': 0, 'voiced': True},
+    ]
     assert [f0.confidence for f0 in f0s] == [0.0, 0.0, 1.0]
 
     assert jam['sandbox']['alternating_melody'] == True

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -15,11 +15,11 @@ def test_track():
     expected_attributes = {
         'track_id': 'Beethoven-S3-I-ex1',
         'audio_path_mono': 'tests/resources/mir_datasets/Orchset/'
-            + 'audio/mono/Beethoven-S3-I-ex1.wav',
+        + 'audio/mono/Beethoven-S3-I-ex1.wav',
         'audio_path_stereo': 'tests/resources/mir_datasets/Orchset/'
-            + 'audio/stereo/Beethoven-S3-I-ex1.wav',
+        + 'audio/stereo/Beethoven-S3-I-ex1.wav',
         'melody_path': 'tests/resources/mir_datasets/Orchset/'
-            + 'GT/Beethoven-S3-I-ex1.mel',
+        + 'GT/Beethoven-S3-I-ex1.mel',
         'composer': 'Beethoven',
         'work': 'S3-I',
         'excerpt': '1',
@@ -33,9 +33,7 @@ def test_track():
         'only_brass': False,
     }
 
-    expected_property_types = {
-        'melody': utils.F0Data
-    }
+    expected_property_types = {'melody': utils.F0Data}
 
     run_track_tests(track, expected_attributes, expected_property_types)
 

--- a/tests/test_rwc_classical.py
+++ b/tests/test_rwc_classical.py
@@ -15,11 +15,11 @@ def test_track():
     expected_attributes = {
         'track_id': 'RM-C003',
         'audio_path': 'tests/resources/mir_datasets/RWC-Classical/'
-            + 'audio/rwc-c-m01/3.wav',
+        + 'audio/rwc-c-m01/3.wav',
         'sections_path': 'tests/resources/mir_datasets/RWC-Classical/'
-            + 'annotations/AIST.RWC-MDB-C-2001.CHORUS/RM-C003.CHORUS.TXT',
+        + 'annotations/AIST.RWC-MDB-C-2001.CHORUS/RM-C003.CHORUS.TXT',
         'beats_path': 'tests/resources/mir_datasets/RWC-Classical/'
-            + 'annotations/AIST.RWC-MDB-C-2001.BEAT/RM-C003.BEAT.TXT',
+        + 'annotations/AIST.RWC-MDB-C-2001.BEAT/RM-C003.BEAT.TXT',
         'piece_number': 'No. 3',
         'suffix': 'M01',
         'track_number': 'Tr. 03',
@@ -30,10 +30,7 @@ def test_track():
         'category': 'Symphony',
     }
 
-    expected_property_types = {
-        'beats': utils.BeatData,
-        'sections': utils.SectionData
-    }
+    expected_property_types = {'beats': utils.BeatData, 'sections': utils.SectionData}
 
     run_track_tests(track, expected_attributes, expected_property_types)
 

--- a/tests/test_rwc_jazz.py
+++ b/tests/test_rwc_jazz.py
@@ -14,11 +14,11 @@ def test_track():
     expected_attributes = {
         'track_id': 'RM-J004',
         'audio_path': 'tests/resources/mir_datasets/RWC-Jazz/'
-            + 'audio/rwc-j-m01/4.wav',
+        + 'audio/rwc-j-m01/4.wav',
         'sections_path': 'tests/resources/mir_datasets/RWC-Jazz/'
-            + 'annotations/AIST.RWC-MDB-J-2001.CHORUS/RM-J004.CHORUS.TXT',
+        + 'annotations/AIST.RWC-MDB-J-2001.CHORUS/RM-J004.CHORUS.TXT',
         'beats_path': 'tests/resources/mir_datasets/RWC-Jazz/'
-            + 'annotations/AIST.RWC-MDB-J-2001.BEAT/RM-J004.BEAT.TXT',
+        + 'annotations/AIST.RWC-MDB-J-2001.BEAT/RM-J004.BEAT.TXT',
         'piece_number': 'No. 4',
         'suffix': 'M01',
         'track_number': 'Tr. 04',
@@ -29,10 +29,7 @@ def test_track():
         'instruments': 'Pf',
     }
 
-    expected_property_types = {
-        'beats': utils.BeatData,
-        'sections': utils.SectionData
-    }
+    expected_property_types = {'beats': utils.BeatData, 'sections': utils.SectionData}
 
     run_track_tests(track, expected_attributes, expected_property_types)
 

--- a/tests/test_rwc_popular.py
+++ b/tests/test_rwc_popular.py
@@ -16,15 +16,15 @@ def test_track():
     expected_attributes = {
         'track_id': 'RM-P001',
         'audio_path': 'tests/resources/mir_datasets/RWC-Popular/'
-            + 'audio/rwc-p-m01/1.wav',
+        + 'audio/rwc-p-m01/1.wav',
         'sections_path': 'tests/resources/mir_datasets/RWC-Popular/'
-            + 'annotations/AIST.RWC-MDB-P-2001.CHORUS/RM-P001.CHORUS.TXT',
+        + 'annotations/AIST.RWC-MDB-P-2001.CHORUS/RM-P001.CHORUS.TXT',
         'beats_path': 'tests/resources/mir_datasets/RWC-Popular/'
-            + 'annotations/AIST.RWC-MDB-P-2001.BEAT/RM-P001.BEAT.TXT',
+        + 'annotations/AIST.RWC-MDB-P-2001.BEAT/RM-P001.BEAT.TXT',
         'chords_path': 'tests/resources/mir_datasets/RWC-Popular/'
-            + 'annotations/AIST.RWC-MDB-P-2001.CHORD/RWC_Pop_Chords/N001-M01-T01.lab',
+        + 'annotations/AIST.RWC-MDB-P-2001.CHORD/RWC_Pop_Chords/N001-M01-T01.lab',
         'voca_inst_path': 'tests/resources/mir_datasets/RWC-Popular/'
-            + 'annotations/AIST.RWC-MDB-P-2001.VOCA_INST/RM-P001.VOCA_INST.TXT',
+        + 'annotations/AIST.RWC-MDB-P-2001.VOCA_INST/RM-P001.VOCA_INST.TXT',
         'piece_number': 'No. 1',
         'suffix': 'M01',
         'track_number': 'Tr. 01',

--- a/tests/test_salami.py
+++ b/tests/test_salami.py
@@ -14,16 +14,15 @@ def test_track():
 
     expected_attributes = {
         'track_id': '2',
-        'audio_path': 'tests/resources/mir_datasets/Salami/'
-            + 'audio/2.mp3',
+        'audio_path': 'tests/resources/mir_datasets/Salami/' + 'audio/2.mp3',
         'sections_annotator1_uppercase_path': 'tests/resources/mir_datasets/Salami/'
-            + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile1_uppercase.txt',
+        + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile1_uppercase.txt',
         'sections_annotator1_lowercase_path': 'tests/resources/mir_datasets/Salami/'
-            + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile1_lowercase.txt',
+        + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile1_lowercase.txt',
         'sections_annotator2_uppercase_path': 'tests/resources/mir_datasets/Salami/'
-            + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile2_uppercase.txt',
+        + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile2_uppercase.txt',
         'sections_annotator2_lowercase_path': 'tests/resources/mir_datasets/Salami/'
-            + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile2_lowercase.txt',
+        + 'salami-data-public-hierarchy-corrections/annotations/2/parsed/textfile2_lowercase.txt',
         'source': 'Codaich',
         'annotator_1_id': '5',
         'annotator_2_id': '8',

--- a/tests/test_tinysol.py
+++ b/tests/test_tinysol.py
@@ -15,7 +15,7 @@ def test_track():
     expected_attributes = {
         'track_id': 'Fl-ord-C4-mf-N-T14d',
         'audio_path': 'tests/resources/mir_datasets/TinySOL/'
-            + 'audio/Winds/Flute/ordinario/Fl-ord-C4-mf-N-T14d.wav',
+        + 'audio/Winds/Flute/ordinario/Fl-ord-C4-mf-N-T14d.wav',
         'dynamics': 'mf',
         'fold': 0,
         'family': 'Winds',

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -13,7 +13,6 @@ else:
 
 
 def test_track_repr():
-
     class TestTrack(track.Track):
         def __init__(self):
             self.a = 'asdf'

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -53,9 +53,9 @@ def get_attributes_and_properties(class_instance):
         else:
             raise ValueError("Unknown type {}".format(attr))
 
-    non_attributes = list(itertools.chain.from_iterable(
-        [properties, cached_properties, functions]
-    ))
+    non_attributes = list(
+        itertools.chain.from_iterable([properties, cached_properties, functions])
+    )
     for val in dir(class_instance):
         if val.startswith('_'):
             continue


### PR DESCRIPTION
This PR implements a JAMS parser for `gtzan_genre`, in the prospect of closing #197 ("DALI and GTZAN Genre lack a to_jams method")

This was quite easy. I am going to write unit tests now.

PS: nevermind that this branch is called `dali-jams`. This is a `gtzan_genre` PR.

EDIT: [rabitt]
This PR now does the following:
* fixes #217 
* adds a test to `test_loaders` which ensures that the output of every `to_jams()` method successfully validates
* the above test broke for nearly every loader, because `duration` was not part of the file_metadata. I've added duration to every `to_jams` method.
* added a new argument to `jams_utils.jams_converter` for gtzan tags.
* changes the convention in `jams_utils` to always us `if not isinstance(...)` over `if type(...) != ...`