### PR TITLE
[RFC] move midi property to Track super class

### DIFF
--- a/mirdata/groove_midi.py
+++ b/mirdata/groove_midi.py
@@ -286,8 +286,6 @@ class Track(track.Track):
         self.midi_filename = self._track_metadata["midi_filename"]
         self.audio_filename = self._track_metadata["audio_filename"]
 
-        self.midi_path = os.path.join(self._data_home, self._track_paths["midi"][0])
-
         self.audio_path = utils.none_path_join(
             [self._data_home, self._track_paths["audio"][0]]
         )
@@ -322,11 +320,6 @@ class Track(track.Track):
             np.array(start_times), np.array(end_times), np.array(events)
         )
 
-    @property
-    def midi(self):
-        """(obj): prettyMIDI obj"""
-        return load_midi(self.midi_path)
-
     def to_jams(self):
         # Initialize top-level JAMS container
         return jams_utils.jams_converter(
@@ -349,19 +342,6 @@ def load_audio(audio_path):
 
     """
     return librosa.load(audio_path, sr=22050, mono=True)
-
-
-def load_midi(midi_path):
-    """Load a Groove MIDI midi file.
-
-    Args:
-        midi_path (str): path to midi file
-
-    Returns:
-        midi_data (obj): pretty_midi object
-
-    """
-    return pretty_midi.PrettyMIDI(midi_path)
 
 
 def download(data_home=None):

--- a/mirdata/track.py
+++ b/mirdata/track.py
@@ -2,6 +2,7 @@
 """track object utility functions
 """
 
+import os
 import pretty_midi
 import types
 

--- a/mirdata/track.py
+++ b/mirdata/track.py
@@ -2,7 +2,7 @@
 """track object utility functions
 """
 
-
+import pretty_midi
 import types
 
 MAX_STR_LEN = 100
@@ -38,6 +38,12 @@ class Track(object):
 
         repr_str += ")"
         return repr_str
+
+    @property
+    def midi(self):
+        """(obj): prettyMIDI obj"""
+        midi_path = os.path.join(self._data_home, self._track_paths["midi"][0])
+        return pretty_midi.PrettyMIDI(midi_path)
 
     def to_jams(self):
         raise NotImplementedError


### PR DESCRIPTION
just an idea; let me know what you think
in the spirit of #224, i propose to move Groove MIDI's `midi` property to the Track parent.
This is backwards compatible, has a negative LOC net count, and passes tests (at least on my machine).

The idea is that, if an index has a `track_path` indexed by the word `midi`, then we use `pretty_midi` to load it automatically. It generalizes the Groove MIDI pattern to potential future MIDI datasets.

Are you OK with this abstraction or is that already to much to assume about future datasets?
