### PR TITLE
Add local exhaustive dataset tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tests/resources/mir_datasets_full
 tests/data/output.wav
 *.DS_Store
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ If your dataset **is not fully downloadable** there are two extra steps you shou
 1. Contacting the mirdata organizers by opening an issue or PR so we can discuss how to proceed with the closed dataset.
 2. Show that the version used to create the checksum is the "canonical" one, either by getting the version from the dataset creator, or by verifying equivalence with several other copies of the dataset.
 
-To reduce friction, we will make commits on top of contributors pull requests by default unless they use the `please-do-not-edit` flag. 
+To reduce friction, we will make commits on top of contributors pull requests by default unless they use the `please-do-not-edit` flag.
 
 ### Dataset description:
 
@@ -382,3 +382,33 @@ Bibtex format citations/s here
   c. If the dataset has a metadata file, reduce the length to a few lines to make it trival to test.
 2. Test all of the dataset specific code, e.g. the public attributes of the Track object, the load functions and any other custom functions you wrote. See the ikala dataset tests (`tests/test_ikala.py`) for a reference.
 *Note that we have written automated tests for all loader's `cite`, `download`, `validate`, `load`, `track_ids` functions, as well as some basic edge cases of the `Track` object, so you don't need to write tests for these!*
+
+## Running your tests locally
+
+You can run all the tests locally by running:
+```
+pytest tests/ --local
+```
+The `--local` flag skips tests that are built for running on the remote testing environment.
+
+To run one specific test file:
+```
+pytest tests/test_ikala.py
+```
+
+Finally, there is one local test you should run, which we can't easily run in our testing environment.
+```
+pytest tests/test_full_dataset.py --local --dataset my_dataset
+```
+Where `my_dataset` is the name of the module of the dataset you added.
+
+This tests that your dataset downloads, validates, and loads properly for every track.
+This test takes a long time for some datasets :( but it's important.
+
+We've added one extra convenience flag for this test, for getting the tests running when the download is very slow:
+```
+pytest tests/test_full_dataset.py --local --dataset my_dataset --skip-download
+
+```
+which will skip the downloading step. Note that this is just for convenience during debugging - the tests should eventually
+all pass without this flag.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--local", action="store_true", default=False, help="run local tests")
+    parser.addoption("--dataset", type=str, default="", help="dataset to test locally")
+    parser.addoption("--skip-download", action="store_true", default=False, help="skip download step")
+
+
+# @pytest.fixture(scope='session')
+# def local(request):
+#     return request.config.getoption('--local')
+
+@pytest.fixture(scope='session')
+def skip_local(request):
+    if request.config.getoption('--local'):
+        pytest.skip()
+
+
+@pytest.fixture(scope='session')
+def skip_remote(request):
+    if not request.config.getoption('--local'):
+        pytest.skip()
+
+
+@pytest.fixture(scope='session')
+def test_dataset(request):
+    return request.config.getoption('--dataset')
+
+
+@pytest.fixture(scope='session')
+def skip_download(request):
+    return request.config.getoption('--skip-download')

--- a/tests/test_full_dataset.py
+++ b/tests/test_full_dataset.py
@@ -25,11 +25,6 @@ def data_home_dir(dataset):
 def test_download(skip_remote, dataset, data_home_dir, test_dataset, skip_download):
     assert test_dataset in mirdata.__all__
 
-    # dataset = importlib.import_module("mirdata.{}".format(test_dataset))
-
-    # # new directory to test download
-    # data_home_dir = os.path.join('tests/resources/mir_datasets_full', dataset.DATASET_DIR)
-
     # download the dataset
     if not skip_download:
         dataset.download(data_home=data_home_dir)

--- a/tests/test_full_dataset.py
+++ b/tests/test_full_dataset.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+This test takes a long time, but it makes sure that the datset can be locally downloaded,
+validated successfully, and loaded.
+"""
+import importlib
+from tests.test_utils import get_attributes_and_properties
+import os
+import pytest
+
+import mirdata
+
+
+@pytest.fixture()
+def dataset(test_dataset):
+    return importlib.import_module("mirdata.{}".format(test_dataset))
+
+@pytest.fixture()
+def data_home_dir(dataset):
+    return os.path.join('tests/resources/mir_datasets_full', dataset.DATASET_DIR)
+
+
+# This is magically skipped by the the remote fixture `skip_remote` in conftest.py
+# when tests are run without the --local flag
+def test_download(skip_remote, dataset, data_home_dir, test_dataset, skip_download):
+    assert test_dataset in mirdata.__all__
+
+    # dataset = importlib.import_module("mirdata.{}".format(test_dataset))
+
+    # # new directory to test download
+    # data_home_dir = os.path.join('tests/resources/mir_datasets_full', dataset.DATASET_DIR)
+
+    # download the dataset
+    if not skip_download:
+        dataset.download(data_home=data_home_dir)
+
+        print(
+            "If this dataset does not have openly downloadable data, " +
+            "follow the instructions printed by the download message and " +
+            "rerun this test."
+        )
+
+
+def test_validation(skip_remote, dataset, data_home_dir):
+    # run validation
+    missing_files, invalid_checksums = dataset.validate(data_home=data_home_dir, silence=True)
+
+    assert missing_files == {}
+    assert invalid_checksums == {}
+
+
+def test_load(skip_remote, dataset, data_home_dir):
+    # run load
+    all_data = dataset.load(data_home=data_home_dir)
+
+    assert isinstance(all_data, dict)
+
+    track_ids = dataset.track_ids()
+    assert set(track_ids) == set(all_data.keys())
+
+    #test that all attributes and properties can be called
+    for track_id in track_ids:
+        track = all_data[track_id]
+        track_data = get_attributes_and_properties(track)
+
+        for attr in track_data['attributes']:
+            ret = getattr(track, attr)
+
+        for prop in track_data['properties']:
+            ret = getattr(track, prop)
+
+        for cprop in track_data['cached_properties']:
+            ret = getattr(track, cprop)
+
+        jam = track.to_jams()
+        assert jam.validate()

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -43,7 +43,9 @@ def test_download():
         assert params['data_home'].default is None
 
 
-def test_validate():
+# This is magically skipped by the the remote fixture `skip_local` in conftest.py
+# when tests are run with the --local flag
+def test_validate(skip_local):
     for dataset in DATASETS:
         data_home = os.path.join('tests/resources/mir_datasets', dataset.DATASET_DIR)
         dataset.validate(data_home=data_home)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -140,5 +140,7 @@ def test_validator(mocker, mock_check_index, missing_files, invalid_checksums):
     mock_check_index.assert_called_once_with('foo', 'bar')
 
 
-def test_get_default_dataset_path():
+# This is magically skipped by the the remote fixture `skip_local` in conftest.py
+# when tests are run with the --local flag
+def test_get_default_dataset_path(skip_local):
     assert '/tmp/mir_datasets/data_home' == utils.get_default_dataset_path('data_home')


### PR DESCRIPTION
fixes #234

What changed:
* I've added `tests/test_full_dataset.py`, which downloads, validates and loads a dataset, and for each track object, calls all properties to make sure they are callable.
* we can now run pytest with an optional `--local` argument (in `tests/conftest.py`) which skips any tests that are built for the remote tests and always fail
* I've decorated a few of the existing tests to either skip when run remotely or skip when run locally, when it makes sense
* Updated documentation in `CONTRIBUTING.md` to explain how to use the `--local` flag and how to run the new full test.

Once this is merged, we should (ugh...) run this for every dataset and make sure there are no secret outstanding bugs.