### PR TITLE
[RFC] Dataset class. Cross-module download, duration, from_jams, load, to_jams, and validate

### DIFF
--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -394,6 +394,7 @@ remotes = {
 
 
 class Track2(track2.Track2):
+    @utils.cached_property
     def artist():
         """string: artist name"""
         return "The Beatles"

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -394,8 +394,8 @@ remotes = {
 
 
 class Track2(track2.Track2):
-    @staticmethod
     def artist():
+        """string: artist name"""
         return "The Beatles"
 
     @utils.cached_property

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -362,3 +362,32 @@ Mauch, Matthias, et al.
     """
 
     print(cite_data)
+
+
+name = "Beatles"
+
+bibtex = """@inproceedings{mauch2009beatles,
+title={OMRAS2 metadata project 2009},
+author={Mauch, Matthias and Cannam, Chris and Davies, Matthew and Dixon, Simon and Harte,
+Christopher and Kolozali, Sefki and Tidhar, Dan and Sandler, Mark},
+booktitle={12th International Society for Music Information Retrieval Conference},
+year={2009},
+series = {ISMIR}
+}"""
+
+remotes = {
+    "annotations": ANNOTATIONS_REMOTE = download_utils.RemoteFileMetadata(
+        filename='The Beatles Annotations.tar.gz',
+        url='http://isophonics.net/files/annotations/The%20Beatles%20Annotations.tar.gz',
+        checksum='62425c552d37c6bb655a78e4603828cc',
+        destination_dir='annotations',
+    )
+    "audio": """
+        Unfortunately the audio files of the Beatles dataset are not available
+        for download. If you have the Beatles dataset, place the contents into
+        a folder called Beatles with the following structure:
+            > Beatles/
+                > annotations/
+                > audio/
+        and copy the Beatles folder to {}"""
+}

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -60,8 +60,12 @@ class Dataset(object):
         return self[random.choice(self.track_ids())]
 
     def cite(self):
+        # TODO: use pybtex to convert to MLA
         print("========== BibTeX ==========")
-        print(self.bibtex)
+        if isinstance(self.bibtex, str):
+            print(self.bibtex)
+        else:
+            print("\n".join(self.bibtex.values()))
 
     def download(self, force_overwrite=False, cleanup=False, download_items=None):
         if not os.path.exists(self.data_home):

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -79,7 +79,7 @@ class Dataset(object):
         for remote_key in download_items:
             remote = self.remotes[remote_key]
             if isinstance(remote, str):
-                print(remote.format(data_home))
+                print(remote.format(self.data_home))
                 continue
 
             if ".zip" in remote.url:

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -1,0 +1,81 @@
+import jams
+import json
+import os
+import tqdm
+import re
+
+from mirdata import utils
+
+
+class Dataset(object):
+    def __init__(
+        self, name, load_track, load_metadata, bibtex, remotes, data_home=None
+    ):
+        super(Dataset, self).__init__()
+        self.name = name
+        self.load_metadata = load_metadata
+        self.load_track = load_track
+        self.bibtex = bibtex
+        self.remotes = remotes
+        if data_home is None:
+            self.data_home = self.dataset_default_path
+        else:
+            self.data_home = data_home
+
+    def __getitem__(self, track_id):
+        track_metadata = self.metadata[track_id]
+        track_index = self.index[track_id].copy()
+        for track_key in self.index[track_id]:
+            track_index[track_key][0] = os.path.join(
+                self.data_home, track_index[track_key][0]
+            )
+        return Track(self.load_track, track_metadata, track_index)
+
+    @property
+    def dataset_default_path(self):
+        mir_datasets_dir = os.path.join(os.getenv('HOME', '/tmp'), 'mir_datasets')
+        dataset_dir = re.sub(' ', '-', self.name)
+        return os.path.join(mir_datasets_dir, dataset_dir)
+
+    @utils.cached_property
+    def index(self):
+        return self.load_index()
+
+    @property
+    def index_path(self):
+        json_name = re.sub('[^0-9a-z]+', '_', self.name.lower()) + "_index.json"
+        cwd = os.path.dirname(os.path.realpath(__file__))
+        return os.path.join(cwd, "indexes", json_name)
+
+    @utils.cached_property
+    def metadata(self):
+        metadata_index = self.load_metadata(self.data_home)
+        metadata_index['data_home'] = self.data_home
+        return metadata_index
+
+    def cite(self):
+        bibtex_citation = self.bibtex
+        print("========== BibTeX ==========")
+        print(bibtex)
+
+    def load(self, verbose=False):
+        tracks = {}
+        for track_id in tqdm.tqdm(self.index, disable=not verbose):
+            tracks[track_id] = self[track_id]
+        return tracks
+
+    def load_index(self):
+        with open(self.index_path) as f:
+            return json.load(f)
+
+    def track_ids(self):
+        return list(self.index.keys())
+
+    def validate(self, verbose=False):
+        missing_files = []
+        invalid_checksums = []
+        for track_id in tqdm.tqdm(self.track_ids(), disable=not verbose):
+            track_validation = self[track_id].validate()
+            missing_files += track_validation[0]
+            invalid_checksums += track_validation[1]
+        return missing_files, invalid_checksums

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -89,10 +89,17 @@ class Dataset(object):
         if download_items is None:
             download_items = self.remotes
 
+        # The list previus_remote_prints stores all the previously printed
+        # messages. This avoids printing the same message over and over for
+        # different remotes when multiple remotes are absent from download,
+        # e.g. in ikala
+        previous_remote_prints = []
         for remote_key in download_items:
             remote = self.remotes[remote_key]
             if isinstance(remote, str):
-                print(remote.format(self.data_home))
+                if remote not in previous_remote_prints:
+                    print(remote.format(self.data_home))
+                previous_remote_prints.append(remote)
                 continue
 
             if ".zip" in remote.url:

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -120,10 +120,6 @@ class Dataset(object):
         with open(self.index_path) as f:
             return json.load(f)
 
-    @staticmethod
-    def parse_track_id(self):
-        return {}
-
     def track_ids(self):
         return list(self.index.keys())
 

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -79,7 +79,7 @@ class Dataset(object):
         for remote_key in download_items:
             remote = self.remotes[remote_key]
             if isinstance(remote, str):
-                print(remote)
+                print(remote.format(data_home))
                 continue
 
             if ".zip" in remote.url:

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -59,11 +59,15 @@ class Dataset(object):
         print("========== BibTeX ==========")
         print(self.bibtex)
 
-    def download(self, force_overwrite=False, cleanup=False):
+    def download(self, force_overwrite=False, cleanup=False, download_items=None):
         if not os.path.exists(self.data_home):
             os.makedirs(self.data_home, exist_ok=True)
 
-        for remote_key in self.remotes:
+        # By default, download all remotes
+        if download_items is None:
+            download_items = self.remotes
+
+        for remote_key in download_items:
             remote = self.remotes[remote_key]
             if ".zip" in remote.url:
                 download_utils.download_zip_file(

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -30,9 +30,12 @@ class Dataset(object):
             track_metadata = {}
         track_index = self.index[track_id].copy()
         for track_key in self.index[track_id]:
-            track_index[track_key][0] = os.path.join(
-                self.data_home, track_index[track_key][0]
-            )
+            if track_index[track_key][0] is not None:
+                track_index[track_key][0] = os.path.join(
+                    self.data_home, track_index[track_key][0]
+                )
+            else:
+                del track_index[track_key]
         return self.Track2(track_index, track_metadata)
 
     @property

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -68,6 +68,7 @@ class Dataset(object):
             print("\n".join(self.bibtex.values()))
 
     def download(self, force_overwrite=False, cleanup=False, download_items=None):
+        # TODO: perhaps find a shorter kwarg name than "download_items"?
         if not os.path.exists(self.data_home):
             os.makedirs(self.data_home, exist_ok=True)
 
@@ -77,6 +78,10 @@ class Dataset(object):
 
         for remote_key in download_items:
             remote = self.remotes[remote_key]
+            if isinstance(remote, str):
+                print(remote)
+                continue
+
             if ".zip" in remote.url:
                 download_utils.download_zip_file(
                     remote, self.data_home, force_overwrite, cleanup

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -1,8 +1,9 @@
 import jams
 import json
 import os
-import tqdm
+import random
 import re
+import tqdm
 
 from mirdata import download_utils
 from mirdata import utils
@@ -54,6 +55,9 @@ class Dataset(object):
     def metadata(self):
         metadata_index = self.Track2.load_metadata(self.data_home)
         return metadata_index
+
+    def choice(self):
+        return self[random.choice(self.track_ids())]
 
     def cite(self):
         print("========== BibTeX ==========")

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -14,8 +14,7 @@ class Dataset(object):
         self.name = module.name
         self.bibtex = module.bibtex
         self.remotes = module.remotes
-        self.load_metadata = module.load_metadata
-        self.load_track = module.load_track
+        self.Track2 = module.Track2
         self.readme = module.__doc__
         self.module_path = module.__file__
         if data_home is None:
@@ -30,7 +29,7 @@ class Dataset(object):
             track_index[track_key][0] = os.path.join(
                 self.data_home, track_index[track_key][0]
             )
-        return track2.Track2(self.load_track, track_metadata, track_index)
+        return self.Track2(track_index, track_metadata)
 
     @property
     def dataset_default_path(self):
@@ -50,7 +49,7 @@ class Dataset(object):
 
     @utils.cached_property
     def metadata(self):
-        metadata_index = self.load_metadata(self.data_home)
+        metadata_index = self.Track2.load_metadata(self.data_home)
         metadata_index['data_home'] = self.data_home
         return metadata_index
 

--- a/mirdata/dataset.py
+++ b/mirdata/dataset.py
@@ -23,7 +23,10 @@ class Dataset(object):
             self.data_home = data_home
 
     def __getitem__(self, track_id):
-        track_metadata = self.metadata[track_id]
+        if track_id in self.metadata:
+            track_metadata = self.metadata[track_id]
+        else:
+            track_metadata = {}
         track_index = self.index[track_id].copy()
         for track_key in self.index[track_id]:
             track_index[track_key][0] = os.path.join(
@@ -50,7 +53,6 @@ class Dataset(object):
     @utils.cached_property
     def metadata(self):
         metadata_index = self.Track2.load_metadata(self.data_home)
-        metadata_index['data_home'] = self.data_home
         return metadata_index
 
     def cite(self):

--- a/mirdata/guitarset.py
+++ b/mirdata/guitarset.py
@@ -566,5 +566,5 @@ class Track2(track2.Track2):
             "mode": title_list[2],
             "player_id": title_list[0],
             "tempo": float(tempo),
-            "style":  _STYLE_DICT[style[:-1]],
+            "style": _STYLE_DICT[style[:-1]],
         }

--- a/mirdata/guitarset.py
+++ b/mirdata/guitarset.py
@@ -477,16 +477,6 @@ remotes = {
 
 
 class Track2(track2.Track2):
-    def __init__(self, track_index, track_metadata):
-        super().__init__(track_index, track_metadata)
-        track_id = self.jams.file_metadata.title
-        title_list = track_id.split('_')  # [PID, S-T-K, mode, rec_mode]
-        style, tempo, _ = title_list[1].split('-')  # [style, tempo, key]
-        self.player_id = title_list[0]
-        self.mode = title_list[2]
-        self.tempo = float(tempo)
-        self.style = _STYLE_DICT[style[:-1]]
-
     @property
     def audio_hex(self):
         """(np.ndarray, float): raw hexaphonic audio signal, sample rate"""
@@ -567,3 +557,14 @@ class Track2(track2.Track2):
             string_f0s = utils.F0Data(times, frequencies, np.ones_like(times))
             contours[_GUITAR_STRINGS[i]] = string_f0s
         return contours
+
+    @staticmethod
+    def parse_track_id(track_id):
+        title_list = track_id.split('_')  # [PID, S-T-K, mode, rec_mode]
+        style, tempo, _ = title_list[1].split('-')  # [style, tempo, key]
+        return {
+            "mode": title_list[2],
+            "player_id": title_list[0],
+            "tempo": float(tempo),
+            "style":  _STYLE_DICT[style[:-1]],
+        }

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -365,7 +365,9 @@ remotes = {
 }
 
 for remote_key in ["audio", "lyrics", "pitch"]:
-    remotes[remote_key] = """
+    remotes[
+        remote_key
+    ] = """
         Unfortunately the iKala dataset is not available for download.
         If you have the iKala dataset, place the contents into a folder called
         iKala with the following structure:

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -30,7 +30,7 @@ import os
 
 from mirdata import download_utils
 from mirdata import jams_utils
-from mirdata import track
+from mirdata import track, track2
 from mirdata import utils
 
 DATASET_DIR = "Medley-solos-DB"
@@ -235,3 +235,57 @@ In Proceedings of the 16th International Society for Music Information Retrieval
 }
 """
     print(cite_data)
+
+
+name = "Medley-solos-DB"
+
+bibtex = """@inproceedings{lostanlen2019ismir,
+    title={Deep Convolutional Networks in the Pitch Spiral for Musical Instrument Recognition},
+    author={Lostanlen, Vincent and Cella, Carmine Emanuele},
+    booktitle={International Society of Music Information Retrieval (ISMIR)},
+    year={2016}
+}"""
+
+remotes = {
+    "annotation": download_utils.RemoteFileMetadata(
+        filename="Medley-solos-DB_metadata.csv",
+        url="https://zenodo.org/record/3464194/files/Medley-solos-DB_metadata.csv?download=1",
+        checksum="fda6a589c56785f2195c9227809c521a",
+        destination_dir="annotation",
+    ),
+    "audio": download_utils.RemoteFileMetadata(
+        filename="Medley-solos-DB.tar.gz",
+        url="https://zenodo.org/record/3464194/files/Medley-solos-DB.tar.gz?download=1",
+        checksum="f5facf398793ef5c1f80c013afdf3e5f",
+        destination_dir="audio",
+    ),
+}
+
+
+class Track2(track2.Track2):
+    def __init__(self, track_index, track_metadata):
+        super().__init__(track_index, track_metadata)
+
+    @utils.cached_property
+    def duration(self):
+        """(number): duration of the file in seconds"""
+        return 65536 / 22050
+
+    @staticmethod
+    def load_metadata(data_home):
+        metadata_path = os.path.join(
+            data_home, "annotation", "Medley-solos-DB_metadata.csv"
+        )
+        metadata_index = {}
+        with open(metadata_path, "r") as fhandle:
+            csv_reader = csv.reader(fhandle, delimiter=",")
+            next(csv_reader)
+            for row in csv_reader:
+                subset, instrument_str, instrument_id, song_id, track_id = row
+                metadata_index[str(track_id)] = {
+                    "subset": str(subset),
+                    "instrument": str(instrument_str),
+                    "instrument_id": int(instrument_id),
+                    "song_id": int(song_id),
+                }
+        return metadata_index

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -374,9 +374,6 @@ remotes = {
 
 
 class Track2(track2.Track2):
-    def __init__(self, track_id, track_metadata):
-        super().__init__(track_id, track_metadata)
-
     @staticmethod
     def load_metadata(data_home):
         predominant_inst_path = os.path.join(

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -429,7 +429,7 @@ def load_metadata(data_home):
     return metadata_index
 
 
-def load_track(self, track_metadata, track_paths):
+def load_track(self, track_paths, track_metadata):
     # Store track paths
     self.melody_path = track_paths['melody']
     self.audio_path_mono = track_paths['audio_mono']

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -427,6 +427,15 @@ bibtex = """@inproceedings{goto2002rwc,
 }"""
 
 remotes = {
+    "audio": """
+        Unfortunately the audio files of the RWC-Jazz dataset are not available
+        for download. If you have the RWC-Classical dataset, place the contents into a
+        folder called RWC-Classical with the following structure:
+            > RWC-Classical/
+                > annotations/
+                > audio/rwc-c-m0i with i in [1 .. 6]
+                > metadata-master/
+        and copy the RWC-Classical folder to {}""",
     "metadata": download_utils.RemoteFileMetadata(
         filename='rwc-c.csv',
         url='https://github.com/magdalenafuentes/metadata/archive/master.zip',

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -451,33 +451,13 @@ remotes = {
 class Track2(track2.Track2):
     @utils.cached_property
     def beats(self):
-        beat_times = []  # timestamps of beat interval beginnings
-        beat_positions = []  # beat position inside the bar
-        with open(self.track_index["beats"][0], 'r') as fhandle:
-            reader = csv.reader(fhandle, delimiter='\t')
-            for line in reader:
-                beat_times.append(float(line[0]) / 100.0)
-                beat_positions.append(int(line[2]))
-
-        beat_positions, beat_times = _position_in_bar(
-            np.array(beat_positions), np.array(beat_times)
-        )
-        return utils.BeatData(beat_times, beat_positions.astype(int))
+        """BeatData: human-labeled beat data"""
+        return load_beats(self.track_index["beats"][0])
 
     @utils.cached_property
     def sections(self):
-        begs = []  # timestamps of section beginnings
-        ends = []  # timestamps of section endings
-        secs = []  # section labels
-
-        with open(self.track_index["sections"][0], 'r') as fhandle:
-            reader = csv.reader(fhandle, delimiter='\t')
-            for line in reader:
-                begs.append(float(line[0]) / 100.0)
-                ends.append(float(line[1]) / 100.0)
-                secs.append(line[2])
-
-        return utils.SectionData(np.array([begs, ends]).T, secs)
+        """SectionData: human labeled section annotations"""
+        return load_sections(self.track_index["sections"][0])
 
     @staticmethod
     def load_metadata(data_home):

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -449,9 +449,6 @@ remotes = {
 
 
 class Track2(track2.Track2):
-    def __init__(self, track_id, track_metadata):
-        super().__init__(track_id, track_metadata)
-
     @utils.cached_property
     def beats(self):
         beat_times = []  # timestamps of beat interval beginnings

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -464,6 +464,21 @@ class Track2(track2.Track2):
         )
         return utils.BeatData(beat_times, beat_positions.astype(int))
 
+    @utils.cached_property
+    def sections(self):
+        begs = []  # timestamps of section beginnings
+        ends = []  # timestamps of section endings
+        secs = []  # section labels
+
+        with open(self.track_index["sections"][0], 'r') as fhandle:
+            reader = csv.reader(fhandle, delimiter='\t')
+            for line in reader:
+                begs.append(float(line[0]) / 100.0)
+                ends.append(float(line[1]) / 100.0)
+                secs.append(line[2])
+
+        return utils.SectionData(np.array([begs, ends]).T, secs)
+
     @staticmethod
     def load_metadata(data_home):
         metadata_path = os.path.join(data_home, 'metadata-master', 'rwc-c.csv')

--- a/mirdata/rwc_jazz.py
+++ b/mirdata/rwc_jazz.py
@@ -317,6 +317,15 @@ bibtex = """@inproceedings{goto2002rwc,
 }"""
 
 remotes = {
+    "audio": """
+        Unfortunately the audio files of the RWC-Jazz dataset are not available
+        for download. If you have the RWC-Jazz dataset, place the contents into a
+        folder called RWC-Jazz with the following structure:
+            > RWC-Jazz/
+                > annotations/
+                > audio/rwc-j-m0i with i in [1 .. 4]
+                > metadata-master/
+        and copy the RWC-Jazz folder to {}""",
     "metadata": download_utils.RemoteFileMetadata(
         filename='rwc-j.csv',
         url='https://github.com/magdalenafuentes/metadata/archive/master.zip',

--- a/mirdata/rwc_popular.py
+++ b/mirdata/rwc_popular.py
@@ -451,8 +451,7 @@ folder called RWC-Popular with the following structure:
         > annotations/
         > audio/rwc-p-m0i with i in [1 .. 7]
         > metadata-master/
-and copy the RWC-Popular folder to your "data_home" folder
-    """,
+and copy the RWC-Popular folder to {}""",
     "metadata": download_utils.RemoteFileMetadata(
         filename='rwc-p.csv',
         url='https://github.com/magdalenafuentes/metadata/archive/master.zip',

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+"""track object utility functions
+"""
+
+import jams
+import librosa
+import types
+
+from mirdata import utils
+
+MAX_STR_LEN = 100
+
+
+class Track2(object):
+    def __init__(self, load_track, track_metadata, track_index):
+        self.load_track = load_track
+        self.track_index = track_index
+        track_paths = {
+            track_key: track_index[track_key][0] for track_key in track_index
+        }
+        self.load_track(self, track_metadata, track_paths)
+        if not hasattr(self, "duration"):
+            self.duration = self.estimate_duration()
+        self.jam = self.to_jams()
+
+    def __repr__(self):
+        properties = [v for v in dir(self.__class__) if not v.startswith('_')]
+        attributes = [
+            v for v in dir(self) if not v.startswith('_') and v not in properties
+        ]
+
+        repr_str = "Track(\n"
+
+        for attr in attributes:
+            val = getattr(self, attr)
+            if isinstance(val, str):
+                if len(val) > MAX_STR_LEN:
+                    val = '...{}'.format(val[-MAX_STR_LEN:])
+                val = '"{}"'.format(val)
+            repr_str += "  {}={},\n".format(attr, val)
+
+        for prop in properties:
+            val = getattr(self.__class__, prop)
+            if isinstance(val, types.FunctionType):
+                continue
+
+            if val.__doc__ is None:
+                raise ValueError("{} has no documentation".format(prop))
+
+            val_type_str = val.__doc__.split(':')[0]
+            repr_str += "  {}: {},\n".format(prop, val_type_str)
+
+        repr_str += ")"
+        return repr_str
+
+    def estimate_duration(self):
+        if hasattr(self, "audio_path") and os.path.exists(self.audio_path):
+            return librosa.get_duration(filename=self.audio_path)
+        if hasattr(self, "audio_path_mono") and os.path.exists(self.audio_path_mono):
+            return librosa.get_duration(filename=self.audio_path_mono)
+        if hasattr(self, "beats"):
+            return self.beats.beat_times[-1]
+        return 0
+
+    def to_jams(self):
+        """Jams: the track's data in jams format"""
+        # Initialize top-level JAMS object
+        jam = jams.JAMS()
+
+        # Encode duration in seconds
+        jam.file_metadata.duration = self.duration
+
+        # Encode annotation metadata
+        ann_meta = jams.AnnotationMetadata(data_source='mirdata')
+
+        # Encode beats
+        if hasattr(self, "beats"):
+            ann = jams.Annotation(namespace='beat')
+            beats = self.beats
+            ann.annotation_metadata = ann_meta
+            for t, p in zip(beats.beat_times, beats.beat_positions):
+                ann.append(time=t, duration=0.0, value=p)
+            jam.annotations.append(ann)
+
+        return jam
+
+    def validate(self):
+        missing_files = []
+        invalid_checksums = []
+        for track_tuple in self.track_index.values():
+            track_path, checksum = track_tuple
+            # validate that the file exists on disk
+            if not os.path.exists(track_path):
+                missing_files.append(track_path)
+            # validate that the checksum matches
+            elif utils.md5(track_path) != checksum:
+                invalid_checksums.append(track_path)
+        return missing_files, invalid_checksums
+
+    @property
+    def audio_mono(self):
+        """(np.ndarray, float): mono audio signal, sample rate"""
+        return librosa.load(self.audio_path_mono, sr=None, mono=True)
+
+    @property
+    def audio_stereo(self):
+        """(np.ndarray, float): stereo audio signal, sample rate"""
+        return librosa.load(self.audio_path_stereo, sr=None, mono=False)
+
+    def to_jams(self):
+        raise NotImplementedError

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -74,7 +74,7 @@ class Track2(object):
         else:
             raise AttributeError("Track object has no attribute 'audio'")
 
-    @utils.property
+    @property
     def duration(self):
         """(float): estimated duration of the track in seconds"""
         if "duration" in self.track_metadata:

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -15,7 +15,6 @@ MAX_STR_LEN = 100
 class Track2(object):
     def __init__(self, track_index, track_metadata):
         self.track_index = track_index
-        self.track_metadata = track_metadata
         for key in track_metadata:
             self.__dict__[key] = track_metadata[key]
         if hasattr(self, "jams"):

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -71,7 +71,29 @@ class Track2(object):
         return 0.0
 
     def from_jams(self):
+        # Duration
         self.duration = self.jams.file_metadata.duration
+
+        # Beats
+        jam_beats = self.jams.search(namespace='beat_position')
+        if len(jam_beats) > 0 and not hasattr(self, "beats"):
+            beat_ann = jam_beats[0]
+            times, values = beat_ann.to_event_values()
+            positions = [int(v['position']) for v in values]
+            self.beats = utils.BeatData(times, positions)
+
+        # Chords
+        jam_chords = self.jams.search(namespace='chord')
+        if len(jam_chords) > 0 and not hasattr(self, "chords"):
+            chord_ann = jam_chords[0]
+            self.chords = utils.ChordData(*chord_ann.to_interval_values())
+
+        # Keys
+        jam_keys = self.jams.search(namespace='key_mode')
+        if len(jam_keys) > 0 and not hasattr(self, "key_mode"):
+            key_ann = jam_keys[0]
+            intervals, values = key_ann.to_interval_values()
+            self.key_mode = utils.KeyData(intervals[:, 0], intervals[:, 1], values)
 
     @staticmethod
     def load_metadata(data_home):

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -13,13 +13,21 @@ MAX_STR_LEN = 100
 
 
 class Track2(object):
-    def __init__(self, track_index, track_metadata):
+    # TODO: bikeshed the naming of the kwarg flag196
+    def __init__(self, track_index, track_metadata, flag196="error"):
         self.track_index = track_index
         self.track_metadata = track_metadata
         for key in track_metadata:
             self.__dict__[key] = track_metadata[key]
         if "jams" in track_index:
-            self.jams = jams.load(track_index["jams"][0])
+            try:
+                self.jams = jams.load(track_index["jams"][0])
+            except FileNotFoundError as file_not_found_error:
+                # Failsafe mode
+                if flag196 == "pass":
+                    pass
+                else:
+                    raise file_not_found_error
         if hasattr(self, "jams"):
             self.from_jams()
 

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -73,7 +73,9 @@ class Track2(object):
             return self.track_metadata["duration"]
         if "audio" in self.track_index and os.path.exists(self.track_index["audio"][0]):
             return librosa.get_duration(filename=self.track_index["audio"][0])
-        elif "audio_mono" in self.track_index and os.path.exists(self.track_index["audio_mono"][0]):
+        elif "audio_mono" in self.track_index and os.path.exists(
+            self.track_index["audio_mono"][0]
+        ):
             return librosa.get_duration(filename=self.track_index["audio_mono"][0])
         elif hasattr(self, "beats"):
             return self.beats.beat_times[-1]

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -74,7 +74,7 @@ class Track2(object):
         else:
             raise AttributeError("Track object has no attribute 'audio'")
 
-    @utils.cached_property
+    @utils.property
     def duration(self):
         """(float): estimated duration of the track in seconds"""
         if "duration" in self.track_metadata:

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -74,21 +74,6 @@ class Track2(object):
         else:
             raise AttributeError("Track object has no attribute 'audio'")
 
-    @property
-    def duration(self):
-        """(float): estimated duration of the track in seconds"""
-        if "duration" in self.track_metadata:
-            return self.track_metadata["duration"]
-        if "audio" in self.track_index and os.path.exists(self.track_index["audio"][0]):
-            return librosa.get_duration(filename=self.track_index["audio"][0])
-        elif "audio_mono" in self.track_index and os.path.exists(
-            self.track_index["audio_mono"][0]
-        ):
-            return librosa.get_duration(filename=self.track_index["audio_mono"][0])
-        elif hasattr(self, "beats"):
-            return self.beats.beat_times[-1]
-        return 0.0
-
     def from_jams(self):
         # Duration
         self.duration = self.jams.file_metadata.duration
@@ -122,7 +107,7 @@ class Track2(object):
     def parse_track_id(self):
         return {}
 
-    def to_jams(self):
+    def to_jams(duration, self):
         """Jams: the track's data in jams format"""
         # If the JAMS object is natively provided, simply return it
         if hasattr(self, "jams"):
@@ -132,7 +117,7 @@ class Track2(object):
         jam = jams.JAMS()
 
         # Encode duration in seconds
-        jam.file_metadata.duration = self.duration
+        jam.file_metadata.duration = duration
 
         # Encode title and artist if available
         if hasattr(self, "title"):

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -118,6 +118,10 @@ class Track2(object):
     def load_metadata(data_home):
         return {}
 
+    @staticmethod
+    def parse_track_id(self):
+        return {}
+
     def to_jams(self):
         """Jams: the track's data in jams format"""
         # If the JAMS object is natively provided, simply return it

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -17,6 +17,8 @@ class Track2(object):
         self.track_index = track_index
         for key in track_metadata:
             self.__dict__[key] = track_metadata[key]
+        if "jams" in track_index:
+            self.jams = jams.load(track_index["jams"][0])
         if hasattr(self, "jams"):
             self.from_jams()
 

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -4,6 +4,7 @@
 
 import jams
 import librosa
+import os
 import types
 
 from mirdata import utils
@@ -106,6 +107,3 @@ class Track2(object):
     def audio_stereo(self):
         """(np.ndarray, float): stereo audio signal, sample rate"""
         return librosa.load(self.audio_path_stereo, sr=None, mono=False)
-
-    def to_jams(self):
-        raise NotImplementedError

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -18,7 +18,7 @@ class Track2(object):
         self.track_metadata = track_metadata
         for key in track_metadata:
             self.__dict__[key] = track_metadata[key]
-        if "jams" in track_index:
+        if hasattr(self, "jams"):
             self.from_jams()
 
     def __repr__(self):
@@ -61,17 +61,17 @@ class Track2(object):
 
     @utils.cached_property
     def duration(self):
-        """Estimated duration of the track in seconds."""
+        """(float): estimated duration of the track in seconds"""
         if "audio" in self.track_index:
             return librosa.get_duration(filename=self.track_index["audio"][0])
         elif "audio_mono" in self.track_index:
             return librosa.get_duration(filename=self.track_index["audio_mono"][0])
-        if hasattr(self, "beats"):
+        elif hasattr(self, "beats"):
             return self.beats.beat_times[-1]
         return 0.0
 
     def from_jams(self):
-        pass
+        self.duration = self.jams.file_metadata.duration
 
     @staticmethod
     def load_metadata(data_home):
@@ -79,7 +79,11 @@ class Track2(object):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        # Initialize top-level JAMS object
+        # If the JAMS object is natively provided, simply return it
+        if hasattr(self, "jams"):
+            return self.jams
+
+        # Otherwise, initialize a top-level JAMS object
         jam = jams.JAMS()
 
         # Encode duration in seconds

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -71,9 +71,9 @@ class Track2(object):
         """(float): estimated duration of the track in seconds"""
         if "duration" in self.track_metadata:
             return self.track_metadata["duration"]
-        if "audio" in self.track_index:
+        if "audio" in self.track_index and os.path.exists(self.track_index["audio"][0]):
             return librosa.get_duration(filename=self.track_index["audio"][0])
-        elif "audio_mono" in self.track_index:
+        elif "audio_mono" in self.track_index and os.path.exists(self.track_index["audio_mono"][0]):
             return librosa.get_duration(filename=self.track_index["audio_mono"][0])
         elif hasattr(self, "beats"):
             return self.beats.beat_times[-1]
@@ -119,6 +119,12 @@ class Track2(object):
 
         # Encode duration in seconds
         jam.file_metadata.duration = self.duration
+
+        # Encode title and artist if available
+        if hasattr(self, "title"):
+            jam.file_metadata.title = self.title
+        if hasattr(self, "artist"):
+            jam.file_metadata.artist = self.artist
 
         # Encode annotation metadata
         ann_meta = jams.AnnotationMetadata(data_source='mirdata')

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -23,9 +23,14 @@ class Track2(object):
             self.from_jams()
 
     def __repr__(self):
-        properties = [v for v in dir(self.__class__) if not v.startswith('_')]
+        exclude = ["from_jams", "jams", "load_metadata", "to_jams", "validate"]
+        properties = [
+            v for v in dir(self.__class__) if not v.startswith('_') and v not in exclude
+        ]
         attributes = [
-            v for v in dir(self) if not v.startswith('_') and v not in properties
+            v
+            for v in dir(self)
+            if not v.startswith('_') and v not in properties and v not in exclude
         ]
 
         repr_str = "Track(\n"

--- a/mirdata/track2.py
+++ b/mirdata/track2.py
@@ -19,7 +19,7 @@ class Track2(object):
         track_paths = {
             track_key: track_index[track_key][0] for track_key in track_index
         }
-        self.load_track(self, track_metadata, track_paths)
+        self.load_track(self, track_paths, track_metadata)
         if not hasattr(self, "duration"):
             self.duration = self.estimate_duration()
         self.jam = self.to_jams()
@@ -97,6 +97,11 @@ class Track2(object):
             elif utils.md5(track_path) != checksum:
                 invalid_checksums.append(track_path)
         return missing_files, invalid_checksums
+
+    @property
+    def audio(self):
+        """(np.ndarray, float): mono or stereo audio signal, sample rate"""
+        return librosa.load(self.audio_path, sr=None)
 
     @property
     def audio_mono(self):


### PR DESCRIPTION
Reduce module-level code to the bare essentials:
1. README
2. official name
3. BibTex reference(s)
4. download remotes
5. cached properties
6. metadata parsing (optional)

Closes #196, closes #197, closes #210, closes #217 
Offers a development path towards closing #81, #153, #176, #184, and #196

New features:
* modules no longer have a `to_jams` implementation. The `to_jams` method is shared across modules, and is implemented in the parent class. 
* metadata is now a cached property of `Dataset`. I re-used the implementation of `LargeData` so that there's no loss in performance. Dataset construction is still very fast.
* BibTeX citation is not only printable via `cite()`, but also accessible as a string via `dataset.bibtex`
* The `Dataset` class overloads `__getitem__`, so it's still possible to load tracks one by one. I figured that this would be easier to use for newcomers than for them to learn about the `Track` constructor
* `load_index()` now turns the index paths into machine-specific absolute paths. As a result, there is no need to store data_home in the Track object anymore.
* a new function `dataset.choice()` picks a Track in the Dataset uniformly at random and loads it.
* dataset.download now has a verbose flag and has an opt-in for `remotes`. I called the kwarg `download_items`, in accordance with #216, but the kwarg seems a bit long in my opinion. Perhaps we can find a shorter name? I'll defer to @magdalenafuentes for this decision.
* validate is now possible both at the Track level and the Dataset level. Ties down with #213
* new utility function `from_jams` which converts a JAMS Annotation into mirdata namedtuples: BeatData, ChordData, KeyData, SectionData. 
* "fail-safe" mode allows to load some metadata of a Dataset before anything is downloaded (not event a dataset-wide CSV annotation file). This is done via a static method named `parse_track_id`. I am using this in Guitarset. This ties down with #128 and resolves #196 quite nicely. (we can error / warn / pass if metadata is not found).

Demo: 
```
import mirdata.dataset
gset = mirdata.dataset.Dataset(mirdata.guitarset)

# Fail-safe load. This flag will be called differently eventually. I'll let you decide
gset.load(flag196="pass")

# We haven't downloaded anything yet, but we already have some metadata, obtained by parsing track_ids from the JSON index.
print(gset.choice())

# Now download the annotation.
gset.download(download_items=["annotation"])

# Now we have beats, keys, and chords. This is done with the `from_jams` utility
print(gset.choice())
```

Worth noting that these new features come alongside a ~4x reduction in line count.
(although i haven't removed anything from the previous implementation because i want unit tests to keep working)

The new class is called `track2.Track2` for the time being

Covered loaders:
- [x] `beatles`
- [x] `gtzan_genre`
- [x] `guitarset`
- [x]  `ikala`
- [x] `medley_solos_db`
- [ ] `medleydb_melody`
- [ ] `medleydb_pitch`
- [x] `orchset`
- [x] `rwc_classical`
- [x] `rwc_jazz`
- [x] `rwc_popular`
- [x] `salami`
- [ ] `tinysol`

(i'm not counting DALI because DALI is broken at the moment)

- [ ] ensure backwards compatibility
- [ ] ensure that test coverage increases
- [ ] ensure that the LOC net count is negative
- [ ] bikeshed the name of the "failsafe" flag (issue #196). I called it `flag196` temporarily

Let me know your thoughts!