### PR TITLE
fixes #226

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,9 +208,9 @@ class Track(track.Track):
             self._data_home, self._track_paths['annotation'][0])
 
         # -- if the user doesn't have a metadata file, load None
-        metadata = DATA.metadata(data_home)
-        if metadata is not None and track_id in metadata:
-            self.some_metadata = metadata[track_id]['some_metadata']
+        self._metadata = DATA.metadata(data_home)
+        if self._metadata is not None and track_id in self._metadata:
+            self.some_metadata = self._metadata[track_id]['some_metadata']
         else:
             self.some_metadata = None
 
@@ -237,10 +237,12 @@ class Track(track.Track):
     # -- object with the annotations.
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        return jams_utils.jams_convertrer(
+        return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             annotation_data=[(self.annotation, None)],
-            metadata=metadata},
+            metadata=self._metadata,
         )
+        # -- see the documentation for `jams_utils.jams_converter for all fields
 
 
 def load_audio(audio_path):

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -107,10 +107,7 @@ class Track(track.Track):
             section_data=[(self.sections, None)],
             chord_data=[(self.chords, None)],
             key_data=[(self.key, None)],
-            metadata={
-                'artist': 'The Beatles',
-                'title': self.title,
-            },
+            metadata={'artist': 'The Beatles', 'title': self.title},
         )
 
 

--- a/mirdata/beatles.py
+++ b/mirdata/beatles.py
@@ -102,6 +102,7 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
             chord_data=[(self.chords, None)],
@@ -109,7 +110,6 @@ class Track(track.Track):
             metadata={
                 'artist': 'The Beatles',
                 'title': self.title,
-                'duration': librosa.get_duration(self.audio[0], self.audio[1]),
             },
         )
 

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -181,7 +181,7 @@ class Track(track.Track):
                 (self.paragraphs, 'paragraph-aligned lyrics'),
             ],
             note_data=[(self.notes, 'annotated vocal notes')],
-            metadata=self._track_metadata
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/dali.py
+++ b/mirdata/dali.py
@@ -173,18 +173,15 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        # Load metadata
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        y, sr = self.audio
-        metadata['duration'] = librosa.get_duration(y=y, sr=sr)
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             lyrics_data=[
                 (self.words, 'word-aligned lyrics'),
                 (self.lines, 'line-aligned lyrics'),
                 (self.paragraphs, 'paragraph-aligned lyrics'),
             ],
             note_data=[(self.notes, 'annotated vocal notes')],
-            metadata=metadata,
+            metadata=self._track_metadata
         )
 
 

--- a/mirdata/ikala.py
+++ b/mirdata/ikala.py
@@ -135,6 +135,7 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             f0_data=[(self.f0, None)],
             lyrics_data=[(self.lyrics, None)],
             metadata={
@@ -142,7 +143,6 @@ class Track(track.Track):
                 'singer_id': self.singer_id,
                 'track_id': self.track_id,
                 'song_id': self.song_id,
-                'duration': librosa.get_duration(self.mix_audio[0], self.mix_audio[1]),
             },
         )
 

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -78,9 +78,9 @@ def jams_converter(
             duration = librosa.get_duration(filename=audio_path)
         else:
             raise OSError(
-                'jams conversion failed because the audio file ' +
-                'for this track cannot be found, and it is required' +
-                'to compute duration.'
+                'jams conversion failed because the audio file '
+                + 'for this track cannot be found, and it is required'
+                + 'to compute duration.'
             )
 
     # metadata
@@ -88,9 +88,9 @@ def jams_converter(
         for key in metadata:
             if key == 'duration' and duration is not None and metadata[key] != duration:
                 print(
-                    'Warning: duration provided in metadata does not' +
-                    'match the duration computed from the audio file.' +
-                    'Using the duration provided by the metadata.'
+                    'Warning: duration provided in metadata does not'
+                    + 'match the duration computed from the audio file.'
+                    + 'Using the duration provided by the metadata.'
                 )
 
             if metadata[key] is None:

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -3,10 +3,14 @@
 """
 
 import jams
+import librosa
+import os
+
 from mirdata import utils
 
 
 def jams_converter(
+    audio_path=None,
     beat_data=None,
     chord_data=None,
     note_data=None,
@@ -24,6 +28,11 @@ def jams_converter(
 
     Parameters
     ----------
+    audio_path (str or None):
+        A path to the corresponding audio file, or None. If provided,
+        the audio file will be read to compute the duration. If None,
+        'duration' must be a field in the metadata dictionary, or the
+        resulting jam object will not validate.
     beat_data (list or None):
         A list of tuples of (BeatData, str), where str describes the annotation (e.g. 'beats_1').
     chord_data (list or None):
@@ -62,13 +71,38 @@ def jams_converter(
 
     jam = jams.JAMS()
 
+    # duration
+    duration = None
+    if audio_path is not None:
+        if os.path.exists(audio_path):
+            duration = librosa.get_duration(filename=audio_path)
+        else:
+            raise OSError(
+                'jams conversion failed because the audio file ' +
+                'for this track cannot be found, and it is required' +
+                'to compute duration.'
+            )
+
     # metadata
     if metadata is not None:
         for key in metadata:
+            if key == 'duration' and duration is not None and metadata[key] != duration:
+                print(
+                    'Warning: duration provided in metadata does not' +
+                    'match the duration computed from the audio file.' +
+                    'Using the duration provided by the metadata.'
+                )
+
+            if metadata[key] is None:
+                continue
+
             if hasattr(jam.file_metadata, key):
                 setattr(jam.file_metadata, key, metadata[key])
             else:
                 setattr(jam.sandbox, key, metadata[key])
+
+    if jam.file_metadata.duration is None:
+        jam.file_metadata.duration = duration
 
     # beats
     if beat_data is not None:

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -138,8 +138,7 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         return jams_utils.jams_converter(
-            audio_path=self.audio_path,
-            metadata=self._track_metadata
+            audio_path=self.audio_path, metadata=self._track_metadata
         )
 
 

--- a/mirdata/medley_solos_db.py
+++ b/mirdata/medley_solos_db.py
@@ -137,9 +137,10 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {'duration': librosa.get_duration(self.audio[0], self.audio[1])}
-        metadata.update(self._track_metadata)
-        return jams_utils.jams_converter(metadata=metadata)
+        return jams_utils.jams_converter(
+            audio_path=self.audio_path,
+            metadata=self._track_metadata
+        )
 
 
 def load_audio(audio_path):

--- a/mirdata/medleydb_melody.py
+++ b/mirdata/medleydb_melody.py
@@ -133,11 +133,10 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         # jams does not support multipitch, so we skip melody3
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             f0_data=[(self.melody1, 'melody1'), (self.melody2, 'melody2')],
-            metadata=metadata,
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -109,7 +109,7 @@ class Track(track.Track):
         return jams_utils.jams_converter(
             audio_path=self.audio_path,
             f0_data=[(self.pitch, 'annotated pitch')],
-            metadata=self._track_metadata
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/medleydb_pitch.py
+++ b/mirdata/medleydb_pitch.py
@@ -106,10 +106,10 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
-            f0_data=[(self.pitch, 'annotated pitch')], metadata=metadata
+            audio_path=self.audio_path,
+            f0_data=[(self.pitch, 'annotated pitch')],
+            metadata=self._track_metadata
         )
 
 

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -198,7 +198,7 @@ class Track(track.Track):
         return jams_utils.jams_converter(
             audio_path=self.audio_path_mono,
             f0_data=[(self.melody, 'annotated melody')],
-            metadata=self._track_metadata
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/orchset.py
+++ b/mirdata/orchset.py
@@ -195,12 +195,10 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(
-            self.audio_mono[0], self.audio_mono[1]
-        )
         return jams_utils.jams_converter(
-            f0_data=[(self.melody, 'annotated melody')], metadata=metadata
+            audio_path=self.audio_path_mono,
+            f0_data=[(self.melody, 'annotated melody')],
+            metadata=self._track_metadata
         )
 
 

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -71,7 +71,7 @@ def _load_metadata(data_home):
         if line[0] == 'Piece No.':
             continue
         p = '00' + line[0].split('.')[1][1:]
-        track_id = 'RM-C{}'.format(p[len(p) - 3:])
+        track_id = 'RM-C{}'.format(p[len(p) - 3 :])
 
         metadata_index[track_id] = {
             'piece_number': line[0],

--- a/mirdata/rwc_classical.py
+++ b/mirdata/rwc_classical.py
@@ -71,7 +71,7 @@ def _load_metadata(data_home):
         if line[0] == 'Piece No.':
             continue
         p = '00' + line[0].split('.')[1][1:]
-        track_id = 'RM-C{}'.format(p[len(p) - 3 :])
+        track_id = 'RM-C{}'.format(p[len(p) - 3:])
 
         metadata_index[track_id] = {
             'piece_number': line[0],
@@ -178,12 +178,11 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
-            metadata=metadata,
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/rwc_jazz.py
+++ b/mirdata/rwc_jazz.py
@@ -203,12 +203,11 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
-            metadata=metadata,
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/rwc_popular.py
+++ b/mirdata/rwc_popular.py
@@ -221,13 +221,12 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             beat_data=[(self.beats, None)],
             section_data=[(self.sections, None)],
             chord_data=[(self.chords, None)],
-            metadata=metadata,
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/salami.py
+++ b/mirdata/salami.py
@@ -197,9 +197,8 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
         return jams_utils.jams_converter(
+            audio_path=self.audio_path,
             multi_section_data=[
                 (
                     [
@@ -216,7 +215,7 @@ class Track(track.Track):
                     'annotator_2',
                 ),
             ],
-            metadata=metadata,
+            metadata=self._track_metadata,
         )
 
 

--- a/mirdata/tinysol.py
+++ b/mirdata/tinysol.py
@@ -194,9 +194,10 @@ class Track(track.Track):
 
     def to_jams(self):
         """Jams: the track's data in jams format"""
-        metadata = {k: v for k, v in self._track_metadata.items() if v is not None}
-        metadata['duration'] = librosa.get_duration(self.audio[0], self.audio[1])
-        return jams_utils.jams_converter(metadata=metadata)  # TODO PR #185
+        return jams_utils.jams_converter(
+            audio_path=self.audio_path,
+            metadata=self._track_metadata
+        )
 
 
 def load_audio(audio_path):

--- a/mirdata/tinysol.py
+++ b/mirdata/tinysol.py
@@ -195,8 +195,7 @@ class Track(track.Track):
     def to_jams(self):
         """Jams: the track's data in jams format"""
         return jams_utils.jams_converter(
-            audio_path=self.audio_path,
-            metadata=self._track_metadata
+            audio_path=self.audio_path, metadata=self._track_metadata
         )
 
 

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -977,6 +977,7 @@ def test_tags():
     tag_data3 = [('invalid', 'asdf')]
     tag_data4 = ('jazz', 'wrong format')
     tag_data5 = ['wrong format too']
+    tag_data6 = [(123, 'asdf')]
     jam1 = jams_utils.jams_converter(
         tags_gtzan_data=tag_data1, metadata={'duration': 10.0}
     )
@@ -991,9 +992,11 @@ def test_tags():
     with pytest.raises(jams.SchemaError):
         assert jam3.validate()
     with pytest.raises(TypeError):
-        jam4 = jams_utils.jams_converter(tags_gtzan_data=tag_data4)
+        jams_utils.jams_converter(tags_gtzan_data=tag_data4)
     with pytest.raises(TypeError):
-        jam5 = jams_utils.jams_converter(tags_gtzan_data=tag_data5)
+        jams_utils.jams_converter(tags_gtzan_data=tag_data5)
+    with pytest.raises(TypeError):
+        jams_utils.jams_converter(tags_gtzan_data=tag_data6)
 
 
 def test_tempos():
@@ -1002,6 +1005,7 @@ def test_tempos():
     tempo_data3 = [(-1, 'asdf')]
     tempo_data4 = (120.5, 'wrong format')
     tempo_data5 = ['wrong format too']
+    tempo_data6 = [('string!', 'string!')]
     jam1 = jams_utils.jams_converter(
         tempo_data=tempo_data1, metadata={'duration': 10.0}
     )
@@ -1016,9 +1020,11 @@ def test_tempos():
     with pytest.raises(jams.SchemaError):
         assert jam3.validate()
     with pytest.raises(TypeError):
-        jam4 = jams_utils.jams_converter(tempo_data=tempo_data4)
+        jams_utils.jams_converter(tempo_data=tempo_data4)
     with pytest.raises(TypeError):
-        jam5 = jams_utils.jams_converter(tempo_data=tempo_data5)
+        jams_utils.jams_converter(tempo_data=tempo_data5)
+    with pytest.raises(TypeError):
+        jams_utils.jams_converter(tempo_data=tempo_data6)
 
 
 def test_events():
@@ -1060,6 +1066,7 @@ def test_events():
     ]
     event_data4 = ('jazz', 'wrong format')
     event_data5 = ['wrong format too']
+    event_data6 = [('wrong', 'description')]
     jam1 = jams_utils.jams_converter(
         event_data=event_data1, metadata={'duration': 10.0}
     )
@@ -1074,9 +1081,11 @@ def test_events():
     with pytest.raises(jams.SchemaError):
         assert jam3.validate()
     with pytest.raises(TypeError):
-        jam4 = jams_utils.jams_converter(event_data=event_data4)
+        jams_utils.jams_converter(event_data=event_data4)
     with pytest.raises(TypeError):
-        jam5 = jams_utils.jams_converter(event_data=event_data5)
+        jams_utils.jams_converter(event_data=event_data5)
+    with pytest.raises(TypeError):
+        jams_utils.jams_converter(event_data=event_data6)
 
 
 def test_metadata():
@@ -1093,6 +1102,20 @@ def test_metadata():
     assert jam_1['file_metadata']['artist'] == 'Meatloaf'
     assert jam_1['file_metadata']['duration'] == 1.5
     assert jam_1['sandbox']['favourite_color'] == 'rainbow'
+
+    # test meatadata value None
+    metadata_2 = {
+        'duration': 1.5,
+        'artist': 'breakmaster cylinder',
+        'title': None,
+        'extra': None
+    }
+    jam2 = jams_utils.jams_converter(metadata=metadata_2)
+    assert jam2.validate()
+    assert jam2['file_metadata']['duration'] == 1.5
+    assert jam2['file_metadata']['artist'] == 'breakmaster cylinder'
+    assert jam2['file_metadata']['title'] == ''
+    assert 'extra' not in jam2['sandbox']
 
 
 def test_duration():

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -1093,3 +1093,39 @@ def test_metadata():
     assert jam_1['file_metadata']['artist'] == 'Meatloaf'
     assert jam_1['file_metadata']['duration'] == 1.5
     assert jam_1['sandbox']['favourite_color'] == 'rainbow'
+
+
+def test_duration():
+    # duration from audio file
+    jam = jams_utils.jams_converter(audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav')
+    assert jam.file_metadata.duration == 2.0
+    assert jam.validate()
+
+    # test invalid file path
+    with pytest.raises(OSError):
+        jams_utils.jams_converter(audio_path='i/dont/exist')
+
+    jam1 = jams_utils.jams_converter(metadata={'duration': 4})
+    assert jam1.file_metadata.duration == 4.0
+    assert jam1.validate()
+
+    # test incomplete metadata
+    jam2 = jams_utils.jams_converter(metadata={'artist': 'b'})
+    with pytest.raises(jams_utils.jams.SchemaError):
+        jam2.validate()
+
+    # test metadata duration and audio file equal
+    jam3 = jams_utils.jams_converter(
+        audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav',
+        metadata={'duration': 2}
+    )
+    assert jam3.file_metadata.duration == 2
+    assert jam3.validate()
+
+    # test metadata and duration not equal
+    jam4 = jams_utils.jams_converter(
+        audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav',
+        metadata={'duration': 1000}
+    )
+    assert jam4.file_metadata.duration == 1000
+    assert jam4.validate()

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -1097,7 +1097,9 @@ def test_metadata():
 
 def test_duration():
     # duration from audio file
-    jam = jams_utils.jams_converter(audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav')
+    jam = jams_utils.jams_converter(
+        audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav'
+    )
     assert jam.file_metadata.duration == 2.0
     assert jam.validate()
 
@@ -1117,7 +1119,7 @@ def test_duration():
     # test metadata duration and audio file equal
     jam3 = jams_utils.jams_converter(
         audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav',
-        metadata={'duration': 2}
+        metadata={'duration': 2},
     )
     assert jam3.file_metadata.duration == 2
     assert jam3.validate()
@@ -1125,7 +1127,7 @@ def test_duration():
     # test metadata and duration not equal
     jam4 = jams_utils.jams_converter(
         audio_path='tests/resources/mir_datasets/iKala/Wavfile/10161_chorus.wav',
-        metadata={'duration': 1000}
+        metadata={'duration': 1000},
     )
     assert jam4.file_metadata.duration == 1000
     assert jam4.validate()

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -36,7 +36,7 @@ def test_cite():
         sys.stdout = sys.__stdout__
 
 
-KNOWN_ISSUES = {'gtzan_genre': ['all']}  # issue #242, remove when fixed
+KNOWN_ISSUES = {}  # key is module, value is REMOTE key
 
 
 def test_download(mocker):


### PR DESCRIPTION
Fixes #226

What changed:
* the jams_converter now takes `audio_path` as an argument which is used to fill the duration value of the resulting jams object
  * this removes the need for computing duration in the individual `to_jams()` methods
  * we can catch the OSError within the `jams_converter` function itself
* updated tests
* updated contributing