### PR TITLE
bugfix dali.download(), implement dali.Track.to_jams()

### DIFF
--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -41,6 +41,13 @@ import mirdata.utils as utils
 
 DATASET_DIR = 'DALI'
 
+METADATA_REMOTE = download_utils.RemoteFileMetadata(
+    filename='dali_metadata.json',
+    url='https://github.com/gabolsgabs/DALI/blob/master/code/DALI/files/dali_v1_metadata.json',
+    checksum='2501a50825564583b6a1b4c0386887f1',
+    destination_dir='.',
+)
+
 
 def _load_metadata(data_home):
     metadata_path = os.path.join(data_home, os.path.join('dali_metadata.json'))
@@ -196,6 +203,8 @@ def download(data_home=None):
 
     if data_home is None:
         data_home = utils.get_default_dataset_path(DATASET_DIR)
+
+    download_utils.downloader(data_home, file_downloads=[METADATA_REMOTE])
 
     print(
         """

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -172,11 +172,12 @@ class Track(track.Track):
         """(np.ndarray, float): audio signal, sample rate"""
         return load_audio(self.audio_path)
 
-    def to_jams(self, duration):
+    def to_jams(self):
         """Jams: the track's data in jams format"""
         # Load metadata
         metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = duration
+        y, sr = self.audio
+        metadata['duration'] = librosa.get_duration(y=y, sr=sr)
         return jams_utils.jams_converter(
             lyrics_data=[(self.words, None)], metadata=metadata
         )

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -172,16 +172,14 @@ class Track(track.Track):
         """(np.ndarray, float): audio signal, sample rate"""
         return load_audio(self.audio_path)
 
-    def to_jams(duration, self):
+    def to_jams(self, duration):
         """Jams: the track's data in jams format"""
+        # Load metadata
+        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
+        metadata['duration'] = duration
         return jams_utils.jams_converter(
-            lyrics_data=[(self.lyrics, None)],
-            metadata={
-                'artist': self.artist,
-                'release': self.album,
-                'track_id': self.track_id,
-                'duration': duration,
-            },
+            lyrics_data=[(self.words, None)],
+            metadata=metadata,
         )
 
 

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -43,8 +43,8 @@ DATASET_DIR = 'DALI'
 
 METADATA_REMOTE = download_utils.RemoteFileMetadata(
     filename='dali_metadata.json',
-    url='https://github.com/gabolsgabs/DALI/blob/master/code/DALI/files/dali_v1_metadata.json',
-    checksum='2501a50825564583b6a1b4c0386887f1',
+    url='https://raw.githubusercontent.com/gabolsgabs/DALI/master/code/DALI/files/dali_v1_metadata.json',
+    checksum='40af5059e7aa97f81b2654758094d24b',
     destination_dir='.',
 )
 
@@ -196,7 +196,7 @@ def load_audio(audio_path):
     return librosa.load(audio_path, sr=None, mono=True)
 
 
-def download(data_home=None):
+def download(data_home=None, force_overwrite=False):
     """DALI is not available for downloading directly.
     This function prints a helper message to download DALI
     through zenodo.org.

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -178,10 +178,8 @@ class Track(track.Track):
         metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
         metadata['duration'] = duration
         return jams_utils.jams_converter(
-            lyrics_data=[(self.words, None)],
-            metadata=metadata,
+            lyrics_data=[(self.words, None)], metadata=metadata
         )
-
 
 
 def load_audio(audio_path):

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -181,11 +181,11 @@ class Track(track.Track):
         return jams_utils.jams_converter(
             lyrics_data=[
                 (self.words, 'word-aligned lyrics'),
-                (self.lines,  'line-aligned lyrics'),
+                (self.lines, 'line-aligned lyrics'),
                 (self.paragraphs, 'paragraph-aligned lyrics'),
             ],
             note_data=[(self.notes, 'annotated vocal notes')],
-            metadata=metadata
+            metadata=metadata,
         )
 
 

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -172,9 +172,18 @@ class Track(track.Track):
         """(np.ndarray, float): audio signal, sample rate"""
         return load_audio(self.audio_path)
 
-    def to_jams(self):
-        """(Not Implemented) Jams: the track's data in jams format"""
-        raise NotImplementedError
+    def to_jams(duration, self):
+        """Jams: the track's data in jams format"""
+        return jams_utils.jams_converter(
+            lyrics_data=[(self.lyrics, None)],
+            metadata={
+                'artist': self.artist,
+                'release': self.album,
+                'track_id': self.track_id,
+                'duration': duration,
+            },
+        )
+
 
 
 def load_audio(audio_path):

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -211,8 +211,8 @@ def download(data_home=None):
         {audio_path}
 
     """.format(
-            save_path=os.path.join(data_home, DATASET_DIR, 'annotatios'),
-            audio_path=os.path.join(data_home, DATASET_DIR, 'audio'),
+            save_path=os.path.join(data_home, 'annotations'),
+            audio_path=os.path.join(data_home, 'audio'),
         )
     )
 

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -179,7 +179,13 @@ class Track(track.Track):
         y, sr = self.audio
         metadata['duration'] = librosa.get_duration(y=y, sr=sr)
         return jams_utils.jams_converter(
-            lyrics_data=[(self.words, None)], metadata=metadata
+            lyrics_data=[
+                (self.words, 'word-aligned lyrics'),
+                (self.lines,  'line-aligned lyrics'),
+                (self.paragraphs, 'paragraph-aligned lyrics'),
+            ],
+            note_data=[(self.notes, 'annotated vocal notes')],
+            metadata=metadata
         )
 
 
@@ -210,10 +216,7 @@ def download(data_home=None, force_overwrite=False):
     if data_home is None:
         data_home = utils.get_default_dataset_path(DATASET_DIR)
 
-    download_utils.downloader(data_home, file_downloads=[METADATA_REMOTE])
-
-    print(
-        """
+    info_message = """
         To download this dataset, visit:
         https://zenodo.org/record/2577915 and request access.
 
@@ -224,11 +227,15 @@ def download(data_home=None, force_overwrite=False):
         Use the function dali_code.get_audio you can find at:
         https://github.com/gabolsgabs/DALI for getting the audio and place them at:
         {audio_path}
-
     """.format(
-            save_path=os.path.join(data_home, 'annotations'),
-            audio_path=os.path.join(data_home, 'audio'),
-        )
+        save_path=os.path.join(data_home, 'annotations'),
+        audio_path=os.path.join(data_home, 'audio'),
+    )
+    download_utils.downloader(
+        data_home,
+        file_downloads=[METADATA_REMOTE],
+        info_message=info_message,
+        force_overwrite=force_overwrite,
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -48,16 +48,15 @@ if __name__ == '__main__':
                 'testcontainers>=2.3',
                 'future==0.17.1',
                 'coveralls>=1.7.0',
-                'dali-dataset',
             ],
             'docs': [
-                'DALI-dataset>=1.0.0',
+                'dali-dataset==1.1',
                 'numpydoc',
                 'recommonmark',
                 'sphinx',
                 'sphinxcontrib-napoleon',
                 'sphinx_rtd_theme',
             ],
-            'dali': ['DALI-dataset>=1.0.0'],
+            'dali': ['dali-dataset==1.1'],
         },
     )

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -9,11 +9,11 @@ import pytest
 
 import mirdata
 import mirdata.track as track
-from tests.test_utils import DEFAULT_DATA_HOME
 
 DATASETS = [importlib.import_module("mirdata.{}".format(d)) for d in mirdata.__all__]
 CUSTOM_TEST_TRACKS = {
     'beatles': '0111',
+    'dali': '4b196e6c99574dd49ad00d56e132712b',
     'guitarset': '03_BN3-119-G_solo',
     'medley_solos_db': 'd07b1fc0-567d-52c2-fef4-239f31c9d40e',
     'medleydb_melody': 'MusicDelta_Beethoven',
@@ -23,6 +23,7 @@ CUSTOM_TEST_TRACKS = {
     'salami': '2',
     'tinysol': 'Fl-ord-C4-mf-N-T14d',
 }
+TOJAMS_NEEDS_DURATION = ["dali"]
 
 
 def test_cite():
@@ -67,7 +68,6 @@ def test_load_and_trackids():
 
 
 def test_track():
-    jams_temporary_exceptions = ['dali']
     data_home_dir = 'tests/resources/mir_datasets'
 
     for dataset in DATASETS:
@@ -92,10 +92,13 @@ def test_track():
 
         assert hasattr(track_test, 'to_jams')
 
-        if dataset_name not in jams_temporary_exceptions:
-            # Validate json schema
+        # Validate JSON schema
+        if dataset_name in TOJAMS_NEEDS_DURATION:
+            # we put a placeholder positive value as duration
+            jam = track_test.to_jams(duration=1.0)
+        else:
             jam = track_test.to_jams()
-            assert jam.validate()
+        assert jam.validate()
 
         # will fail if something goes wrong with __repr__
         print(track_test)

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -24,7 +24,6 @@ CUSTOM_TEST_TRACKS = {
     'salami': '2',
     'tinysol': 'Fl-ord-C4-mf-N-T14d',
 }
-TOJAMS_NEEDS_DURATION = ["dali"]
 
 
 def test_cite():
@@ -96,7 +95,7 @@ def test_track():
         # Validate JSON schema
         if dataset_name in TOJAMS_NEEDS_DURATION:
             # we put a placeholder positive value as duration
-            jam = track_test.to_jams(duration=1.0)
+            jam = track_test.to_jams()
         else:
             jam = track_test.to_jams()
         assert jam.validate()

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -93,11 +93,7 @@ def test_track():
         assert hasattr(track_test, 'to_jams')
 
         # Validate JSON schema
-        if dataset_name in TOJAMS_NEEDS_DURATION:
-            # we put a placeholder positive value as duration
-            jam = track_test.to_jams()
-        else:
-            jam = track_test.to_jams()
+        jam = track_test.to_jams()
         assert jam.validate()
 
         # will fail if something goes wrong with __repr__

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -9,6 +9,7 @@ import pytest
 
 import mirdata
 import mirdata.track as track
+from tests.test_utils import DEFAULT_DATA_HOME
 
 DATASETS = [importlib.import_module("mirdata.{}".format(d)) for d in mirdata.__all__]
 CUSTOM_TEST_TRACKS = {


### PR DESCRIPTION
closes #229 bug
closes #197 `NotImplementedError`

many thanks to @gabolsgabs for this update
triaged for v0.2

TODO:
- [x] implement `dali.Track.to_jams()`
- [x] restore dali module to `test_loaders.py`
- [x] style check
- [x] usability check