### PR TITLE
Fix tinysol localpath

### DIFF
--- a/mirdata/datasets/indexes/tinysol_index.json
+++ b/mirdata/datasets/indexes/tinysol_index.json
@@ -3,17479 +3,17479 @@
   "tracks": {
     "BTb-ord-F#1-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#1-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#1-pp-N-N.wav",
         "e693c5c0d0c77f691896c42571abe162"
       ]
     },
     "BTb-ord-G1-pp-N-R100u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G1-pp-N-R100u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G1-pp-N-R100u.wav",
         "44b969a984bc6a56070ba244a31956c3"
       ]
     },
     "BTb-ord-G#1-pp-N-T16u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#1-pp-N-T16u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#1-pp-N-T16u.wav",
         "13bcb512d28039a0b607fcc917c884fc"
       ]
     },
     "BTb-ord-A1-pp-N-T23d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A1-pp-N-T23d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A1-pp-N-T23d.wav",
         "b60ed43ba56e59cdec410cdb095d714e"
       ]
     },
     "BTb-ord-A#1-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#1-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#1-pp-N-N.wav",
         "4e87d6f9924ccfea700ed68bb5bc2f29"
       ]
     },
     "BTb-ord-B1-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B1-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B1-pp-N-N.wav",
         "8cb05a2b558aaf87ece0efd2206f3c1d"
       ]
     },
     "BTb-ord-C2-pp-N-T13d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C2-pp-N-T13d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C2-pp-N-T13d.wav",
         "f8edfe3bfc54b9f6107cd440a0913038"
       ]
     },
     "BTb-ord-C#2-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#2-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#2-pp-N-N.wav",
         "c60d0e834ee749ca2306a0cb5e85d88a"
       ]
     },
     "BTb-ord-D2-pp-N-T18u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D2-pp-N-T18u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D2-pp-N-T18u.wav",
         "8f3ab514797af3ee34b61c12b530990b"
       ]
     },
     "BTb-ord-D#2-pp-N-T11u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#2-pp-N-T11u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#2-pp-N-T11u.wav",
         "a5285004724ac732a55a49d756e75d87"
       ]
     },
     "BTb-ord-E2-pp-N-T25u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E2-pp-N-T25u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E2-pp-N-T25u.wav",
         "16015bc7d3d7c8ad894cac70a8941065"
       ]
     },
     "BTb-ord-F2-pp-N-T25u_R100u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F2-pp-N-T25u_R100u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F2-pp-N-T25u_R100u.wav",
         "f8741adbecae6900d9a95014e02243f4"
       ]
     },
     "BTb-ord-F#2-pp-N-T14u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#2-pp-N-T14u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#2-pp-N-T14u.wav",
         "bb553dc5b74c0ec1e0eb109d3d7a16ad"
       ]
     },
     "BTb-ord-G2-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G2-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G2-pp-N-N.wav",
         "fe69fde78d4d0522a6754f3382a088e8"
       ]
     },
     "BTb-ord-G#2-pp-N-T16u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#2-pp-N-T16u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#2-pp-N-T16u.wav",
         "feda705d8d9f647553550d0eaca5c6c7"
       ]
     },
     "BTb-ord-A2-pp-N-T15u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A2-pp-N-T15u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A2-pp-N-T15u.wav",
         "fb5e35b583fd4778e4c1f6eae68157d7"
       ]
     },
     "BTb-ord-A#2-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#2-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#2-pp-N-N.wav",
         "8e415d051c9e775082a0e4cacded315d"
       ]
     },
     "BTb-ord-B2-pp-N-T11d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B2-pp-N-T11d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B2-pp-N-T11d.wav",
         "fb2edc248c2e9260b5cd5d5fae526c16"
       ]
     },
     "BTb-ord-C3-pp-N-T11d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C3-pp-N-T11d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C3-pp-N-T11d.wav",
         "f90882f6879408fcf908ba06d74fb9e5"
       ]
     },
     "BTb-ord-C#3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#3-pp-N-N.wav",
         "3c3054488cfbef5bfb0b8d9c559b7e0a"
       ]
     },
     "BTb-ord-D3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D3-pp-N-N.wav",
         "2fa36ac36fd2d5ced57f32752d9d03d0"
       ]
     },
     "BTb-ord-D#3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#3-pp-N-N.wav",
         "0f0a2bcd090ac39d977755c349944138"
       ]
     },
     "BTb-ord-E3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E3-pp-N-N.wav",
         "69e72b01da94a45e22bef65ca902e39c"
       ]
     },
     "BTb-ord-F3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F3-pp-N-N.wav",
         "1e46748681fabe726cca244c73e5817c"
       ]
     },
     "BTb-ord-F#3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#3-pp-N-N.wav",
         "8fbafa39a922209de7ec16bcca78ca02"
       ]
     },
     "BTb-ord-G3-pp-N-T14d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G3-pp-N-T14d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G3-pp-N-T14d.wav",
         "154841be604511bdeea498143df6a789"
       ]
     },
     "BTb-ord-G#3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#3-pp-N-N.wav",
         "48907cfdeeab17d004bb3213cc63e8d6"
       ]
     },
     "BTb-ord-A3-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A3-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A3-pp-N-N.wav",
         "d54259317bbaab3b2ee152bbefacdc20"
       ]
     },
     "BTb-ord-A#3-pp-N-T13d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#3-pp-N-T13d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#3-pp-N-T13d.wav",
         "d832860b9c7fe37dc712d7fc5832a524"
       ]
     },
     "BTb-ord-B3-pp-N-T14d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B3-pp-N-T14d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B3-pp-N-T14d.wav",
         "ac8642f1beaa332d5a720e3504d88f6d"
       ]
     },
     "BTb-ord-C4-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C4-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C4-pp-N-N.wav",
         "191132200cb5d81b6a4cf68942c63bfc"
       ]
     },
     "BTb-ord-C#4-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#4-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#4-pp-N-N.wav",
         "9c8cdae214c8ccf6db9245a736bd5c28"
       ]
     },
     "BTb-ord-D4-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D4-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D4-pp-N-N.wav",
         "2ed0c8e7b87a3303f4becb797087943f"
       ]
     },
     "BTb-ord-D#4-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#4-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#4-pp-N-N.wav",
         "5e7ed1983aa80cff8ed969e701c0582a"
       ]
     },
     "BTb-ord-E4-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E4-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E4-pp-N-N.wav",
         "a70f41f4aeef6157af07ded79222ad1f"
       ]
     },
     "BTb-ord-F4-pp-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F4-pp-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F4-pp-N-N.wav",
         "03f985d958efc70ee571dbb9fc7adc86"
       ]
     },
     "BTb-ord-F#1-mf-N-T18u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#1-mf-N-T18u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#1-mf-N-T18u.wav",
         "4f2b200a372416333ff953c72e95d90b"
       ]
     },
     "BTb-ord-G1-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G1-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G1-mf-N-N.wav",
         "71ffb6ce993a02e2e54b5dcecd2f07fe"
       ]
     },
     "BTb-ord-G#1-mf-N-T18u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#1-mf-N-T18u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#1-mf-N-T18u.wav",
         "27af71e30f15b2ec4a51c236b6a330ae"
       ]
     },
     "BTb-ord-A1-mf-N-T33u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A1-mf-N-T33u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A1-mf-N-T33u.wav",
         "fba7b8e0fdc009123eae671982dc4116"
       ]
     },
     "BTb-ord-A#1-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#1-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#1-mf-N-N.wav",
         "4dd47fd604498eeac106759047a6428f"
       ]
     },
     "BTb-ord-B1-mf-N-T16u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B1-mf-N-T16u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B1-mf-N-T16u.wav",
         "1979425e73905eb6f21e67a322ca5559"
       ]
     },
     "BTb-ord-C2-mf-N-T23u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C2-mf-N-T23u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C2-mf-N-T23u.wav",
         "5835d4359a0a255295a0299619ff05af"
       ]
     },
     "BTb-ord-C#2-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#2-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#2-mf-N-N.wav",
         "d9c2bd1aa01afcd13eae5efdf87e93ad"
       ]
     },
     "BTb-ord-D2-mf-N-T15u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D2-mf-N-T15u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D2-mf-N-T15u.wav",
         "ec92e01e54a5bc444cdced39b957a018"
       ]
     },
     "BTb-ord-D#2-mf-N-T34u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#2-mf-N-T34u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#2-mf-N-T34u.wav",
         "5673bd6db699b83a4ec0f8ccc41add93"
       ]
     },
     "BTb-ord-E2-mf-N-T27u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E2-mf-N-T27u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E2-mf-N-T27u.wav",
         "b4bb5fd5b073c54fb91e63cf26a032c2"
       ]
     },
     "BTb-ord-F2-mf-N-T24u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F2-mf-N-T24u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F2-mf-N-T24u.wav",
         "3e84a274084bd19d5755b9491d5662bf"
       ]
     },
     "BTb-ord-F#2-mf-N-T19u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#2-mf-N-T19u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#2-mf-N-T19u.wav",
         "b4128a1b72a90c305b7906c10aca427b"
       ]
     },
     "BTb-ord-G2-mf-N-T15u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G2-mf-N-T15u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G2-mf-N-T15u.wav",
         "e7a0332b959ff2779fcbb41d8ab22222"
       ]
     },
     "BTb-ord-G#2-mf-N-T26u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#2-mf-N-T26u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#2-mf-N-T26u.wav",
         "3d7bc71ad92c7c88059ba62b91e440a2"
       ]
     },
     "BTb-ord-A2-mf-N-T29u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A2-mf-N-T29u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A2-mf-N-T29u.wav",
         "eae47e0fb8c9740372e66b0ce06048a8"
       ]
     },
     "BTb-ord-A#2-mf-N-T29u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#2-mf-N-T29u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#2-mf-N-T29u.wav",
         "8d24d91b74a63250135fffca6b8e9499"
       ]
     },
     "BTb-ord-B2-mf-N-T17u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B2-mf-N-T17u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B2-mf-N-T17u.wav",
         "97af05577db99fe49689446c0e5a0626"
       ]
     },
     "BTb-ord-C3-mf-N-T28u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C3-mf-N-T28u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C3-mf-N-T28u.wav",
         "78035af2ec1bf5d9df1b67f56262ed59"
       ]
     },
     "BTb-ord-C#3-mf-N-T25u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#3-mf-N-T25u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#3-mf-N-T25u.wav",
         "e8b38a52376c7810d29f40c677f37597"
       ]
     },
     "BTb-ord-D3-mf-N-T16u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D3-mf-N-T16u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D3-mf-N-T16u.wav",
         "86671a73579c9f6c1796e603122e63f9"
       ]
     },
     "BTb-ord-D#3-mf-N-T25u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#3-mf-N-T25u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#3-mf-N-T25u.wav",
         "48e50780b656d9df92b25afa8bf99b8a"
       ]
     },
     "BTb-ord-E3-mf-N-T23u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E3-mf-N-T23u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E3-mf-N-T23u.wav",
         "2480f6928b6bc829a895142d888c9b40"
       ]
     },
     "BTb-ord-F3-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F3-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F3-mf-N-N.wav",
         "d95bd2a744824b64cdc3535adee8aa53"
       ]
     },
     "BTb-ord-F#3-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#3-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#3-mf-N-N.wav",
         "1c06a29f3504e56c2216f514fe3f7bf7"
       ]
     },
     "BTb-ord-G3-mf-N-T14u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G3-mf-N-T14u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G3-mf-N-T14u.wav",
         "d38d84231253fe37f9affd0e5b5b2585"
       ]
     },
     "BTb-ord-G#3-mf-N-T11u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#3-mf-N-T11u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#3-mf-N-T11u.wav",
         "c4aee7a54caa3fc7b7efbccf8d299116"
       ]
     },
     "BTb-ord-A3-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A3-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A3-mf-N-N.wav",
         "5ab39d687e63621c3acf6948fdb18856"
       ]
     },
     "BTb-ord-A#3-mf-N-T14u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#3-mf-N-T14u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#3-mf-N-T14u.wav",
         "cbc0b108fcc517ec8dde8484987bda9a"
       ]
     },
     "BTb-ord-B3-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B3-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B3-mf-N-N.wav",
         "0ba68920120e10fd1ee2415c2975f574"
       ]
     },
     "BTb-ord-C4-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C4-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C4-mf-N-N.wav",
         "0114a274aac010ece5122b90bd519603"
       ]
     },
     "BTb-ord-C#4-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#4-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#4-mf-N-N.wav",
         "999962c28b729d918960a6c686729751"
       ]
     },
     "BTb-ord-D4-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D4-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D4-mf-N-N.wav",
         "fdef9cfc28588a54682d877b9c7a5e6a"
       ]
     },
     "BTb-ord-D#4-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#4-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#4-mf-N-N.wav",
         "3934937f934ac91c5890b22587946183"
       ]
     },
     "BTb-ord-E4-mf-N-T11d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E4-mf-N-T11d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E4-mf-N-T11d.wav",
         "368a7f007cafc5fe37c09159f1bf5573"
       ]
     },
     "BTb-ord-F4-mf-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F4-mf-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F4-mf-N-N.wav",
         "02ee137c5b0215fcb5c543943b6efd7a"
       ]
     },
     "BTb-ord-F#1-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#1-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#1-ff-N-N.wav",
         "33982a9219eec931defc78915de5c1a8"
       ]
     },
     "BTb-ord-G1-ff-N-T15d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G1-ff-N-T15d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G1-ff-N-T15d.wav",
         "be4fa7bce78783bfae9d498ad3b76fcf"
       ]
     },
     "BTb-ord-G#1-ff-N-T12u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#1-ff-N-T12u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#1-ff-N-T12u.wav",
         "371f7d5c1eb9aca6a9672b839b353241"
       ]
     },
     "BTb-ord-A1-ff-N-T19d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A1-ff-N-T19d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A1-ff-N-T19d.wav",
         "36f0a945c1e72140bae0595d0b1a3b69"
       ]
     },
     "BTb-ord-A#1-ff-N-T30d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#1-ff-N-T30d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#1-ff-N-T30d.wav",
         "9330c34aa6eea6da98bfab8fe169c73c"
       ]
     },
     "BTb-ord-B1-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B1-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B1-ff-N-N.wav",
         "0f3d0d3f0297f295cbdbf2e1c7ddccdd"
       ]
     },
     "BTb-ord-C2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C2-ff-N-N.wav",
         "f9d99dea0ea59497aaae0bf059f07273"
       ]
     },
     "BTb-ord-C#2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#2-ff-N-N.wav",
         "83faccdef4172e4425f4eec3a84338db"
       ]
     },
     "BTb-ord-D2-ff-N-T13u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D2-ff-N-T13u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D2-ff-N-T13u.wav",
         "2601681e3cf1783f3508bec82aa3b1f9"
       ]
     },
     "BTb-ord-D#2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#2-ff-N-N.wav",
         "1b8378b8c12d9a0da68ef98e1a2c62ff"
       ]
     },
     "BTb-ord-E2-ff-N-T10u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E2-ff-N-T10u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E2-ff-N-T10u.wav",
         "f75451da0714c0f80e0a53b07f9f0e5e"
       ]
     },
     "BTb-ord-F2-ff-N-T15u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F2-ff-N-T15u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F2-ff-N-T15u.wav",
         "585f67ee86287c38120e183e95503c7d"
       ]
     },
     "BTb-ord-F#2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#2-ff-N-N.wav",
         "19da1ce6cddd70728c96770a4627f32a"
       ]
     },
     "BTb-ord-G2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G2-ff-N-N.wav",
         "30ef743ba8e5938342b4cfa86b9f3dfd"
       ]
     },
     "BTb-ord-G#2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#2-ff-N-N.wav",
         "ad43c21237817174e1dd82b551c337af"
       ]
     },
     "BTb-ord-A2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A2-ff-N-N.wav",
         "c0743d119b2a6bab26f5e086c991da8d"
       ]
     },
     "BTb-ord-A#2-ff-N-T19u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#2-ff-N-T19u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#2-ff-N-T19u.wav",
         "054b20751e84bd26fd1b5743c06dc583"
       ]
     },
     "BTb-ord-B2-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B2-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B2-ff-N-N.wav",
         "7578f2b9a0f9b6c85370dbe137847844"
       ]
     },
     "BTb-ord-C3-ff-N-T18u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C3-ff-N-T18u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C3-ff-N-T18u.wav",
         "ebb94735d5dc66602b21f9ffcec3c732"
       ]
     },
     "BTb-ord-C#3-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#3-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#3-ff-N-N.wav",
         "0d8dc04ed5e23ec76964deb7d4ba8bba"
       ]
     },
     "BTb-ord-D3-ff-N-T15u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D3-ff-N-T15u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D3-ff-N-T15u.wav",
         "66cf45e6e24e8cca53c0a55d3fa03842"
       ]
     },
     "BTb-ord-D#3-ff-N-T17u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#3-ff-N-T17u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#3-ff-N-T17u.wav",
         "8ad4a9847d01fa286a856661a8b1493c"
       ]
     },
     "BTb-ord-E3-ff-N-T16u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E3-ff-N-T16u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E3-ff-N-T16u.wav",
         "9140899b769b0a98691797fabfc6390b"
       ]
     },
     "BTb-ord-F3-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F3-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F3-ff-N-N.wav",
         "97d381775f4aa54b9658c81988459056"
       ]
     },
     "BTb-ord-F#3-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F#3-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#3-ff-N-N.wav",
         "05d6e0e10792aa2d963ee79be2975cb7"
       ]
     },
     "BTb-ord-G3-ff-N-T14u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G3-ff-N-T14u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G3-ff-N-T14u.wav",
         "481947a01244b6fd81dd32526ebf1506"
       ]
     },
     "BTb-ord-G#3-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-G#3-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-G#3-ff-N-N.wav",
         "52f4f794c6e330fdffbbf084c2ff0f3c"
       ]
     },
     "BTb-ord-A3-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A3-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A3-ff-N-N.wav",
         "0db67bbd11f545980fcab1172e55b95e"
       ]
     },
     "BTb-ord-A#3-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-A#3-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-A#3-ff-N-N.wav",
         "165010eeb191c8bb091f10cc14b35b8b"
       ]
     },
     "BTb-ord-B3-ff-N-T18d": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-B3-ff-N-T18d.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-B3-ff-N-T18d.wav",
         "93478e1fd9b9f4ea94c96db547434ed2"
       ]
     },
     "BTb-ord-C4-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C4-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C4-ff-N-N.wav",
         "08728cc86c3b5399b00696af2beb84b5"
       ]
     },
     "BTb-ord-C#4-ff-N-T21u": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-C#4-ff-N-T21u.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-C#4-ff-N-T21u.wav",
         "a46ca05639bd0574dcfcb7bb7ab7fe37"
       ]
     },
     "BTb-ord-D4-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D4-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D4-ff-N-N.wav",
         "3f786fdb08393147e49ebaab566592e9"
       ]
     },
     "BTb-ord-D#4-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-D#4-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-D#4-ff-N-N.wav",
         "027b258d73f11a1de1e5343d1dc02406"
       ]
     },
     "BTb-ord-E4-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-E4-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-E4-ff-N-N.wav",
         "2c295ad4116f9c2698555d39a41c5c89"
       ]
     },
     "BTb-ord-F4-ff-N-N": {
       "audio": [
-        "Brass/Bass_Tuba/ordinario/BTb-ord-F4-ff-N-N.wav",
+        "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F4-ff-N-N.wav",
         "ac059c7b415529b508ea75984c53946c"
       ]
     },
     "Hn-ord-A#1-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#1-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#1-pp-N-N.wav",
         "952d5ac70a8ce97b1ec4d2d3e3a102ec"
       ]
     },
     "Hn-ord-B1-pp-N-T15d": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B1-pp-N-T15d.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B1-pp-N-T15d.wav",
         "d9395e22f26894d530ddcad3b192b6ae"
       ]
     },
     "Hn-ord-C2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C2-pp-N-N.wav",
         "11bf3b59f567143f1d53dcd40d1d7253"
       ]
     },
     "Hn-ord-C#2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#2-pp-N-N.wav",
         "7ee4810e20eab20e45c78f8baca37b77"
       ]
     },
     "Hn-ord-D2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D2-pp-N-N.wav",
         "0ff51e75f8b3f30d8c974f7ba7fbcfe9"
       ]
     },
     "Hn-ord-D#2-pp-N-R100u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#2-pp-N-R100u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#2-pp-N-R100u.wav",
         "ce51545affcf1486ddb7a9920567e642"
       ]
     },
     "Hn-ord-E2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E2-pp-N-N.wav",
         "3ef7bf3cea75df8b7a2c72e3ca83b932"
       ]
     },
     "Hn-ord-F2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F2-pp-N-N.wav",
         "ba1e211f03ab5391e8d97a040447d2bc"
       ]
     },
     "Hn-ord-F#2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#2-pp-N-N.wav",
         "b9194e6bd4e7d217a3b8b430a3890aaf"
       ]
     },
     "Hn-ord-G2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G2-pp-N-N.wav",
         "b00c43cf0ad4f1da94104161b7086548"
       ]
     },
     "Hn-ord-G#2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#2-pp-N-N.wav",
         "5bdf9ef04585c79b747d9f9c4ecc3b05"
       ]
     },
     "Hn-ord-A2-pp-N-R100u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A2-pp-N-R100u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A2-pp-N-R100u.wav",
         "ee56f884e7326ea23fcf223495cf9bdd"
       ]
     },
     "Hn-ord-A#2-pp-N-R100d": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#2-pp-N-R100d.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#2-pp-N-R100d.wav",
         "f2dc56591c97c106f12e375f84657ef2"
       ]
     },
     "Hn-ord-B2-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B2-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B2-pp-N-N.wav",
         "dd1447f1d9a515e140d46b0b8851a8d3"
       ]
     },
     "Hn-ord-C3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C3-pp-N-N.wav",
         "5ee87b10d873205099449db6efe096e6"
       ]
     },
     "Hn-ord-C#3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#3-pp-N-N.wav",
         "1e45288b50ab8591c97a0d032299c945"
       ]
     },
     "Hn-ord-D3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D3-pp-N-N.wav",
         "205404e926d2ee989b260150e442f869"
       ]
     },
     "Hn-ord-D#3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#3-pp-N-N.wav",
         "cc8bc8d58fc4516312c1e8daa1cd4579"
       ]
     },
     "Hn-ord-E3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E3-pp-N-N.wav",
         "f69ba1acdf6f8711b647250999bab650"
       ]
     },
     "Hn-ord-F3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F3-pp-N-N.wav",
         "624c8f7099193d9249860685cf8bca5d"
       ]
     },
     "Hn-ord-F#3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#3-pp-N-N.wav",
         "488ef7dbb8f27325fe356df3c918a325"
       ]
     },
     "Hn-ord-G3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G3-pp-N-N.wav",
         "dddc40fa67ce321b1e57165285385c42"
       ]
     },
     "Hn-ord-G#3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#3-pp-N-N.wav",
         "66591cd3b09b72c2345c63cfc71eeca7"
       ]
     },
     "Hn-ord-A3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A3-pp-N-N.wav",
         "f5e1534ecaadf52a1b0b11dd09901bd3"
       ]
     },
     "Hn-ord-A#3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#3-pp-N-N.wav",
         "74fb96634eaf5ad9a53af66a52173646"
       ]
     },
     "Hn-ord-B3-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B3-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B3-pp-N-N.wav",
         "0e33b951343196f97a7a6cd970ad17f6"
       ]
     },
     "Hn-ord-C4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C4-pp-N-N.wav",
         "86a845ddc5ca283f428ff303a2c14252"
       ]
     },
     "Hn-ord-C#4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#4-pp-N-N.wav",
         "bdd3de5e7fcce9ba1a881085c9c16bfa"
       ]
     },
     "Hn-ord-D4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D4-pp-N-N.wav",
         "89d1ec27f73a444a21db3bab31f4a4eb"
       ]
     },
     "Hn-ord-D#4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#4-pp-N-N.wav",
         "e5bbc6debcc59b77e12febd19806ab07"
       ]
     },
     "Hn-ord-E4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E4-pp-N-N.wav",
         "6b02c43c7e30f6dd4be234bc462e943c"
       ]
     },
     "Hn-ord-F4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F4-pp-N-N.wav",
         "1e1dd7f6dc791f2d76134f28e62bdfb8"
       ]
     },
     "Hn-ord-F#4-pp-N-T10u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#4-pp-N-T10u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#4-pp-N-T10u.wav",
         "8aba0724d04dcb6a9a74993562b0a73c"
       ]
     },
     "Hn-ord-G4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G4-pp-N-N.wav",
         "cdc560a5cb21db9fd7d5f622f499923e"
       ]
     },
     "Hn-ord-G#4-pp-N-T10u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#4-pp-N-T10u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#4-pp-N-T10u.wav",
         "549f98fba2019dc9434ed94493933176"
       ]
     },
     "Hn-ord-A4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A4-pp-N-N.wav",
         "920762b776d6c05fbcd8c33c0cb58998"
       ]
     },
     "Hn-ord-A#4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#4-pp-N-N.wav",
         "9d164586b4ada6b2879563170d579449"
       ]
     },
     "Hn-ord-B4-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B4-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B4-pp-N-N.wav",
         "6e11834dbdcfa1af54e71a25233c7258"
       ]
     },
     "Hn-ord-C5-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C5-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C5-pp-N-N.wav",
         "4636c6f30901c12b0db3054289f1af75"
       ]
     },
     "Hn-ord-C#5-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#5-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#5-pp-N-N.wav",
         "2c91d9ee63e354db41b7526dc9324d2c"
       ]
     },
     "Hn-ord-D5-pp-N-T10u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D5-pp-N-T10u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D5-pp-N-T10u.wav",
         "48197bd2a96e2477297da6b6e8a07149"
       ]
     },
     "Hn-ord-D#5-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#5-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#5-pp-N-N.wav",
         "3ad3594e4125dbb98c3ce5331a05c9af"
       ]
     },
     "Hn-ord-E5-pp-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E5-pp-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E5-pp-N-N.wav",
         "4e3b3cf6f517f8760c8f4febd50fa403"
       ]
     },
     "Hn-ord-F5-pp-N-T11u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F5-pp-N-T11u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F5-pp-N-T11u.wav",
         "f44f59766886b62bac9356992a94ed52"
       ]
     },
     "Hn-ord-G1-mf-N-T40d": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G1-mf-N-T40d.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G1-mf-N-T40d.wav",
         "e804b6e1adc13c7c237fbe727f1eaed3"
       ]
     },
     "Hn-ord-G#1-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#1-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#1-mf-N-N.wav",
         "17e3c2e4b47debc325b3c411d2719f8c"
       ]
     },
     "Hn-ord-A1-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A1-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A1-mf-N-N.wav",
         "423087d75aeb8511f805730cafeacc6d"
       ]
     },
     "Hn-ord-A#1-mf-N-T17d": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#1-mf-N-T17d.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#1-mf-N-T17d.wav",
         "9528ff517fe94655ff47f1749cd243f6"
       ]
     },
     "Hn-ord-B1-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B1-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B1-mf-N-N.wav",
         "0996f414dc4f46ccdc52eea921175124"
       ]
     },
     "Hn-ord-C2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C2-mf-N-N.wav",
         "a80c7d93944124a5817a9c599d6d1a24"
       ]
     },
     "Hn-ord-C#2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#2-mf-N-N.wav",
         "53449c4081dc48744d464e804f38d3f9"
       ]
     },
     "Hn-ord-D2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D2-mf-N-N.wav",
         "f80a6ac8fe78a8dcbb53e24940feb0e9"
       ]
     },
     "Hn-ord-D#2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#2-mf-N-N.wav",
         "3af34696dc662a9fe644dbbd518061b1"
       ]
     },
     "Hn-ord-E2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E2-mf-N-N.wav",
         "87982c29ddfdf6f37111df2752bcfc40"
       ]
     },
     "Hn-ord-F2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F2-mf-N-N.wav",
         "32635ab8d5aee5befc5b2cc3afb3904e"
       ]
     },
     "Hn-ord-F#2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#2-mf-N-N.wav",
         "6ead19f9f01ccb6791298f15fefeee73"
       ]
     },
     "Hn-ord-G2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G2-mf-N-N.wav",
         "3e453ec4a5f0d3580f66801f8cc7561c"
       ]
     },
     "Hn-ord-G#2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#2-mf-N-N.wav",
         "2db4a70c44938fe84a338bcc094f0915"
       ]
     },
     "Hn-ord-A2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A2-mf-N-N.wav",
         "ca42e42f55c88f0465eacce2f24b167d"
       ]
     },
     "Hn-ord-A#2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#2-mf-N-N.wav",
         "2c88316c34250730846549d1b4fb788e"
       ]
     },
     "Hn-ord-B2-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B2-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B2-mf-N-N.wav",
         "14788286e437aa02f5cc78b8e6d15d8e"
       ]
     },
     "Hn-ord-C3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C3-mf-N-N.wav",
         "d507034559fd57399c4387dfb70a0d46"
       ]
     },
     "Hn-ord-C#3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#3-mf-N-N.wav",
         "1dec4005465255ec9cb3ed1a31ded132"
       ]
     },
     "Hn-ord-D3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D3-mf-N-N.wav",
         "f9054644fb1c44f92f642c7f2489c4c4"
       ]
     },
     "Hn-ord-D#3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#3-mf-N-N.wav",
         "e459e4c1ceb46e8bb431682a519bf8e6"
       ]
     },
     "Hn-ord-E3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E3-mf-N-N.wav",
         "67cd539f5e03a7ea67b936c7579bd047"
       ]
     },
     "Hn-ord-F3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F3-mf-N-N.wav",
         "62227ba44b780b4bbc13a920212c68d0"
       ]
     },
     "Hn-ord-F#3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#3-mf-N-N.wav",
         "5a201a161a69016399ade8d3c88de18b"
       ]
     },
     "Hn-ord-G3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G3-mf-N-N.wav",
         "4431f35f41590ded0aeca1bbf7e5a662"
       ]
     },
     "Hn-ord-G#3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#3-mf-N-N.wav",
         "e7beae55255664a5d96bf324fac6ea92"
       ]
     },
     "Hn-ord-A3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A3-mf-N-N.wav",
         "2a4ed3d3d95372214e3bb5bf012214ac"
       ]
     },
     "Hn-ord-A#3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#3-mf-N-N.wav",
         "05aaaf0f467a680b8a842f0873c15fb7"
       ]
     },
     "Hn-ord-B3-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B3-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B3-mf-N-N.wav",
         "c0ae832253cfb1b9364e99a1ff7d675b"
       ]
     },
     "Hn-ord-C4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C4-mf-N-N.wav",
         "bf81f6e5a27623f5249565bfcf11b436"
       ]
     },
     "Hn-ord-C#4-mf-N-T12u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#4-mf-N-T12u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#4-mf-N-T12u.wav",
         "5e7894991b7fa8d462497ad370f2f33f"
       ]
     },
     "Hn-ord-D4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D4-mf-N-N.wav",
         "d1a94ab5fc7baf43c296db7fe4925809"
       ]
     },
     "Hn-ord-D#4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#4-mf-N-N.wav",
         "08a7386ef448ea3b22bbc2779d3b12e5"
       ]
     },
     "Hn-ord-E4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E4-mf-N-N.wav",
         "d528f29bdac66d826405c878aa701646"
       ]
     },
     "Hn-ord-F4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F4-mf-N-N.wav",
         "c48ace1889c40c2e4ba9c4f11ae3d9bd"
       ]
     },
     "Hn-ord-F#4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#4-mf-N-N.wav",
         "b60b7e6d25fc878a2eb1abb460104217"
       ]
     },
     "Hn-ord-G4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G4-mf-N-N.wav",
         "2b686ec5d8e33ad2e5c061f339f7c1a0"
       ]
     },
     "Hn-ord-G#4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#4-mf-N-N.wav",
         "6429bf90c7ccaaef3d5f609038cb1300"
       ]
     },
     "Hn-ord-A4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A4-mf-N-N.wav",
         "443a64949d161d544213893c531e8cad"
       ]
     },
     "Hn-ord-A#4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#4-mf-N-N.wav",
         "25679d006760a31346275b1f029c0aa8"
       ]
     },
     "Hn-ord-B4-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B4-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B4-mf-N-N.wav",
         "0d9b5589432e107adfcd5eebf7465695"
       ]
     },
     "Hn-ord-C5-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C5-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C5-mf-N-N.wav",
         "5e9dfd6e77a14682f41bf4463dd058ac"
       ]
     },
     "Hn-ord-C#5-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#5-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#5-mf-N-N.wav",
         "e366f14ec4a89595723eb65e7bb9f64d"
       ]
     },
     "Hn-ord-D5-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D5-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D5-mf-N-N.wav",
         "e48cc4c111e7d9f4b89ee111412eb0da"
       ]
     },
     "Hn-ord-D#5-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#5-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#5-mf-N-N.wav",
         "95b4b817f833c9e9fec6c0250a193de0"
       ]
     },
     "Hn-ord-E5-mf-N-T13u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E5-mf-N-T13u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E5-mf-N-T13u.wav",
         "18d8cdbdb2bb49ac3378234183c232e4"
       ]
     },
     "Hn-ord-F5-mf-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F5-mf-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F5-mf-N-N.wav",
         "7ac4006d31ec68d3910c088a93ed0618"
       ]
     },
     "Hn-ord-B1-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B1-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B1-ff-N-N.wav",
         "c71576c785e9458213aefef5dd1edf8a"
       ]
     },
     "Hn-ord-C2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C2-ff-N-N.wav",
         "932289b1cae6ce15d7b86cf57b1baa28"
       ]
     },
     "Hn-ord-C#2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#2-ff-N-N.wav",
         "7b946c81e9ec66647e60b0b2e8ae2bd1"
       ]
     },
     "Hn-ord-D2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D2-ff-N-N.wav",
         "0b0f70f4d5926ae41dc7769fa7556c74"
       ]
     },
     "Hn-ord-D#2-ff-N-T11u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#2-ff-N-T11u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#2-ff-N-T11u.wav",
         "8bd6e612d34404f49698e707176a1447"
       ]
     },
     "Hn-ord-E2-ff-N-T18u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E2-ff-N-T18u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E2-ff-N-T18u.wav",
         "3b798335bd5508cf8988fc92bd3570b1"
       ]
     },
     "Hn-ord-F2-ff-N-T11u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F2-ff-N-T11u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F2-ff-N-T11u.wav",
         "7e21701f750420cc9d2e3eca32775b4f"
       ]
     },
     "Hn-ord-F#2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#2-ff-N-N.wav",
         "89320467aae666c2adbd78db51b0324a"
       ]
     },
     "Hn-ord-G2-ff-N-R100u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G2-ff-N-R100u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G2-ff-N-R100u.wav",
         "198b6821969ff9cfe2545292e5257fda"
       ]
     },
     "Hn-ord-G#2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#2-ff-N-N.wav",
         "e43bdaee0d4ed6dbe0a5111d17edbabb"
       ]
     },
     "Hn-ord-A2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A2-ff-N-N.wav",
         "44e1c2931bb7838b17f283cf7949eeef"
       ]
     },
     "Hn-ord-A#2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#2-ff-N-N.wav",
         "629504277c82fa12b131b46df1f55c89"
       ]
     },
     "Hn-ord-B2-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B2-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B2-ff-N-N.wav",
         "f6200c50f8ce167d51cffaf8a26b4f20"
       ]
     },
     "Hn-ord-C3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C3-ff-N-N.wav",
         "d13d825ac035017c11f5e5d6452f3bf0"
       ]
     },
     "Hn-ord-C#3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#3-ff-N-N.wav",
         "7d3d30b6a803c02aa22e9b7f3753f4fd"
       ]
     },
     "Hn-ord-D3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D3-ff-N-N.wav",
         "a497d736bdd2b1a0d1a8bbeda792b747"
       ]
     },
     "Hn-ord-D#3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#3-ff-N-N.wav",
         "6a88716990e3b2cac4e4b0d3ae7e5442"
       ]
     },
     "Hn-ord-E3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E3-ff-N-N.wav",
         "6d02e11a72329a11574df627fc430c3a"
       ]
     },
     "Hn-ord-F3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F3-ff-N-N.wav",
         "61ab6828fa91393f09ca525c8599cd41"
       ]
     },
     "Hn-ord-F#3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#3-ff-N-N.wav",
         "8e865d4b8b7dd465dc5b0f74f0fd722f"
       ]
     },
     "Hn-ord-G3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G3-ff-N-N.wav",
         "bc9f9f0acd72b95025a3698096ec59bd"
       ]
     },
     "Hn-ord-G#3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#3-ff-N-N.wav",
         "d40a93fb466b94a2bd3a5455b87b241b"
       ]
     },
     "Hn-ord-A3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A3-ff-N-N.wav",
         "0ca51621e807640b4eff40b365750d42"
       ]
     },
     "Hn-ord-A#3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#3-ff-N-N.wav",
         "fb7ac45a54f25b33b5cc73c7c6d6359a"
       ]
     },
     "Hn-ord-B3-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B3-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B3-ff-N-N.wav",
         "7098600d8a21359184deabb7499be8eb"
       ]
     },
     "Hn-ord-C4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C4-ff-N-N.wav",
         "e77036a3c60ababb55d9a449f204596f"
       ]
     },
     "Hn-ord-C#4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#4-ff-N-N.wav",
         "16ab4d45e6e1abce788bedb9d818e4c0"
       ]
     },
     "Hn-ord-D4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D4-ff-N-N.wav",
         "b4436e543160508f13bea66ea72ca687"
       ]
     },
     "Hn-ord-D#4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#4-ff-N-N.wav",
         "48cd84aadd45a7c3b2872170c7c8d36c"
       ]
     },
     "Hn-ord-E4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E4-ff-N-N.wav",
         "19836b02e7eb4a7555b977a007d1a7b2"
       ]
     },
     "Hn-ord-F4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F4-ff-N-N.wav",
         "9afd24d7966c448e1f793f9abc81bab9"
       ]
     },
     "Hn-ord-F#4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F#4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F#4-ff-N-N.wav",
         "1ad4ff3d96986308064f46282c17248f"
       ]
     },
     "Hn-ord-G4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G4-ff-N-N.wav",
         "ae25989d366ff5c3a90bc40b76bac9ef"
       ]
     },
     "Hn-ord-G#4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-G#4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-G#4-ff-N-N.wav",
         "101c5b7e2255bdc3220362f62aa6588c"
       ]
     },
     "Hn-ord-A4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A4-ff-N-N.wav",
         "8b72731b5f4e15aed6e34a81e5367826"
       ]
     },
     "Hn-ord-A#4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-A#4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-A#4-ff-N-N.wav",
         "e29bfb49cefeb75493fb178ea47cb566"
       ]
     },
     "Hn-ord-B4-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-B4-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-B4-ff-N-N.wav",
         "f287bcea73847b37447cdc7af1e954e4"
       ]
     },
     "Hn-ord-C5-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C5-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C5-ff-N-N.wav",
         "9d5089ffa85efe4571c625afd677b540"
       ]
     },
     "Hn-ord-C#5-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-C#5-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-C#5-ff-N-N.wav",
         "edc04fb6aaff1ac1e41a6d1812bf5bf7"
       ]
     },
     "Hn-ord-D5-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D5-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D5-ff-N-N.wav",
         "b95a82290de996ccd50eb36061d4e2e5"
       ]
     },
     "Hn-ord-D#5-ff-N-T10u": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-D#5-ff-N-T10u.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-D#5-ff-N-T10u.wav",
         "34ae36c505f4577123b3efe5a5396bf8"
       ]
     },
     "Hn-ord-E5-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-E5-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-E5-ff-N-N.wav",
         "d925fa5800fa8c2d07d2e2e7a989aa1f"
       ]
     },
     "Hn-ord-F5-ff-N-N": {
       "audio": [
-        "Brass/Horn/ordinario/Hn-ord-F5-ff-N-N.wav",
+        "audio/Brass/Horn/ordinario/Hn-ord-F5-ff-N-N.wav",
         "3d223cd9a10358357e586cb50869fe9d"
       ]
     },
     "Tbn-ord-A#1-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#1-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#1-pp-N-N.wav",
         "c17296e79a44c68b99d49a74ab82a1b5"
       ]
     },
     "Tbn-ord-B1-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B1-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B1-pp-N-N.wav",
         "2723822c2ebe3853374adc8e0a3e1bb0"
       ]
     },
     "Tbn-ord-C2-pp-N-T23d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C2-pp-N-T23d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C2-pp-N-T23d.wav",
         "6cd323db21548b6a0fa053e7963d1e2f"
       ]
     },
     "Tbn-ord-C#2-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#2-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#2-pp-N-N.wav",
         "af0017da00fe3bb78ab261f79c4199dd"
       ]
     },
     "Tbn-ord-D2-pp-N-T12d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D2-pp-N-T12d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D2-pp-N-T12d.wav",
         "bb9e257ed42b96f943b17900ed368b14"
       ]
     },
     "Tbn-ord-D#2-pp-N-T14u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#2-pp-N-T14u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#2-pp-N-T14u.wav",
         "3c6c708587f96ed5cd6d9c8aa3ee3e69"
       ]
     },
     "Tbn-ord-E2-pp-N-T21u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E2-pp-N-T21u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E2-pp-N-T21u.wav",
         "41b96a42f0eaddec8e1c48dfdc2a7c9d"
       ]
     },
     "Tbn-ord-F2-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F2-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F2-pp-N-N.wav",
         "53b79f925b9010e4e4be90aabc4320b9"
       ]
     },
     "Tbn-ord-F#2-pp-N-T20d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#2-pp-N-T20d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#2-pp-N-T20d.wav",
         "88fd4699c5e8f61a5b2ef6d819a6c00f"
       ]
     },
     "Tbn-ord-G2-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G2-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G2-pp-N-N.wav",
         "0d7c50c53e6080fc4f5033eabd717170"
       ]
     },
     "Tbn-ord-G#2-pp-N-T27u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#2-pp-N-T27u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#2-pp-N-T27u.wav",
         "6590717062ee1c1270a5154b26e4b107"
       ]
     },
     "Tbn-ord-A2-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A2-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A2-pp-N-N.wav",
         "961a01cee2128938e284a5e22681895c"
       ]
     },
     "Tbn-ord-A#2-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#2-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#2-pp-N-N.wav",
         "426fe8e53378e9774c937f4707554d1f"
       ]
     },
     "Tbn-ord-B2-pp-N-T19d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B2-pp-N-T19d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B2-pp-N-T19d.wav",
         "42dbb73c01856abad1baf78f08e87c58"
       ]
     },
     "Tbn-ord-C3-pp-N-T25d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C3-pp-N-T25d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C3-pp-N-T25d.wav",
         "775d0541cb8f7a0ddb80d6cfbfcf92f6"
       ]
     },
     "Tbn-ord-C#3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#3-pp-N-N.wav",
         "aa7ac71d7a99709545feed19d1158fed"
       ]
     },
     "Tbn-ord-D3-pp-N-T11u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D3-pp-N-T11u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D3-pp-N-T11u.wav",
         "3b151b5d543871ec5c5fee12d12624f4"
       ]
     },
     "Tbn-ord-D#3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#3-pp-N-N.wav",
         "6d3bf4b04bf4ac872b48fbe0a23e3232"
       ]
     },
     "Tbn-ord-E3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E3-pp-N-N.wav",
         "75fd455fd171e6c40a5841930c8fa1cd"
       ]
     },
     "Tbn-ord-F3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F3-pp-N-N.wav",
         "80997f4cb1636b6d569216c68e5a77e5"
       ]
     },
     "Tbn-ord-F#3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#3-pp-N-N.wav",
         "1c33d37f03dda72acfd0dd1f18d34578"
       ]
     },
     "Tbn-ord-G3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G3-pp-N-N.wav",
         "5aa193e21d6ef7e117bcac95232f6f11"
       ]
     },
     "Tbn-ord-G#3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#3-pp-N-N.wav",
         "96a5bc0e2ce4b0b0646db6f40bb6fbeb"
       ]
     },
     "Tbn-ord-A3-pp-N-T14u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A3-pp-N-T14u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A3-pp-N-T14u.wav",
         "6bcd843a2f6c33f32109e124ab81bda7"
       ]
     },
     "Tbn-ord-A#3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#3-pp-N-N.wav",
         "56cd3caa117467b69b3334cf95fae73b"
       ]
     },
     "Tbn-ord-B3-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B3-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B3-pp-N-N.wav",
         "c68ef50c73d8804c312db091234a7dba"
       ]
     },
     "Tbn-ord-C4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C4-pp-N-N.wav",
         "177f49401025104e8313f4531cb25ef9"
       ]
     },
     "Tbn-ord-C#4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#4-pp-N-N.wav",
         "80fd17f8a68e52c120dce11ed1694316"
       ]
     },
     "Tbn-ord-D4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D4-pp-N-N.wav",
         "c2b399deb49fe03627a7d268f8a3fcdf"
       ]
     },
     "Tbn-ord-D#4-pp-N-T13u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#4-pp-N-T13u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#4-pp-N-T13u.wav",
         "ed066f07e0eedf079c55231041cab523"
       ]
     },
     "Tbn-ord-E4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E4-pp-N-N.wav",
         "19073b3795bfca9f0cf5e81e91b50125"
       ]
     },
     "Tbn-ord-F4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F4-pp-N-N.wav",
         "71eda8858e0827ab86cb2e3e53b5f52d"
       ]
     },
     "Tbn-ord-F#4-pp-N-T10u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#4-pp-N-T10u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#4-pp-N-T10u.wav",
         "e52ab4828288b5cacd8b4e3318d9231c"
       ]
     },
     "Tbn-ord-G4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G4-pp-N-N.wav",
         "e7054bd1e5e363ba1c24e1fe01137f61"
       ]
     },
     "Tbn-ord-G#4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#4-pp-N-N.wav",
         "eac97b1d844211db05a14f313314ac8a"
       ]
     },
     "Tbn-ord-A4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A4-pp-N-N.wav",
         "c8fbda74c234d0be68036f87b1e528c0"
       ]
     },
     "Tbn-ord-A#4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#4-pp-N-N.wav",
         "e0f5ce82587b8031bef258ac9c86f2a7"
       ]
     },
     "Tbn-ord-B4-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B4-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B4-pp-N-N.wav",
         "61a9a64dd4d96464f607f2c932ea7b61"
       ]
     },
     "Tbn-ord-C5-pp-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C5-pp-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C5-pp-N-N.wav",
         "90488ea83575d2db2050f61d4850b7bb"
       ]
     },
     "Tbn-ord-A#1-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#1-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#1-mf-N-N.wav",
         "6cf15efddcb337def1ac12ae1e19b1c3"
       ]
     },
     "Tbn-ord-B1-mf-N-T14d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B1-mf-N-T14d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B1-mf-N-T14d.wav",
         "80f9b3e9de843bf3b5df56886a92002e"
       ]
     },
     "Tbn-ord-C2-mf-N-T44d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C2-mf-N-T44d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C2-mf-N-T44d.wav",
         "5a8b87ac8f0e0960da3f712461f039e3"
       ]
     },
     "Tbn-ord-C#2-mf-N-T33d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#2-mf-N-T33d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#2-mf-N-T33d.wav",
         "c706a1692b0f2c7c12f00d47f1df24eb"
       ]
     },
     "Tbn-ord-D2-mf-N-T26d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D2-mf-N-T26d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D2-mf-N-T26d.wav",
         "2494e10a01cdfa0527f49152da276800"
       ]
     },
     "Tbn-ord-D#2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#2-mf-N-N.wav",
         "34a55f1ddf1873f53a14702787b4ad39"
       ]
     },
     "Tbn-ord-E2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E2-mf-N-N.wav",
         "5a6d46fc8ff4718784ecdcda7482112d"
       ]
     },
     "Tbn-ord-F2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F2-mf-N-N.wav",
         "d613b6f4b8c14dbf1b3064748353b321"
       ]
     },
     "Tbn-ord-F#2-mf-N-T28d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#2-mf-N-T28d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#2-mf-N-T28d.wav",
         "4d5637736d3ac6dfe7d55ab37e003a4d"
       ]
     },
     "Tbn-ord-G2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G2-mf-N-N.wav",
         "9a60fd7593013623394f51e51308f59d"
       ]
     },
     "Tbn-ord-G#2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#2-mf-N-N.wav",
         "a477f35e04b53d80ff71e9c1a512c62f"
       ]
     },
     "Tbn-ord-A2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A2-mf-N-N.wav",
         "e7c6c64c0c5dbfb0458f28e6fec1b4ef"
       ]
     },
     "Tbn-ord-A#2-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#2-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#2-mf-N-N.wav",
         "118995f40da2ae6cb1b7944b685ecfee"
       ]
     },
     "Tbn-ord-B2-mf-N-T26d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B2-mf-N-T26d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B2-mf-N-T26d.wav",
         "cfe2c165371d760e01a8761868929f10"
       ]
     },
     "Tbn-ord-C3-mf-N-T18d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C3-mf-N-T18d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C3-mf-N-T18d.wav",
         "dce2832bd805eff6654078f0f68a0eff"
       ]
     },
     "Tbn-ord-C#3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#3-mf-N-N.wav",
         "a83350e0e70325455d6c75f0ec29abbf"
       ]
     },
     "Tbn-ord-D3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D3-mf-N-N.wav",
         "2e808881f20f518ab7a96e81ffc03f66"
       ]
     },
     "Tbn-ord-D#3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#3-mf-N-N.wav",
         "d44bf54a4c21c034115c07bfd0c0da43"
       ]
     },
     "Tbn-ord-E3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E3-mf-N-N.wav",
         "eaad46bec1e38c248c9c12081c37b7a4"
       ]
     },
     "Tbn-ord-F3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F3-mf-N-N.wav",
         "ca28a90643d04f8225e4c78f138e59eb"
       ]
     },
     "Tbn-ord-F#3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#3-mf-N-N.wav",
         "3cf04b7c171f0e6dc25665c1b32b64fe"
       ]
     },
     "Tbn-ord-G3-mf-N-T18d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G3-mf-N-T18d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G3-mf-N-T18d.wav",
         "3cd0b7799781d6ba1e42aa657a069769"
       ]
     },
     "Tbn-ord-G#3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#3-mf-N-N.wav",
         "6b676be50e1933755d43106474f7c558"
       ]
     },
     "Tbn-ord-A3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A3-mf-N-N.wav",
         "19de638374d0c6112e72d81e0522ffff"
       ]
     },
     "Tbn-ord-A#3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#3-mf-N-N.wav",
         "aae617f91948b26fbc1b1df868ef90b6"
       ]
     },
     "Tbn-ord-B3-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B3-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B3-mf-N-N.wav",
         "206754d11aceee0defee15020f7b69d3"
       ]
     },
     "Tbn-ord-C4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C4-mf-N-N.wav",
         "c08f88fb0868a89f421cb8562c079ff3"
       ]
     },
     "Tbn-ord-C#4-mf-N-T13d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#4-mf-N-T13d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#4-mf-N-T13d.wav",
         "d76c4568d200753ad58a6167db5492f9"
       ]
     },
     "Tbn-ord-D4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D4-mf-N-N.wav",
         "f10794d1a6c99f6bf38bc1b055beec9b"
       ]
     },
     "Tbn-ord-D#4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#4-mf-N-N.wav",
         "354b1bd14ec3f3689b69e63e21d5972d"
       ]
     },
     "Tbn-ord-E4-mf-N-T10u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E4-mf-N-T10u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E4-mf-N-T10u.wav",
         "551e30fbda4893a3fcc7dd3f3da128ad"
       ]
     },
     "Tbn-ord-F4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F4-mf-N-N.wav",
         "6b4e5e832cec109182dd2f1a6e3b3793"
       ]
     },
     "Tbn-ord-F#4-mf-N-T10u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#4-mf-N-T10u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#4-mf-N-T10u.wav",
         "616dec41e648725803c973355fbd7885"
       ]
     },
     "Tbn-ord-G4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G4-mf-N-N.wav",
         "b851912bc72e38f512d53d293ba88eb3"
       ]
     },
     "Tbn-ord-G#4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#4-mf-N-N.wav",
         "7895a5f3edb4f7e1a5edce4196bec6b4"
       ]
     },
     "Tbn-ord-A4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A4-mf-N-N.wav",
         "bb709375c4371774230fb05d1ce4b835"
       ]
     },
     "Tbn-ord-A#4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#4-mf-N-N.wav",
         "fce15337470636ed8033e131317d158f"
       ]
     },
     "Tbn-ord-B4-mf-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B4-mf-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B4-mf-N-N.wav",
         "c758c36d206e8f8518a751d4093bdcea"
       ]
     },
     "Tbn-ord-C5-mf-N-T23u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C5-mf-N-T23u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C5-mf-N-T23u.wav",
         "5a99cfc28c1534d8fbe8fbb44ab06d3d"
       ]
     },
     "Tbn-ord-A#1-ff-N-T14d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#1-ff-N-T14d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#1-ff-N-T14d.wav",
         "0dbe3f8b6bbaafb78be87c0aa8baf4f2"
       ]
     },
     "Tbn-ord-B1-ff-N-T27d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B1-ff-N-T27d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B1-ff-N-T27d.wav",
         "7f78550c9dc11e9091b2a026c88b8184"
       ]
     },
     "Tbn-ord-C2-ff-N-T58d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C2-ff-N-T58d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C2-ff-N-T58d.wav",
         "9b7e5352510fecd20feced693e0ebbed"
       ]
     },
     "Tbn-ord-C#2-ff-N-T21d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#2-ff-N-T21d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#2-ff-N-T21d.wav",
         "185ed4c9a01060426fecee513e8c9206"
       ]
     },
     "Tbn-ord-D2-ff-N-T37d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D2-ff-N-T37d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D2-ff-N-T37d.wav",
         "6b4f878e133c856ececcd1cd816c6f0b"
       ]
     },
     "Tbn-ord-D#2-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#2-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#2-ff-N-N.wav",
         "a130900f7bd65ac96da04414282ad73c"
       ]
     },
     "Tbn-ord-E2-ff-N-T12d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E2-ff-N-T12d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E2-ff-N-T12d.wav",
         "d4ad478d2618071293d53dbbe389fbf5"
       ]
     },
     "Tbn-ord-F2-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F2-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F2-ff-N-N.wav",
         "e6afba1d64f33051e819bc108d4ad24e"
       ]
     },
     "Tbn-ord-F#2-ff-N-T24d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#2-ff-N-T24d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#2-ff-N-T24d.wav",
         "2b7df14a5d464bc02f07f3b89f9735c2"
       ]
     },
     "Tbn-ord-G2-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G2-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G2-ff-N-N.wav",
         "0dfb79d81d70ae68c6e102e46558dc06"
       ]
     },
     "Tbn-ord-G#2-ff-N-T15u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#2-ff-N-T15u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#2-ff-N-T15u.wav",
         "1d477971bfa1bb74a7fd30747c4cdafc"
       ]
     },
     "Tbn-ord-A2-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A2-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A2-ff-N-N.wav",
         "96c746cb53ccd6a3b26cd6b0c151f685"
       ]
     },
     "Tbn-ord-A#2-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#2-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#2-ff-N-N.wav",
         "9b4e43bd26465e3554b2751a34665058"
       ]
     },
     "Tbn-ord-B2-ff-N-T26d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B2-ff-N-T26d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B2-ff-N-T26d.wav",
         "ced7ee1150d32d5a7b2548052465bd53"
       ]
     },
     "Tbn-ord-C3-ff-N-T25d": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C3-ff-N-T25d.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C3-ff-N-T25d.wav",
         "53f94f2fcd197c135563979bed1e991c"
       ]
     },
     "Tbn-ord-C#3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#3-ff-N-N.wav",
         "3080bcc31f95fd74ba3ed5238013c34e"
       ]
     },
     "Tbn-ord-D3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D3-ff-N-N.wav",
         "b51068384a39b33645964767481dee56"
       ]
     },
     "Tbn-ord-D#3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#3-ff-N-N.wav",
         "7f6b1186f954601ba8c449055233dd4b"
       ]
     },
     "Tbn-ord-E3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E3-ff-N-N.wav",
         "c86d7208970d2f49733abed93abaf611"
       ]
     },
     "Tbn-ord-F3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F3-ff-N-N.wav",
         "58eed917299c767e617b27c59db44037"
       ]
     },
     "Tbn-ord-F#3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#3-ff-N-N.wav",
         "ee7862ec987a5c4a2599c0d82ed09153"
       ]
     },
     "Tbn-ord-G3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G3-ff-N-N.wav",
         "e6aad84dddc56fa65f7797677a4b727e"
       ]
     },
     "Tbn-ord-G#3-ff-N-T10u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#3-ff-N-T10u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#3-ff-N-T10u.wav",
         "fbe6dec07f1273c36ad34257d871208b"
       ]
     },
     "Tbn-ord-A3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A3-ff-N-N.wav",
         "df1c7f813c7abf1c9113f1d4175ab495"
       ]
     },
     "Tbn-ord-A#3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#3-ff-N-N.wav",
         "5494ebbc1346d789a70a7fe1111c86b7"
       ]
     },
     "Tbn-ord-B3-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B3-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B3-ff-N-N.wav",
         "c7c528920baec72fe2a13fb91c899fec"
       ]
     },
     "Tbn-ord-C4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C4-ff-N-N.wav",
         "71a640f2956eef9323409bf18a03a48d"
       ]
     },
     "Tbn-ord-C#4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C#4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C#4-ff-N-N.wav",
         "aec2c25293c283967efd903b36941173"
       ]
     },
     "Tbn-ord-D4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D4-ff-N-N.wav",
         "045cb9bc94b2ec544d484520e0b4345a"
       ]
     },
     "Tbn-ord-D#4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-D#4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-D#4-ff-N-N.wav",
         "49a5fdad819d5aa83821fc0fd87e05f1"
       ]
     },
     "Tbn-ord-E4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-E4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-E4-ff-N-N.wav",
         "6bcc1ca5de0abd4c8b44357968f8b00e"
       ]
     },
     "Tbn-ord-F4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F4-ff-N-N.wav",
         "9f7a0f54ddae1a50d9f84dc67d2a455d"
       ]
     },
     "Tbn-ord-F#4-ff-N-T10u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-F#4-ff-N-T10u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-F#4-ff-N-T10u.wav",
         "9646b584f6adaea58e2a4afc32059bcc"
       ]
     },
     "Tbn-ord-G4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G4-ff-N-N.wav",
         "18f5bd54b764fc905e9563f3facfdc07"
       ]
     },
     "Tbn-ord-G#4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-G#4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-G#4-ff-N-N.wav",
         "5105c68392abb3c8a4c9153712a600ee"
       ]
     },
     "Tbn-ord-A4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A4-ff-N-N.wav",
         "0ae15783d48bd405d6c6b5c65ad04e3c"
       ]
     },
     "Tbn-ord-A#4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-A#4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-A#4-ff-N-N.wav",
         "53c869a6297b701418433c8a9336cae0"
       ]
     },
     "Tbn-ord-B4-ff-N-N": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-B4-ff-N-N.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-B4-ff-N-N.wav",
         "335d9d65ffa5be97b406bd02743040fd"
       ]
     },
     "Tbn-ord-C5-ff-N-T24u": {
       "audio": [
-        "Brass/Trombone/ordinario/Tbn-ord-C5-ff-N-T24u.wav",
+        "audio/Brass/Trombone/ordinario/Tbn-ord-C5-ff-N-T24u.wav",
         "eb64186c07cfd3cacf3bb8df11e439d1"
       ]
     },
     "TpC-ord-F#3-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#3-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#3-pp-N-N.wav",
         "15b75403bcb437c3d04008ca37b3afef"
       ]
     },
     "TpC-ord-G3-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G3-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G3-pp-N-N.wav",
         "5993cca04bd6f3ab0d5465b4283116b4"
       ]
     },
     "TpC-ord-G#3-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#3-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#3-pp-N-N.wav",
         "d170a8f44f3226fee3b457e98743d7ef"
       ]
     },
     "TpC-ord-A3-pp-N-T10d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A3-pp-N-T10d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A3-pp-N-T10d.wav",
         "d7df4743d22cc565deb4bfdf4e10f993"
       ]
     },
     "TpC-ord-A#3-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#3-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#3-pp-N-N.wav",
         "b7357990267dad371003015da4dfe62e"
       ]
     },
     "TpC-ord-B3-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B3-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B3-pp-N-N.wav",
         "6589e71f91caf5322e4253cc10ff2c16"
       ]
     },
     "TpC-ord-C4-pp-N-T10d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C4-pp-N-T10d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C4-pp-N-T10d.wav",
         "eb62220f676c0149a4496d9250d7d3db"
       ]
     },
     "TpC-ord-C#4-pp-N-T11u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#4-pp-N-T11u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#4-pp-N-T11u.wav",
         "04d5b903ae059585860758b9a12bea2f"
       ]
     },
     "TpC-ord-D4-pp-N-T18u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D4-pp-N-T18u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D4-pp-N-T18u.wav",
         "3609b8f924a51b98727b3b33de600f04"
       ]
     },
     "TpC-ord-D#4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D#4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D#4-pp-N-N.wav",
         "93e40f6f6692f7b796b6fac86db32802"
       ]
     },
     "TpC-ord-E4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-E4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-E4-pp-N-N.wav",
         "6ffe46f58a8942be9e45cb8260902474"
       ]
     },
     "TpC-ord-F4-pp-N-T12u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F4-pp-N-T12u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F4-pp-N-T12u.wav",
         "7ad67a56a0cd3095202da86112c14588"
       ]
     },
     "TpC-ord-F#4-pp-N-T12u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#4-pp-N-T12u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#4-pp-N-T12u.wav",
         "522e352086a633ed7b06a91f761a3cc4"
       ]
     },
     "TpC-ord-G4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G4-pp-N-N.wav",
         "6f0470b48e81378f4e63c6d675ae995b"
       ]
     },
     "TpC-ord-G#4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#4-pp-N-N.wav",
         "0d677810e2b381f4e471f9be703db7b2"
       ]
     },
     "TpC-ord-A4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A4-pp-N-N.wav",
         "6436c57e27820bc5c525cf7c4457d054"
       ]
     },
     "TpC-ord-A#4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#4-pp-N-N.wav",
         "3131c4cf3886a4c03324d857b22b2478"
       ]
     },
     "TpC-ord-B4-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B4-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B4-pp-N-N.wav",
         "009a90a49e61833b458ff8a2f305e5bb"
       ]
     },
     "TpC-ord-C5-pp-N-T11d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C5-pp-N-T11d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C5-pp-N-T11d.wav",
         "035384e5fb720b9c3b4eaa6387315b8a"
       ]
     },
     "TpC-ord-C#5-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#5-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#5-pp-N-N.wav",
         "375058814444ec0dd001d3cf14615e6b"
       ]
     },
     "TpC-ord-D5-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D5-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D5-pp-N-N.wav",
         "d6b37d849a1cee7cca4c840629c2f3ec"
       ]
     },
     "TpC-ord-D#5-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D#5-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D#5-pp-N-N.wav",
         "915a08acff39ab45fc98ac2d3621df0c"
       ]
     },
     "TpC-ord-E5-pp-N-T31d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-E5-pp-N-T31d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-E5-pp-N-T31d.wav",
         "da5fc9b4a0f3b861055526348c3c8380"
       ]
     },
     "TpC-ord-F5-pp-N-T12d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F5-pp-N-T12d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F5-pp-N-T12d.wav",
         "26a60450c8756c9f4749540d62034c15"
       ]
     },
     "TpC-ord-F#5-pp-N-T22d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#5-pp-N-T22d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#5-pp-N-T22d.wav",
         "53b6294b28b96930dd85df9cf8b6f533"
       ]
     },
     "TpC-ord-G5-pp-N-T25d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G5-pp-N-T25d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G5-pp-N-T25d.wav",
         "460e6010a5b07735ea413c5b20d2020e"
       ]
     },
     "TpC-ord-G#5-pp-N-T23d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#5-pp-N-T23d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#5-pp-N-T23d.wav",
         "039a8c7ea9f9d22c4e71d77e66bba074"
       ]
     },
     "TpC-ord-A5-pp-N-T26d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A5-pp-N-T26d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A5-pp-N-T26d.wav",
         "c07bb2e97e3bab86c5ba5241305f2f4d"
       ]
     },
     "TpC-ord-A#5-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#5-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#5-pp-N-N.wav",
         "7eacca6a9b3ec9799d618269d0024519"
       ]
     },
     "TpC-ord-B5-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B5-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B5-pp-N-N.wav",
         "8fd7d83bfd8bf54bf2c4f2af41a723b8"
       ]
     },
     "TpC-ord-C6-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C6-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C6-pp-N-N.wav",
         "587da3e4058bb5351f09475331b03bcb"
       ]
     },
     "TpC-ord-C#6-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#6-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#6-pp-N-N.wav",
         "4f3c4df4635268c34bf615e39e126246"
       ]
     },
     "TpC-ord-D6-pp-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D6-pp-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D6-pp-N-N.wav",
         "110d8be7c484cbd015e97188b890134e"
       ]
     },
     "TpC-ord-F#3-mf-N-T23u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#3-mf-N-T23u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#3-mf-N-T23u.wav",
         "44209a0bcd2a2c8fd0209b8dd3a9dfa6"
       ]
     },
     "TpC-ord-G3-mf-N-T12u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G3-mf-N-T12u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G3-mf-N-T12u.wav",
         "c00a55669874e04e632f4429e680f6da"
       ]
     },
     "TpC-ord-G#3-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#3-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#3-mf-N-N.wav",
         "b1f933991062bc12f788e1e0a8c2523d"
       ]
     },
     "TpC-ord-A3-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A3-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A3-mf-N-N.wav",
         "8b71c9553cbbb85233052bd64c2ef68f"
       ]
     },
     "TpC-ord-A#3-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#3-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#3-mf-N-N.wav",
         "df5ef78d8585d8b06ada759849ee7668"
       ]
     },
     "TpC-ord-B3-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B3-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B3-mf-N-N.wav",
         "a6c42d831d4e4a9b06129984c846a61b"
       ]
     },
     "TpC-ord-C4-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C4-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C4-mf-N-N.wav",
         "7d6a02136ff39d818a1e667624bcdf63"
       ]
     },
     "TpC-ord-C#4-mf-N-T17u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#4-mf-N-T17u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#4-mf-N-T17u.wav",
         "30b1037dcc1c4ffe28256d86e0ae8712"
       ]
     },
     "TpC-ord-D4-mf-N-T13u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D4-mf-N-T13u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D4-mf-N-T13u.wav",
         "0f909a0cc59f16f5336c812421f79366"
       ]
     },
     "TpC-ord-D#4-mf-N-T16u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D#4-mf-N-T16u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D#4-mf-N-T16u.wav",
         "a22ae830014cdb2c6d07dafaeb4a4423"
       ]
     },
     "TpC-ord-E4-mf-N-T11u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-E4-mf-N-T11u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-E4-mf-N-T11u.wav",
         "6fcd4ecc95b07c103fd4ea4f8a2bffdf"
       ]
     },
     "TpC-ord-F4-mf-N-T25u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F4-mf-N-T25u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F4-mf-N-T25u.wav",
         "82c27f3710c7ff947afcaaef4e53584e"
       ]
     },
     "TpC-ord-F#4-mf-N-T16u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#4-mf-N-T16u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#4-mf-N-T16u.wav",
         "72a2e281eb34fe085cf5f8d64ec53b18"
       ]
     },
     "TpC-ord-G4-mf-N-T15u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G4-mf-N-T15u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G4-mf-N-T15u.wav",
         "adac4e8c5edc247132d2ecaa7faa3fba"
       ]
     },
     "TpC-ord-G#4-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#4-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#4-mf-N-N.wav",
         "781e0eeced8262de64606f71e18133c8"
       ]
     },
     "TpC-ord-A4-mf-N-T19u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A4-mf-N-T19u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A4-mf-N-T19u.wav",
         "2ad5af253d4e611c5d232fa99089c831"
       ]
     },
     "TpC-ord-A#4-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#4-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#4-mf-N-N.wav",
         "2fbd884f7d313a9347393f8dbc515842"
       ]
     },
     "TpC-ord-B4-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B4-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B4-mf-N-N.wav",
         "b5714ae9d9c0f7c12c9864627540cfa7"
       ]
     },
     "TpC-ord-C5-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C5-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C5-mf-N-N.wav",
         "98b7ea090bed8a3c6a91a355a1ddb9bc"
       ]
     },
     "TpC-ord-C#5-mf-N-T17u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#5-mf-N-T17u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#5-mf-N-T17u.wav",
         "cf4d2d65cd8da00bd2a05a2c49ccee04"
       ]
     },
     "TpC-ord-D5-mf-N-T14u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D5-mf-N-T14u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D5-mf-N-T14u.wav",
         "b8b73f061e5d3595d79f4019e7e6cd54"
       ]
     },
     "TpC-ord-D#5-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D#5-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D#5-mf-N-N.wav",
         "fec36ca3fd3009fd34d6a5f62b7689b5"
       ]
     },
     "TpC-ord-E5-mf-N-R100u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-E5-mf-N-R100u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-E5-mf-N-R100u.wav",
         "25272548a69528f8562f053b19af80a5"
       ]
     },
     "TpC-ord-F5-mf-N-T11d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F5-mf-N-T11d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F5-mf-N-T11d.wav",
         "a0fd057bad487c48b8b689f645af8bb4"
       ]
     },
     "TpC-ord-F#5-mf-N-T10d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#5-mf-N-T10d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#5-mf-N-T10d.wav",
         "176c52a505286bf4bf544a40a06c637c"
       ]
     },
     "TpC-ord-G5-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G5-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G5-mf-N-N.wav",
         "0923680be1e80e4cc400344f4217798a"
       ]
     },
     "TpC-ord-G#5-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#5-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#5-mf-N-N.wav",
         "39b13af3c7d39c419e695f1bb174e21e"
       ]
     },
     "TpC-ord-A5-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A5-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A5-mf-N-N.wav",
         "739ccbd28662c3c6698818d3b78f15ec"
       ]
     },
     "TpC-ord-A#5-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#5-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#5-mf-N-N.wav",
         "4b612699f02c90908e5b8bceff368350"
       ]
     },
     "TpC-ord-B5-mf-N-T13u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B5-mf-N-T13u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B5-mf-N-T13u.wav",
         "678b929d61594502af6e5eb8655dc01d"
       ]
     },
     "TpC-ord-C6-mf-N-T11u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C6-mf-N-T11u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C6-mf-N-T11u.wav",
         "2bdd6ca95106a550ab451ea5fd207f1a"
       ]
     },
     "TpC-ord-C#6-mf-N-T10u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#6-mf-N-T10u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#6-mf-N-T10u.wav",
         "447bbb389a7590a1909a496e86acdd97"
       ]
     },
     "TpC-ord-D6-mf-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D6-mf-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D6-mf-N-N.wav",
         "a91a73324047043864cfcfb426749b21"
       ]
     },
     "TpC-ord-G3-ff-N-T21u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G3-ff-N-T21u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G3-ff-N-T21u.wav",
         "7a6439347c94b67bd8878aeee0405f3c"
       ]
     },
     "TpC-ord-G#3-ff-N-T23u_R100d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#3-ff-N-T23u_R100d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#3-ff-N-T23u_R100d.wav",
         "4f580bf6a80a942c71f257ecd6f6d761"
       ]
     },
     "TpC-ord-A3-ff-N-T23u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A3-ff-N-T23u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A3-ff-N-T23u.wav",
         "7500ee806c985769795cd5f050156fd3"
       ]
     },
     "TpC-ord-A#3-ff-N-T23u_R100u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#3-ff-N-T23u_R100u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#3-ff-N-T23u_R100u.wav",
         "dccebf95aded655aa862d214bab3924c"
       ]
     },
     "TpC-ord-B3-ff-N-R100d": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B3-ff-N-R100d.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B3-ff-N-R100d.wav",
         "39f42f34e8635e9db069d6be342ffdd2"
       ]
     },
     "TpC-ord-C4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C4-ff-N-N.wav",
         "c67d45d20039142f347f146d8a39662a"
       ]
     },
     "TpC-ord-C#4-ff-N-T39u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#4-ff-N-T39u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#4-ff-N-T39u.wav",
         "4336b1bd100cff5018706d39a23574e5"
       ]
     },
     "TpC-ord-D4-ff-N-T27u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D4-ff-N-T27u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D4-ff-N-T27u.wav",
         "0ddd387d6703f2ba89e94660842ef8c6"
       ]
     },
     "TpC-ord-D#4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D#4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D#4-ff-N-N.wav",
         "579cd09c962d83dfb1eebd71c2041663"
       ]
     },
     "TpC-ord-E4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-E4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-E4-ff-N-N.wav",
         "8141021114e72894f8337218368893c1"
       ]
     },
     "TpC-ord-F4-ff-N-T17u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F4-ff-N-T17u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F4-ff-N-T17u.wav",
         "01414ce6029a95dd1dd764809b5beb5e"
       ]
     },
     "TpC-ord-F#4-ff-N-T14u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#4-ff-N-T14u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#4-ff-N-T14u.wav",
         "326c4f4ac5bd2afc890803863505bb0d"
       ]
     },
     "TpC-ord-G4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G4-ff-N-N.wav",
         "82d060d78d88abf2247cd1142634e779"
       ]
     },
     "TpC-ord-G#4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#4-ff-N-N.wav",
         "9dbe9feb93e3f223a9736cfdb57f7e54"
       ]
     },
     "TpC-ord-A4-ff-N-T22u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A4-ff-N-T22u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A4-ff-N-T22u.wav",
         "8db6abd336b44c368043b8ed5c42c9d9"
       ]
     },
     "TpC-ord-A#4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#4-ff-N-N.wav",
         "b3209a309447b550064333a14f051d5f"
       ]
     },
     "TpC-ord-B4-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B4-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B4-ff-N-N.wav",
         "3c7f741951446e23bc325a10b6b2b60e"
       ]
     },
     "TpC-ord-C5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C5-ff-N-N.wav",
         "c75fdecd5419ed1d4c6a2c7c4f28b1bb"
       ]
     },
     "TpC-ord-C#5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C#5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C#5-ff-N-N.wav",
         "3e639fc7c2882c6ce91fc5787330f91d"
       ]
     },
     "TpC-ord-D5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D5-ff-N-N.wav",
         "fb0ea315f5b9a09b1adb11624f425914"
       ]
     },
     "TpC-ord-D#5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-D#5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-D#5-ff-N-N.wav",
         "882d5f6a33d8ca54de8663afd1ef167e"
       ]
     },
     "TpC-ord-E5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-E5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-E5-ff-N-N.wav",
         "691ffddf18a718967b090eee9921865b"
       ]
     },
     "TpC-ord-F5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F5-ff-N-N.wav",
         "ce2f216e7ec4c91a7f80c724cc7a5033"
       ]
     },
     "TpC-ord-F#5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-F#5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-F#5-ff-N-N.wav",
         "c87875919b075d40e92e962bc8c5ac4d"
       ]
     },
     "TpC-ord-G5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G5-ff-N-N.wav",
         "7c859af612cc9a052cbb43bd29a8fc94"
       ]
     },
     "TpC-ord-G#5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-G#5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-G#5-ff-N-N.wav",
         "e84018c6afb4ea97ee5cf6c12b4c2be2"
       ]
     },
     "TpC-ord-A5-ff-N-T13u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A5-ff-N-T13u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A5-ff-N-T13u.wav",
         "618816b8e3cde515533870362338c107"
       ]
     },
     "TpC-ord-A#5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-A#5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-A#5-ff-N-N.wav",
         "bd091f40e29b5fbcb8f64719051e3172"
       ]
     },
     "TpC-ord-B5-ff-N-N": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-B5-ff-N-N.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-B5-ff-N-N.wav",
         "9d298e8cc6e366c2416b3167c9fd4bfa"
       ]
     },
     "TpC-ord-C6-ff-N-T17u": {
       "audio": [
-        "Brass/Trumpet_C/ordinario/TpC-ord-C6-ff-N-T17u.wav",
+        "audio/Brass/Trumpet_C/ordinario/TpC-ord-C6-ff-N-T17u.wav",
         "e5cae1f979b897fe4ec4097cefd3f84c"
       ]
     },
     "Acc-ord-E1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E1-pp-N-N.wav",
         "f61f8faa08a9e80205e9b8613259cdfb"
       ]
     },
     "Acc-ord-F1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F1-pp-N-N.wav",
         "0cba8a81c38185398ebeffd36852e25e"
       ]
     },
     "Acc-ord-F#1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#1-pp-N-N.wav",
         "e2fc7f27a09a9ac62768165c4ea4901a"
       ]
     },
     "Acc-ord-G1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G1-pp-N-N.wav",
         "8b97ba39c264cfa39b9bbf2f1c0c5e61"
       ]
     },
     "Acc-ord-G#1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#1-pp-N-N.wav",
         "107693bc35b961fbacbe4ae0bf8d845e"
       ]
     },
     "Acc-ord-A1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A1-pp-N-N.wav",
         "69b3229040130d5e25f68cde5691ffc8"
       ]
     },
     "Acc-ord-A#1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#1-pp-N-N.wav",
         "6ba16286b27698c5d3d8d5f0037ef656"
       ]
     },
     "Acc-ord-B1-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B1-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B1-pp-N-N.wav",
         "6dba1fb161d3fce1bda7e4f6cef27779"
       ]
     },
     "Acc-ord-C2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C2-pp-N-N.wav",
         "931c9ad8b09d0e801cdc424a8d6cd2fa"
       ]
     },
     "Acc-ord-C#2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#2-pp-N-N.wav",
         "b210e856f7202b1e8e45ec16805620d9"
       ]
     },
     "Acc-ord-D2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D2-pp-N-N.wav",
         "e06bd1d94caa8abd44cefcd6f4c9ef5c"
       ]
     },
     "Acc-ord-D#2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#2-pp-N-N.wav",
         "cfe72b0ff3def32b7563608489631d10"
       ]
     },
     "Acc-ord-E2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-pp-N-N.wav",
         "9b5d7bd97fb29a5a52beaaec1f257514"
       ]
     },
     "Acc-ord-E2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-pp-alt1-N.wav",
         "b322dded61204fafeafc68d5ae214cf8"
       ]
     },
     "Acc-ord-F2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-pp-N-N.wav",
         "7a9262e0de9d36283b839827935bbbb2"
       ]
     },
     "Acc-ord-F2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-pp-alt1-N.wav",
         "7c33e81495aead9e9e661d05c7536e46"
       ]
     },
     "Acc-ord-F#2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-pp-N-N.wav",
         "a56cc9c95e454b30ad4059fc8c93f0d9"
       ]
     },
     "Acc-ord-F#2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-pp-alt1-N.wav",
         "6807f10168b74a709e32ea76aabdc4db"
       ]
     },
     "Acc-ord-G2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-pp-N-N.wav",
         "302d7e8d82be699bc1b92ee56e0b13b6"
       ]
     },
     "Acc-ord-G2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-pp-alt1-N.wav",
         "c3c01b6556f62055d1967bf3becaa52c"
       ]
     },
     "Acc-ord-G#2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-pp-N-N.wav",
         "566cce4c10fc534272fc28f638a04980"
       ]
     },
     "Acc-ord-G#2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-pp-alt1-N.wav",
         "79d034116cbcba6cca641dc86dcba645"
       ]
     },
     "Acc-ord-A2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-pp-N-N.wav",
         "a4b47a0fc123ff077a9a047853703dff"
       ]
     },
     "Acc-ord-A2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-pp-alt1-N.wav",
         "2e44259227a9482758ff35f71c5ef5ae"
       ]
     },
     "Acc-ord-A#2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-pp-N-N.wav",
         "71e66795ad25750dab8089235a255174"
       ]
     },
     "Acc-ord-A#2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-pp-alt1-N.wav",
         "3150ff7118bcc8fd95f930d7048eadd3"
       ]
     },
     "Acc-ord-B2-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-pp-N-N.wav",
         "afcd1d826f6b3457eb21a87d68e16eff"
       ]
     },
     "Acc-ord-B2-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-pp-alt1-N.wav",
         "0ff0ce7f998008a74e561c30ca8a75a7"
       ]
     },
     "Acc-ord-C3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-pp-N-N.wav",
         "e351af861eeea7d094a1791384717751"
       ]
     },
     "Acc-ord-C3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-pp-alt1-N.wav",
         "e9a9f000a769d733490c6ad754e637a1"
       ]
     },
     "Acc-ord-C#3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-pp-N-N.wav",
         "5f9c82059acf3c1f9c9496b85170d398"
       ]
     },
     "Acc-ord-C#3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-pp-alt1-N.wav",
         "853daf34498e83f79d443ca15d41c280"
       ]
     },
     "Acc-ord-D3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-pp-N-N.wav",
         "116ad579242cfef4907182fff204e921"
       ]
     },
     "Acc-ord-D3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-pp-alt1-N.wav",
         "6eb56205f9239cc05db55cbc8a83630d"
       ]
     },
     "Acc-ord-D#3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-pp-N-N.wav",
         "e1c094b3457e134ef030950395f5afde"
       ]
     },
     "Acc-ord-D#3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-pp-alt1-N.wav",
         "e9ebac88094d34e33be7983e39d32c68"
       ]
     },
     "Acc-ord-E3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-pp-N-N.wav",
         "5457891037cd863f8fbf0b7080a13ddf"
       ]
     },
     "Acc-ord-E3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-pp-alt1-N.wav",
         "a8053454c5bf9022f102680e5aef354f"
       ]
     },
     "Acc-ord-E3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-pp-alt2-N.wav",
         "cb63936ffe2d46852d0a706cb6286dc0"
       ]
     },
     "Acc-ord-F3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-pp-N-N.wav",
         "ee049aed057657eb722646568bb1e831"
       ]
     },
     "Acc-ord-F3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-pp-alt1-N.wav",
         "8bf3d0a46af2f6f8f3451cb43f9f5836"
       ]
     },
     "Acc-ord-F#3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-pp-N-N.wav",
         "c7d10efae37c7e5484d2655f5e0bfe0a"
       ]
     },
     "Acc-ord-F#3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-pp-alt1-N.wav",
         "da532531acce6dce6e466514e88d863d"
       ]
     },
     "Acc-ord-F#3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-pp-alt2-N.wav",
         "70e9e01d5b12f40d6f07559a85f5a18b"
       ]
     },
     "Acc-ord-G3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-pp-N-N.wav",
         "44865b775fdcc06032e182bf1500395f"
       ]
     },
     "Acc-ord-G3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-pp-alt1-N.wav",
         "afe2db503df631d3db8df50e0eec13e0"
       ]
     },
     "Acc-ord-G3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-pp-alt2-N.wav",
         "d3c9d99081d26601d19ef7b5aa7fda4d"
       ]
     },
     "Acc-ord-G#3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-pp-N-N.wav",
         "7a9bd90b386ef65d8d867ce0f871ea07"
       ]
     },
     "Acc-ord-G#3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-pp-alt1-N.wav",
         "ccd485836b86de55714e4adf1647e8ef"
       ]
     },
     "Acc-ord-G#3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-pp-alt2-N.wav",
         "c9ebe8e3cba86ac1370f0e839ce5d79c"
       ]
     },
     "Acc-ord-A3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-pp-N-N.wav",
         "1155dca9935946f0339e0555d7e83c26"
       ]
     },
     "Acc-ord-A3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-pp-alt1-N.wav",
         "6f13d0e71429f15691141b61f270e977"
       ]
     },
     "Acc-ord-A3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-pp-alt2-N.wav",
         "035ee955c4f58c3022bfb965a1a14b74"
       ]
     },
     "Acc-ord-A#3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-pp-N-N.wav",
         "0a57aef0c39053fd19495828b996a381"
       ]
     },
     "Acc-ord-A#3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-pp-alt1-N.wav",
         "8cddbfe8cae020da165319105d841a49"
       ]
     },
     "Acc-ord-A#3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-pp-alt2-N.wav",
         "6c23dd0e2ecc7ca8df97b57b63c123d4"
       ]
     },
     "Acc-ord-B3-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-pp-N-N.wav",
         "a51eb95b1b8884d40bf69b782a63116e"
       ]
     },
     "Acc-ord-B3-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-pp-alt1-N.wav",
         "5abc3b4c129c65b5f0cd8c9762195c90"
       ]
     },
     "Acc-ord-B3-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-pp-alt2-N.wav",
         "9dc0f2cc06b31ad0b24e6a09a1db933b"
       ]
     },
     "Acc-ord-C4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-pp-N-N.wav",
         "6063efcc21206987f0865f3be7254469"
       ]
     },
     "Acc-ord-C4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-pp-alt1-N.wav",
         "49212599e5d34457ea894e0bb46ff1a1"
       ]
     },
     "Acc-ord-C4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-pp-alt2-N.wav",
         "5f5ca02105c0520ebc302fbd9588b14b"
       ]
     },
     "Acc-ord-C#4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-pp-N-N.wav",
         "4aa708f435a5665c4fc8ebd114d0e613"
       ]
     },
     "Acc-ord-C#4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-pp-alt1-N.wav",
         "cbb55767b595341b36ba79d290d8fe5d"
       ]
     },
     "Acc-ord-C#4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-pp-alt2-N.wav",
         "c42c5b40b9bdf0735b6f223fe2d1061b"
       ]
     },
     "Acc-ord-D4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-pp-N-N.wav",
         "dc04d5f20f0dad84520c799f97258fc9"
       ]
     },
     "Acc-ord-D4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-pp-alt1-N.wav",
         "d2f3566b2312c5746fddb84621fa044f"
       ]
     },
     "Acc-ord-D4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-pp-alt2-N.wav",
         "1b198c87fb46331ca3676beb24af3a21"
       ]
     },
     "Acc-ord-D#4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-pp-N-N.wav",
         "e3ae9edfed3cbed6b8b7e0eeb6b90c09"
       ]
     },
     "Acc-ord-D#4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-pp-alt1-N.wav",
         "ec9b2030d19f90e64cad1b792c7fe493"
       ]
     },
     "Acc-ord-D#4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-pp-alt2-N.wav",
         "49bc3969357148015f5e73d9586bdf93"
       ]
     },
     "Acc-ord-E4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-pp-N-N.wav",
         "1556c52271e5ddaf75b3271034efffef"
       ]
     },
     "Acc-ord-E4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-pp-alt1-N.wav",
         "eb57e875405af420245f5b6f9733f692"
       ]
     },
     "Acc-ord-E4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-pp-alt2-N.wav",
         "bebc33f41b8755d5f24241cabf245435"
       ]
     },
     "Acc-ord-F4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-pp-N-N.wav",
         "0dd05ed2349bb616d9a314b31621c6e2"
       ]
     },
     "Acc-ord-F4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-pp-alt1-N.wav",
         "dce576728e02724748caf2001c0b0e6f"
       ]
     },
     "Acc-ord-F4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-pp-alt2-N.wav",
         "dc3fe49e207db61027e5fd5ea5aef817"
       ]
     },
     "Acc-ord-F#4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-pp-N-N.wav",
         "f7553e9d7c7aaee217cabb6899e647db"
       ]
     },
     "Acc-ord-F#4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-pp-alt1-N.wav",
         "ad5dae71de6afd7bd6d0791fa735eb7f"
       ]
     },
     "Acc-ord-F#4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-pp-alt2-N.wav",
         "1dd3b84ebee77d07a5da92410122c486"
       ]
     },
     "Acc-ord-G4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-pp-N-N.wav",
         "2d70b5a95763d6565497250901847634"
       ]
     },
     "Acc-ord-G4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-pp-alt1-N.wav",
         "2bde7c97f6890f0aec0552eab2b0a827"
       ]
     },
     "Acc-ord-G4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-pp-alt2-N.wav",
         "968599cfb02df732831d20ce2b558747"
       ]
     },
     "Acc-ord-G#4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-pp-N-N.wav",
         "c9229fe8835b659921e2bf56e793f9f8"
       ]
     },
     "Acc-ord-G#4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-pp-alt1-N.wav",
         "60a0ad65b05eef31afddd25832d4a687"
       ]
     },
     "Acc-ord-G#4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-pp-alt2-N.wav",
         "c61f5ff8b750d8e9dbffbfdf6e8a34c9"
       ]
     },
     "Acc-ord-A4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-pp-N-N.wav",
         "da27ddfc5810f6e75b3c30f8a81c6230"
       ]
     },
     "Acc-ord-A4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-pp-alt1-N.wav",
         "2a40952218331b1736bbcd80bb6eba55"
       ]
     },
     "Acc-ord-A4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-pp-alt2-N.wav",
         "8ab0b4869214ca8d50210034a53e1c39"
       ]
     },
     "Acc-ord-A#4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-pp-N-N.wav",
         "3cab247470d0b6b488806f374f00516f"
       ]
     },
     "Acc-ord-A#4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-pp-alt1-N.wav",
         "b2913275a131eca916e09c8410fbc88a"
       ]
     },
     "Acc-ord-A#4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-pp-alt2-N.wav",
         "cbbb2669106dbba853df4d54b631de25"
       ]
     },
     "Acc-ord-B4-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-pp-N-N.wav",
         "b79512ed1590d5cb2f562a2745046d50"
       ]
     },
     "Acc-ord-B4-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-pp-alt1-N.wav",
         "83cec9eac9ecc9c9ef532afec023f3b0"
       ]
     },
     "Acc-ord-B4-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-pp-alt2-N.wav",
         "cdd20358bd983400fd546d13bec04a16"
       ]
     },
     "Acc-ord-C5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-pp-N-N.wav",
         "4b11572e414b0fbc72917aec2817b79a"
       ]
     },
     "Acc-ord-C5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-pp-alt1-N.wav",
         "7e7e4782d8279f04a54b113b6d856275"
       ]
     },
     "Acc-ord-C5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-pp-alt2-N.wav",
         "c477d23e526c4a49833e7fac07af6099"
       ]
     },
     "Acc-ord-C#5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-pp-N-N.wav",
         "19bc0c729db45fb7ef959a671be46c33"
       ]
     },
     "Acc-ord-C#5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-pp-alt1-N.wav",
         "1809235d61112bc40eac7de152d7895d"
       ]
     },
     "Acc-ord-C#5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-pp-alt2-N.wav",
         "990908a36cd93830d7f46d48b6249525"
       ]
     },
     "Acc-ord-D5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-pp-N-N.wav",
         "425ec5302abb5de534e184149771112e"
       ]
     },
     "Acc-ord-D5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-pp-alt1-N.wav",
         "1f294c1a38e5689997182123977b33d1"
       ]
     },
     "Acc-ord-D5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-pp-alt2-N.wav",
         "338310682a80da52db7b749bbd145bfe"
       ]
     },
     "Acc-ord-D#5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-pp-N-N.wav",
         "b67de715e3189ab0876f646a0dd0fd60"
       ]
     },
     "Acc-ord-D#5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-pp-alt1-N.wav",
         "aedd184ede7370ec96c918d4764bc9ed"
       ]
     },
     "Acc-ord-D#5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-pp-alt2-N.wav",
         "840042639acc9ae20ca2ea0dbeb5dd0d"
       ]
     },
     "Acc-ord-E5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-pp-N-N.wav",
         "9e956be036b2ed0f18b0c4de93b561b4"
       ]
     },
     "Acc-ord-E5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-pp-alt1-N.wav",
         "1d8bc765eeca0be6df32680ac525275d"
       ]
     },
     "Acc-ord-E5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-pp-alt2-N.wav",
         "55d216f0db487f113f4913659a54e7b5"
       ]
     },
     "Acc-ord-F5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-pp-N-N.wav",
         "ec8b25ea7a40e60984d779bfa89bfece"
       ]
     },
     "Acc-ord-F5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-pp-alt1-N.wav",
         "2a8e83aa91aa39535a649fed5f52b68d"
       ]
     },
     "Acc-ord-F5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-pp-alt2-N.wav",
         "04a677d19898ba23fd3d2a4134e30539"
       ]
     },
     "Acc-ord-F#5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-pp-N-N.wav",
         "41a797918439d28e3068bba6607ae111"
       ]
     },
     "Acc-ord-F#5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-pp-alt1-N.wav",
         "981fee49bbce311daffe25fc52b76f4d"
       ]
     },
     "Acc-ord-F#5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-pp-alt2-N.wav",
         "b53b99dd015c698c4c10701c6c5a274a"
       ]
     },
     "Acc-ord-G5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-pp-N-N.wav",
         "7b3b0bc54d6647ec99f8346a13bcdd8c"
       ]
     },
     "Acc-ord-G5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-pp-alt1-N.wav",
         "f7ab6fb17544b0a9499c772c940a93d1"
       ]
     },
     "Acc-ord-G5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-pp-alt2-N.wav",
         "e211ee154ecb0e88b056a0c3a2067ec9"
       ]
     },
     "Acc-ord-G#5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-pp-N-N.wav",
         "819252045a7cae8dbbc55df3451740e6"
       ]
     },
     "Acc-ord-G#5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-pp-alt1-N.wav",
         "86d64de6ce8b07912668277927941a17"
       ]
     },
     "Acc-ord-G#5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-pp-alt2-N.wav",
         "095a5b31af06bcc2f5a3367bbbb86607"
       ]
     },
     "Acc-ord-A5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-pp-N-N.wav",
         "46ec238a3fcd14dc89927720a009390e"
       ]
     },
     "Acc-ord-A5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-pp-alt1-N.wav",
         "b661d906f23a7c352ef4712276ddeafe"
       ]
     },
     "Acc-ord-A5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-pp-alt2-N.wav",
         "942eb729d58e95cf976518cbf1605293"
       ]
     },
     "Acc-ord-A#5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-pp-N-N.wav",
         "079dfd6291973423f8dcc8a710f13e7c"
       ]
     },
     "Acc-ord-A#5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-pp-alt1-N.wav",
         "16c7d925c9be123f4a19ef40f7cd2827"
       ]
     },
     "Acc-ord-A#5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-pp-alt2-N.wav",
         "e0cd27bc87f1cc59d1f8c148c734b469"
       ]
     },
     "Acc-ord-B5-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-pp-N-N.wav",
         "6bc0b7bec89505971545ad8caf96630c"
       ]
     },
     "Acc-ord-B5-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-pp-alt1-N.wav",
         "daca0a634ae510b7b87da2f6a2bbc43c"
       ]
     },
     "Acc-ord-B5-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-pp-alt2-N.wav",
         "b2c1b2ab7dd51aabe4ca0618db7b0e30"
       ]
     },
     "Acc-ord-C6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-pp-N-N.wav",
         "acd6e0dcc1d0175c1c4de6a16d641db9"
       ]
     },
     "Acc-ord-C6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-pp-alt1-N.wav",
         "2473d26c0240953469f9b5a9b90f8cde"
       ]
     },
     "Acc-ord-C6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-pp-alt2-N.wav",
         "79f0b451f4e6e03b3d7505d95e6dda6d"
       ]
     },
     "Acc-ord-C#6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-pp-N-N.wav",
         "8694779a5ee7ea86de87d7b2380f301b"
       ]
     },
     "Acc-ord-C#6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-pp-alt1-N.wav",
         "e3a2a5ff6deed4847103bd48ead94f63"
       ]
     },
     "Acc-ord-C#6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-pp-alt2-N.wav",
         "cdadfd29f42b8449005e53a3211f2c04"
       ]
     },
     "Acc-ord-D6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-pp-N-N.wav",
         "2b70939df5b84c2b7cbfb74ecb41c946"
       ]
     },
     "Acc-ord-D6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-pp-alt1-N.wav",
         "7d8447facd2e6c9458aeacb66503e133"
       ]
     },
     "Acc-ord-D6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-pp-alt2-N.wav",
         "8b58b4e1744d7f5712ea3fc4d8155948"
       ]
     },
     "Acc-ord-D#6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-pp-N-N.wav",
         "d0000f5909987fca959601c060e1638c"
       ]
     },
     "Acc-ord-D#6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-pp-alt1-N.wav",
         "77541d2ba275a3b43d93095fcdb0c968"
       ]
     },
     "Acc-ord-D#6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-pp-alt2-N.wav",
         "d70519954ff367207c838668e2bfad6d"
       ]
     },
     "Acc-ord-E6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-pp-N-N.wav",
         "c824dc70e6be1bccc6544f0fda78951b"
       ]
     },
     "Acc-ord-E6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-pp-alt1-N.wav",
         "2344f5da018132d0b66e949b36bba8cf"
       ]
     },
     "Acc-ord-E6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-pp-alt2-N.wav",
         "1fe266ed61de7d67315eb869fd4ea485"
       ]
     },
     "Acc-ord-F6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-pp-N-N.wav",
         "03eb0dc3341b6f2415d0a6d8505d6a21"
       ]
     },
     "Acc-ord-F6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-pp-alt1-N.wav",
         "88bc1a3f813ca9752dd455dde1f4b4ec"
       ]
     },
     "Acc-ord-F6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-pp-alt2-N.wav",
         "31e756bfa468d8e0c1a57fc49d5b9805"
       ]
     },
     "Acc-ord-F#6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-pp-N-N.wav",
         "47c754e8d831062c7ef5ffd29b8325e8"
       ]
     },
     "Acc-ord-F#6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-pp-alt1-N.wav",
         "230ed866abec79230f5ee020db7f709f"
       ]
     },
     "Acc-ord-F#6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-pp-alt2-N.wav",
         "e85c45ba73302c2ce329c5bf0f09e360"
       ]
     },
     "Acc-ord-G6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-pp-N-N.wav",
         "462fe7fb8c688abff3360c4f2aa36fc9"
       ]
     },
     "Acc-ord-G6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-pp-alt1-N.wav",
         "a9dc0bb2fb27570a80cf84fde6c756de"
       ]
     },
     "Acc-ord-G6-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-pp-alt2-N.wav",
         "9a2b9b6276504882db65dcae8f98643e"
       ]
     },
     "Acc-ord-G#6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-pp-N-N.wav",
         "960378ce133fe087f3d3419571eb1746"
       ]
     },
     "Acc-ord-G#6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-pp-alt1-N.wav",
         "330d8bd2fa471903868025d38da0db60"
       ]
     },
     "Acc-ord-A6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A6-pp-N-N.wav",
         "0d3ad2d703c5ee81e412a2f8ef579455"
       ]
     },
     "Acc-ord-A6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A6-pp-alt1-N.wav",
         "4eb85cdeada35f3aaf77239972a901c8"
       ]
     },
     "Acc-ord-A#6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-pp-N-N.wav",
         "7d212d6bc286e26b4fa676d71e6610ad"
       ]
     },
     "Acc-ord-A#6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-pp-alt1-N.wav",
         "324079962fcd6b145b11f4fe52215707"
       ]
     },
     "Acc-ord-B6-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-pp-N-N.wav",
         "addbeae1bf10c666afdbf23508848676"
       ]
     },
     "Acc-ord-B6-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-pp-alt1-N.wav",
         "b5d55903d3d088a6e4c163a7d1d9f8b4"
       ]
     },
     "Acc-ord-C7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-pp-N-N.wav",
         "6f229ae2a87478891b529299151a9a8e"
       ]
     },
     "Acc-ord-C7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-pp-alt1-N.wav",
         "0f698cb781073f463c7d0e5135b59fa7"
       ]
     },
     "Acc-ord-C#7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-pp-N-N.wav",
         "723236314aab4e8eccabd0be44add6fd"
       ]
     },
     "Acc-ord-C#7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-pp-alt1-N.wav",
         "b1081a88a63a51ed43229eaf7562cfb3"
       ]
     },
     "Acc-ord-D7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-pp-N-N.wav",
         "62f84275544fab53d81d7a4aea1ffaa8"
       ]
     },
     "Acc-ord-D7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-pp-alt1-N.wav",
         "e281a626d9c03b1ca4998b5af317c85d"
       ]
     },
     "Acc-ord-D#7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-pp-N-N.wav",
         "19c10270977582afd05f8dd38475f929"
       ]
     },
     "Acc-ord-D#7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-pp-alt1-N.wav",
         "bb894ffc6ce45d3dde87c4f1e0c18463"
       ]
     },
     "Acc-ord-E7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-pp-N-N.wav",
         "6f8ff410eb661cf633f67425dfb7d3e7"
       ]
     },
     "Acc-ord-E7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-pp-alt1-N.wav",
         "6e489506dcf9353f9255e3cf2f55752d"
       ]
     },
     "Acc-ord-F7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-pp-N-N.wav",
         "55fb9a2a20cf1d39fe4546eecb48b995"
       ]
     },
     "Acc-ord-F7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-pp-alt1-N.wav",
         "53cdc603ae339c3a6f2a541952e5bf7e"
       ]
     },
     "Acc-ord-F7-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-pp-alt2-N.wav",
         "f5879e14cce9e9b14a7c2b88c3f4807b"
       ]
     },
     "Acc-ord-F#7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-pp-N-N.wav",
         "52cbadccd6f293d053cd13c5149749ca"
       ]
     },
     "Acc-ord-F#7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-pp-alt1-N.wav",
         "49dbf1b856b53921a61a03ecc3bb7130"
       ]
     },
     "Acc-ord-F#7-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-pp-alt2-N.wav",
         "4b4448cada536f70b17f2dcd9be318a8"
       ]
     },
     "Acc-ord-G7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-pp-N-N.wav",
         "82d8ea299f07df8d7eb48ed6f9070c5b"
       ]
     },
     "Acc-ord-G7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-pp-alt1-N.wav",
         "ff59bdd3cb398d056928681a115610e3"
       ]
     },
     "Acc-ord-G7-pp-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-pp-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-pp-alt2-N.wav",
         "b88573b17fe66145aad30e63156fcb3b"
       ]
     },
     "Acc-ord-G#7-pp-N-T11d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#7-pp-N-T11d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#7-pp-N-T11d.wav",
         "ff68d91698215a1e065b5245b74a2644"
       ]
     },
     "Acc-ord-G#7-pp-alt1-T10d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#7-pp-alt1-T10d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#7-pp-alt1-T10d.wav",
         "0b4236bf2bc813d476c87b1751b383ed"
       ]
     },
     "Acc-ord-A7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A7-pp-N-N.wav",
         "a16c00b47e262d9a9b0d98e46e1b5556"
       ]
     },
     "Acc-ord-A7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A7-pp-alt1-N.wav",
         "68514a398a8420acf79e4b504dcff33f"
       ]
     },
     "Acc-ord-A#7-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#7-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#7-pp-N-N.wav",
         "2c047a6b35b518be468c251d4dfbb7bc"
       ]
     },
     "Acc-ord-A#7-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#7-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#7-pp-alt1-N.wav",
         "ea3dadd557f0139201e8df94a4b8561e"
       ]
     },
     "Acc-ord-B7-pp-N-T13d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B7-pp-N-T13d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B7-pp-N-T13d.wav",
         "57595238d87dc0f15822bb3b4c62793a"
       ]
     },
     "Acc-ord-B7-pp-alt1-T13d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B7-pp-alt1-T13d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B7-pp-alt1-T13d.wav",
         "213a384d9117d9e626f89fff1bd5cac9"
       ]
     },
     "Acc-ord-C8-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C8-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C8-pp-N-N.wav",
         "d2ef283c115c5a066bab5296964efb2b"
       ]
     },
     "Acc-ord-C8-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C8-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C8-pp-alt1-N.wav",
         "95ab90060ea9eb6c3b8dea6983ef129f"
       ]
     },
     "Acc-ord-C#8-pp-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#8-pp-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#8-pp-N-N.wav",
         "f4cd63c848737b0d7918d566d7dd9fd4"
       ]
     },
     "Acc-ord-C#8-pp-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#8-pp-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#8-pp-alt1-N.wav",
         "0c5ecabad4beeb2432f9993e47916eba"
       ]
     },
     "Acc-ord-A6-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A6-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A6-p-N-N.wav",
         "0ffa64a1f5e1f20a0a5071b4bdc9d57a"
       ]
     },
     "Acc-ord-A#6-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-p-N-N.wav",
         "2e31540418213b49abb64b49f63f1f40"
       ]
     },
     "Acc-ord-B6-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-p-N-N.wav",
         "f37fc61705b66dfbf6e84b472978ee7f"
       ]
     },
     "Acc-ord-C7-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-p-N-N.wav",
         "df8b9eead58ee1f1b082a43b48c797b3"
       ]
     },
     "Acc-ord-C#7-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-p-N-N.wav",
         "f5009bf0ab6164a4edbebf73382bfb09"
       ]
     },
     "Acc-ord-D7-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-p-N-N.wav",
         "7db69d0258c34e174d86c3fb76099a32"
       ]
     },
     "Acc-ord-D#7-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-p-N-N.wav",
         "98e4990c7a945e94400d280e64cf1c27"
       ]
     },
     "Acc-ord-E7-p-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-p-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-p-N-N.wav",
         "07844d3b990fb12023408683e2b45b24"
       ]
     },
     "Acc-ord-E1-mf-N-T17u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E1-mf-N-T17u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E1-mf-N-T17u.wav",
         "5b1680d2e243a068a7d8fbf8e8b8b678"
       ]
     },
     "Acc-ord-E1-mf-alt1-T13u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E1-mf-alt1-T13u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E1-mf-alt1-T13u.wav",
         "82021dd6fff15d0fd7f9baf81dbdb6f2"
       ]
     },
     "Acc-ord-F1-mf-N-T19u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F1-mf-N-T19u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F1-mf-N-T19u.wav",
         "72f84d326b94119115eadd148b816e9c"
       ]
     },
     "Acc-ord-F1-mf-alt1-T27u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F1-mf-alt1-T27u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F1-mf-alt1-T27u.wav",
         "dbc722f143600fa883af2ca6d918c003"
       ]
     },
     "Acc-ord-F#1-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#1-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#1-mf-N-N.wav",
         "210bdaca50f7901ee1d50b158d3b94cc"
       ]
     },
     "Acc-ord-F#1-mf-alt1-T12u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#1-mf-alt1-T12u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#1-mf-alt1-T12u.wav",
         "4af2e888693ba8624e7bbd54035697ae"
       ]
     },
     "Acc-ord-G1-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G1-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G1-mf-N-N.wav",
         "3ca19866b8e334b635198d72fb726b34"
       ]
     },
     "Acc-ord-G1-mf-alt1-T18u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G1-mf-alt1-T18u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G1-mf-alt1-T18u.wav",
         "c0f8916173b82c3308d0f9f3477ebc6c"
       ]
     },
     "Acc-ord-G#1-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#1-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#1-mf-N-N.wav",
         "4a05b4b36325534cc819f73eb7a49f84"
       ]
     },
     "Acc-ord-G#1-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#1-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#1-mf-alt1-N.wav",
         "7a9d195479a396d1c5daadd868e923a3"
       ]
     },
     "Acc-ord-A1-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A1-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A1-mf-N-N.wav",
         "695e9d8ba3e2e82a6e0cd44788894c31"
       ]
     },
     "Acc-ord-A1-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A1-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A1-mf-alt1-N.wav",
         "629bc4107f9fee3b1f2aa8cb73eefd8e"
       ]
     },
     "Acc-ord-A#1-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#1-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#1-mf-N-N.wav",
         "86402adae3cbafdb6ea30524f491ebf1"
       ]
     },
     "Acc-ord-A#1-mf-alt1-T12u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#1-mf-alt1-T12u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#1-mf-alt1-T12u.wav",
         "6f05f7414e3da5c62174d023e4474ce6"
       ]
     },
     "Acc-ord-B1-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B1-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B1-mf-N-N.wav",
         "a6b3605aa4e96eb4cd7bbb62dcdc822c"
       ]
     },
     "Acc-ord-B1-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B1-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B1-mf-alt1-N.wav",
         "deb9249b2743b3a5d6194b89961f9ea2"
       ]
     },
     "Acc-ord-C2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C2-mf-N-N.wav",
         "d2df9b82107109b9f7a1e0abc88f77ec"
       ]
     },
     "Acc-ord-C2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C2-mf-alt1-N.wav",
         "739cc708b1c25933bcde3199ac37e2af"
       ]
     },
     "Acc-ord-C#2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#2-mf-N-N.wav",
         "128b9dc11d846a06da5e507662874f60"
       ]
     },
     "Acc-ord-C#2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#2-mf-alt1-N.wav",
         "c23830c3e3ed111c8321ddfa2e1b0ace"
       ]
     },
     "Acc-ord-D2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D2-mf-N-N.wav",
         "425d9148d2f82c67bf634bd8037159a4"
       ]
     },
     "Acc-ord-D2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D2-mf-alt1-N.wav",
         "d3b5a6c2b1872cbcf452337a44f0cdea"
       ]
     },
     "Acc-ord-D#2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#2-mf-N-N.wav",
         "4a1370190a4ea274aa62ff3f9f7b84d7"
       ]
     },
     "Acc-ord-D#2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#2-mf-alt1-N.wav",
         "e551b39405b92d7fbd9e0a0f16c86e30"
       ]
     },
     "Acc-ord-E2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-mf-N-N.wav",
         "da5d8144a2f73474562ccecf4857d8b8"
       ]
     },
     "Acc-ord-E2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-mf-alt1-N.wav",
         "969ef06959b7aecf175c904a4acfc689"
       ]
     },
     "Acc-ord-E2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-mf-alt2-N.wav",
         "74b029d42338ca02c3cd1f1f7c2961d3"
       ]
     },
     "Acc-ord-E2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-mf-alt3-N.wav",
         "280ee1c773b4c8c12d20b9681e4b209a"
       ]
     },
     "Acc-ord-F2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-mf-N-N.wav",
         "5975a22bb637c9d7d7f46494ed7aed9b"
       ]
     },
     "Acc-ord-F2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-mf-alt1-N.wav",
         "746491e798767deba91ded344d771b22"
       ]
     },
     "Acc-ord-F2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-mf-alt2-N.wav",
         "73ece6b5ef1295582fb3d789512e978e"
       ]
     },
     "Acc-ord-F2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-mf-alt3-N.wav",
         "111add2a7e8f991b38f54629c7912a72"
       ]
     },
     "Acc-ord-F#2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-N-N.wav",
         "f50a600f8db8eeac44525126e5d54998"
       ]
     },
     "Acc-ord-F#2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-alt1-N.wav",
         "944e77b49cbc18acacfbbc9a019a4039"
       ]
     },
     "Acc-ord-F#2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-alt2-N.wav",
         "3561af5e26223f87784e039606e4e595"
       ]
     },
     "Acc-ord-F#2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-mf-alt3-N.wav",
         "87c38e0a778d0b6d14930e558bfc8530"
       ]
     },
     "Acc-ord-G2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-mf-N-N.wav",
         "6ce0a972d79e107ef4d1f5e4bf61c52e"
       ]
     },
     "Acc-ord-G2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-mf-alt1-N.wav",
         "b1e54f8ddc3938de51975e7bcab0b136"
       ]
     },
     "Acc-ord-G2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-mf-alt2-N.wav",
         "25b78e7ee088baf56fa8ac62412fd22e"
       ]
     },
     "Acc-ord-G2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-mf-alt3-N.wav",
         "c4c28f47d6333565a9117756fd7e34d2"
       ]
     },
     "Acc-ord-G#2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-N-N.wav",
         "66c6ea66bb034fcaa1d245bfcaf7a1a5"
       ]
     },
     "Acc-ord-G#2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-alt1-N.wav",
         "ba808c755ca7b6d93adcae7690a6fbaa"
       ]
     },
     "Acc-ord-G#2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-alt2-N.wav",
         "2bb4f3273091c09ff33ed0b681096ff2"
       ]
     },
     "Acc-ord-G#2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-mf-alt3-N.wav",
         "bfae5642f6c65643f7f8fe43bcb77319"
       ]
     },
     "Acc-ord-A2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-mf-N-N.wav",
         "c66c096e4af9ca92be1c5f5fbe452605"
       ]
     },
     "Acc-ord-A2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-mf-alt1-N.wav",
         "de1a9bb2d1428f0dae3b3eba1d542a7b"
       ]
     },
     "Acc-ord-A2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-mf-alt2-N.wav",
         "1e8ca4154bcc1fdfce0fce78b741c3ed"
       ]
     },
     "Acc-ord-A2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-mf-alt3-N.wav",
         "1cb82657546772084000ec9bca7544cc"
       ]
     },
     "Acc-ord-A#2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-N-N.wav",
         "8c64b57b46b914cc7a108ac211cd7ce4"
       ]
     },
     "Acc-ord-A#2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-alt1-N.wav",
         "2ecc5a55815011652ab735154a5b9feb"
       ]
     },
     "Acc-ord-A#2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-alt2-N.wav",
         "d59746c7eeb82fe5940f0cc1ea89f52f"
       ]
     },
     "Acc-ord-A#2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-mf-alt3-N.wav",
         "e531770b461b09e1e33620e78280ecc9"
       ]
     },
     "Acc-ord-B2-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-mf-N-N.wav",
         "fe470afa8ef0c15e340ddb85a3d0d3e2"
       ]
     },
     "Acc-ord-B2-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-mf-alt1-N.wav",
         "d322bc5689d75ed2a787a82995388b10"
       ]
     },
     "Acc-ord-B2-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-mf-alt2-N.wav",
         "4f0a50e3d0b6167a90711e23fe0f0ec1"
       ]
     },
     "Acc-ord-B2-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-mf-alt3-N.wav",
         "8ba471220061822895efcaa6a8a766cc"
       ]
     },
     "Acc-ord-C3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-mf-N-N.wav",
         "a5e2543ed5d02b74b842fce405ed4c1d"
       ]
     },
     "Acc-ord-C3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-mf-alt1-N.wav",
         "20b66f2a86bb272933787632fe0d5ef8"
       ]
     },
     "Acc-ord-C3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-mf-alt2-N.wav",
         "f64c1ac802fd73537e8dc43f05e4a7e2"
       ]
     },
     "Acc-ord-C3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-mf-alt3-N.wav",
         "9b35320485106bee165447a7cc831618"
       ]
     },
     "Acc-ord-C#3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-N-N.wav",
         "39c618af41b296c8fcdaa87399253fba"
       ]
     },
     "Acc-ord-C#3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-alt1-N.wav",
         "14a2aa58f680d7828850f2c7ba7134a9"
       ]
     },
     "Acc-ord-C#3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-alt2-N.wav",
         "dcc9da53f21568bc3d69f7888e2be593"
       ]
     },
     "Acc-ord-C#3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-mf-alt3-N.wav",
         "6e2f305ef311697b5507f1d7e4aea33b"
       ]
     },
     "Acc-ord-D3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-mf-N-N.wav",
         "3d9668cc23ed394cebd69d87e25c57e5"
       ]
     },
     "Acc-ord-D3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-mf-alt1-N.wav",
         "d08d49fac2f258a71885b84a97900fa1"
       ]
     },
     "Acc-ord-D3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-mf-alt2-N.wav",
         "988a5a4e14e4e232c532c5f3d2e6ecdc"
       ]
     },
     "Acc-ord-D3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-mf-alt3-N.wav",
         "9a4cfe03bd5fd8adf1ba44f08ed5db8d"
       ]
     },
     "Acc-ord-D#3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-N-N.wav",
         "86e9dc5b65291ea7ecbea6699be3c160"
       ]
     },
     "Acc-ord-D#3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-alt1-N.wav",
         "ad60ece4eaadbdebc49dc29156235697"
       ]
     },
     "Acc-ord-D#3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-alt2-N.wav",
         "763027bbee751fcc9d13c37cf492409b"
       ]
     },
     "Acc-ord-D#3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-mf-alt3-N.wav",
         "e2a468492ec6943a5764b1c88e3c929a"
       ]
     },
     "Acc-ord-E3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-mf-N-N.wav",
         "bfee8df1adcd32b75483799c25c695a5"
       ]
     },
     "Acc-ord-E3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt1-N.wav",
         "789f46f4727c20c4878cd386be96471d"
       ]
     },
     "Acc-ord-E3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt2-N.wav",
         "95a973bbe6d8a18f7ed2db72bd31a18e"
       ]
     },
     "Acc-ord-E3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt3-N.wav",
         "bc3cd48afef0f0a01823139ec844979a"
       ]
     },
     "Acc-ord-E3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt4-N.wav",
         "9d432ea41b16b73b2cca88aca4789e11"
       ]
     },
     "Acc-ord-E3-mf-alt5-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt5-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-mf-alt5-N.wav",
         "3dd27b493ed059501af79489c1f2306b"
       ]
     },
     "Acc-ord-F3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-mf-N-N.wav",
         "027dc70d37fb05aee2f4f888023f9c3b"
       ]
     },
     "Acc-ord-F3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt1-N.wav",
         "b9c2ab23753e473f35671227ccf6251e"
       ]
     },
     "Acc-ord-F3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt2-N.wav",
         "e2bc51fe04e4647987ad44a7e4596039"
       ]
     },
     "Acc-ord-F3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt3-N.wav",
         "c0e24de77a83317a953a20a5ebd8b938"
       ]
     },
     "Acc-ord-F3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-mf-alt4-N.wav",
         "2bd3aa5c19b47448fd265ed74ec8620a"
       ]
     },
     "Acc-ord-F#3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-N-N.wav",
         "93e5b074464790dcadd6bf040418bf98"
       ]
     },
     "Acc-ord-F#3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt1-N.wav",
         "2d6a622c0e6b253a1814646aa3e1a5e6"
       ]
     },
     "Acc-ord-F#3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt2-N.wav",
         "b7759d20ad9d8831d65d9a593b9b62c2"
       ]
     },
     "Acc-ord-F#3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt3-N.wav",
         "4f2975b3fedcabce3de91215a6cab88d"
       ]
     },
     "Acc-ord-F#3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-mf-alt4-N.wav",
         "6ac46284a58872bff3a670926c950254"
       ]
     },
     "Acc-ord-G3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-mf-N-N.wav",
         "5ffaa217e25322290453bdf64b50fc73"
       ]
     },
     "Acc-ord-G3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt1-N.wav",
         "c36acb4bf00c344f6db62102b67ddc0a"
       ]
     },
     "Acc-ord-G3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt2-N.wav",
         "30ddd5949b0141ebbd898972305e78e7"
       ]
     },
     "Acc-ord-G3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt3-N.wav",
         "bc811c2191b7064c386ef7ab82933526"
       ]
     },
     "Acc-ord-G3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-mf-alt4-N.wav",
         "e476d08a09656e791f38d1406c29dc49"
       ]
     },
     "Acc-ord-G#3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-N-N.wav",
         "26b9f68fad11f245ea12f53127eeaa56"
       ]
     },
     "Acc-ord-G#3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt1-N.wav",
         "ed0e764635b7efe8a2231eee3da58a79"
       ]
     },
     "Acc-ord-G#3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt2-N.wav",
         "c4c5153d3f5e678d15b4b851f6754170"
       ]
     },
     "Acc-ord-G#3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt3-N.wav",
         "57219a1b9f3af0f49d9c624d76622352"
       ]
     },
     "Acc-ord-G#3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-mf-alt4-N.wav",
         "e4af01f0400ef4b2c6ea3c4c81a4e6aa"
       ]
     },
     "Acc-ord-A3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-mf-N-N.wav",
         "c07aa2e67cdc89a4a8d93d62e128ec0d"
       ]
     },
     "Acc-ord-A3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt1-N.wav",
         "dd330451684b0d788680876e563e4797"
       ]
     },
     "Acc-ord-A3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt2-N.wav",
         "2a74d167a61e2ba490876d7cba51839c"
       ]
     },
     "Acc-ord-A3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt3-N.wav",
         "491d929ba8f03bbfaca009dcb4f690cd"
       ]
     },
     "Acc-ord-A3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-mf-alt4-N.wav",
         "2745d30ae365b9101be23c74e28a3ef2"
       ]
     },
     "Acc-ord-A#3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-N-N.wav",
         "d3bb0963c4f3a668df7c55a81965146b"
       ]
     },
     "Acc-ord-A#3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt1-N.wav",
         "2739167fbd5c67d98c139d843eb2f04e"
       ]
     },
     "Acc-ord-A#3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt2-N.wav",
         "ab2018f150d02a0611e1a99c0c1612fe"
       ]
     },
     "Acc-ord-A#3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt3-N.wav",
         "6be7b98fd8dc78960ea1b0d47088f571"
       ]
     },
     "Acc-ord-A#3-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-mf-alt4-N.wav",
         "1dc1256bafa09125c870eac851a9d605"
       ]
     },
     "Acc-ord-B3-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-mf-N-N.wav",
         "71cb61fde520e18d87503d0753fc2177"
       ]
     },
     "Acc-ord-B3-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt1-N.wav",
         "d709226dde597e4ccea18ac12ada4a73"
       ]
     },
     "Acc-ord-B3-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt2-N.wav",
         "58a7a86c0712c2e16f8d4780ee2a286d"
       ]
     },
     "Acc-ord-B3-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt3-N.wav",
         "3a6dea68d0ba3e3684136b127f4621c5"
       ]
     },
     "Acc-ord-B3-mf-alt4-T10d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt4-T10d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-mf-alt4-T10d.wav",
         "ee1755f3ee238c2883e6b960feea45fa"
       ]
     },
     "Acc-ord-C4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-mf-N-N.wav",
         "b3335e029ae324e247988283c54bbc77"
       ]
     },
     "Acc-ord-C4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt1-N.wav",
         "ba7fe8c81e9edb8dfb794b7cae3a38c1"
       ]
     },
     "Acc-ord-C4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt2-N.wav",
         "b2a5fc185e30ea5f49d4be79579e0888"
       ]
     },
     "Acc-ord-C4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt3-N.wav",
         "cb5e0f279ae2750958eb8f5c22f659ea"
       ]
     },
     "Acc-ord-C4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-mf-alt4-N.wav",
         "6b8114a3500bdc6c751b1c3e5aad2285"
       ]
     },
     "Acc-ord-C#4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-N-N.wav",
         "819adfb7ee0f53ed4db4c57daac25cdc"
       ]
     },
     "Acc-ord-C#4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt1-N.wav",
         "67a510a57b45e863cf98549d7fa3fd3a"
       ]
     },
     "Acc-ord-C#4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt2-N.wav",
         "4b86a13b7bffd67674d3bebee7fc010b"
       ]
     },
     "Acc-ord-C#4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt3-N.wav",
         "af668cc67dfda24d8ba35079e0ecb209"
       ]
     },
     "Acc-ord-C#4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-mf-alt4-N.wav",
         "b5e2dfba77b3a17195b9e08d21e6fda3"
       ]
     },
     "Acc-ord-D4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-mf-N-N.wav",
         "bf990eaa8b910b9cb6cb1e2e7ab094fc"
       ]
     },
     "Acc-ord-D4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt1-N.wav",
         "2f5272b394128b08ba006a7f9a0679fa"
       ]
     },
     "Acc-ord-D4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt2-N.wav",
         "c3f5fdd0bad015b5556f82431a6332ce"
       ]
     },
     "Acc-ord-D4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt3-N.wav",
         "f0d84889f850903b7ae5a51584eb7f32"
       ]
     },
     "Acc-ord-D4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-mf-alt4-N.wav",
         "77431d326fd467838077070f3e7310e4"
       ]
     },
     "Acc-ord-D#4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-N-N.wav",
         "56bf0bdac0e471569ae885a36a49b48b"
       ]
     },
     "Acc-ord-D#4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt1-N.wav",
         "17904c85988891b6c51dcb34815dfeae"
       ]
     },
     "Acc-ord-D#4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt2-N.wav",
         "3f7f7fb7a26ce17a7e09471cf8f523f7"
       ]
     },
     "Acc-ord-D#4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt3-N.wav",
         "71f1ba4598a5aa0ac57e69c90e377ad4"
       ]
     },
     "Acc-ord-D#4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-mf-alt4-N.wav",
         "68f642c12334b2b0d5afbcae7a8d9b60"
       ]
     },
     "Acc-ord-E4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-mf-N-N.wav",
         "5814b8f0b68765013326ad7dd5992e81"
       ]
     },
     "Acc-ord-E4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt1-N.wav",
         "83cc5f9014b873f175058dda97b08ede"
       ]
     },
     "Acc-ord-E4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt2-N.wav",
         "f36de06b0775ecabb21f1f28e018d44a"
       ]
     },
     "Acc-ord-E4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt3-N.wav",
         "b928185d03acb301a5798ebd5b43a2b3"
       ]
     },
     "Acc-ord-E4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt4-N.wav",
         "0ba05a5bd338d7b3c607f261c381ffb1"
       ]
     },
     "Acc-ord-E4-mf-alt5-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt5-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-mf-alt5-N.wav",
         "5c33383b84c4a6570c4645d585f05a20"
       ]
     },
     "Acc-ord-F4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-mf-N-N.wav",
         "0b86b7c6a6e0559e905f47cfb3d1a2b6"
       ]
     },
     "Acc-ord-F4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt1-N.wav",
         "8dbd1c2f64d6fbe27ce491256fab6ad5"
       ]
     },
     "Acc-ord-F4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt2-N.wav",
         "7479d04ef17b9218887dd18231d6695b"
       ]
     },
     "Acc-ord-F4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt3-N.wav",
         "3afa95564248905e3686dc04f854c481"
       ]
     },
     "Acc-ord-F4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-mf-alt4-N.wav",
         "ee34186e1665c250da12b94567eecbee"
       ]
     },
     "Acc-ord-F#4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-N-N.wav",
         "0a163dced08d89b04d152d689a147c42"
       ]
     },
     "Acc-ord-F#4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt1-N.wav",
         "3ea557e7457c05d547207d4b02f511f5"
       ]
     },
     "Acc-ord-F#4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt2-N.wav",
         "16ebea884861bb4905c6a55878a947fd"
       ]
     },
     "Acc-ord-F#4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt3-N.wav",
         "85456b6b19763fe815c0fbfcc54a890b"
       ]
     },
     "Acc-ord-F#4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-mf-alt4-N.wav",
         "2c93f07ffaebb83dd08243a86afe245d"
       ]
     },
     "Acc-ord-G4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-mf-N-N.wav",
         "4ad057599ecf9cd30217d6beeeaa5259"
       ]
     },
     "Acc-ord-G4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt1-N.wav",
         "74e373f1028615da6ada5eeef64f66b8"
       ]
     },
     "Acc-ord-G4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt2-N.wav",
         "f1e5a9fa56df4f8ef4b850e311d446f0"
       ]
     },
     "Acc-ord-G4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt3-N.wav",
         "9e8c664a794e1b86173039d58002913b"
       ]
     },
     "Acc-ord-G4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-mf-alt4-N.wav",
         "e014f7a0ed901f62949338adc8ceb68b"
       ]
     },
     "Acc-ord-G#4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-N-N.wav",
         "0faaf09a791e8fdbe6dc1070a329bece"
       ]
     },
     "Acc-ord-G#4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt1-N.wav",
         "5c95c6aff2938a5364a439da0ce4a396"
       ]
     },
     "Acc-ord-G#4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt2-N.wav",
         "f9070be6911e5a09f78fcf983cc408e4"
       ]
     },
     "Acc-ord-G#4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt3-N.wav",
         "7bff2197b2fddbbc604511ea0e92ae5b"
       ]
     },
     "Acc-ord-G#4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-mf-alt4-N.wav",
         "ebcf5a9a4180779228fbca524a9e52c4"
       ]
     },
     "Acc-ord-A4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-mf-N-N.wav",
         "abba9b9c6d42469df5015add6d887d67"
       ]
     },
     "Acc-ord-A4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt1-N.wav",
         "c531d06a4c53cde1e186a6f38b5ecd09"
       ]
     },
     "Acc-ord-A4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt2-N.wav",
         "b20560b7a7f77025e1bbddf6fa8ed6b1"
       ]
     },
     "Acc-ord-A4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt3-N.wav",
         "1a5256a2fda087ebbb747219fa20e4b5"
       ]
     },
     "Acc-ord-A4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-mf-alt4-N.wav",
         "574ec66ddd35fbaa606efe09138fd71c"
       ]
     },
     "Acc-ord-A#4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-N-N.wav",
         "95e2f621f5b41278d9f96cee3f553e65"
       ]
     },
     "Acc-ord-A#4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt1-N.wav",
         "723037177a512661b8f6e5aba0ed7161"
       ]
     },
     "Acc-ord-A#4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt2-N.wav",
         "9d619d570f04d7a3476d22c6e543f392"
       ]
     },
     "Acc-ord-A#4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt3-N.wav",
         "68b8417146c94197aad475f08bc8daeb"
       ]
     },
     "Acc-ord-A#4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-mf-alt4-N.wav",
         "c896fc05eee008d31588c1b340dea4b1"
       ]
     },
     "Acc-ord-B4-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-mf-N-N.wav",
         "c16f161a0b3cc0ab94118bf725c02bb1"
       ]
     },
     "Acc-ord-B4-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt1-N.wav",
         "14ec1f81bb63b8aa0da280b332aa017f"
       ]
     },
     "Acc-ord-B4-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt2-N.wav",
         "db8bac2c5014995ff97785fd27611a1f"
       ]
     },
     "Acc-ord-B4-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt3-N.wav",
         "da1126b8402d465f99277e03f290cbcd"
       ]
     },
     "Acc-ord-B4-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-mf-alt4-N.wav",
         "c55866559da5f8e7a3257004d94370f1"
       ]
     },
     "Acc-ord-C5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-mf-N-N.wav",
         "96917844be0f65c9d2dd2184665baac6"
       ]
     },
     "Acc-ord-C5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt1-N.wav",
         "1a7c94b6f28a9e560d2e02fd8d478653"
       ]
     },
     "Acc-ord-C5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt2-N.wav",
         "91cc02b1708fc826492a8e40e927f243"
       ]
     },
     "Acc-ord-C5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt3-N.wav",
         "9da59e8d2e268972071e846452683be5"
       ]
     },
     "Acc-ord-C5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-mf-alt4-N.wav",
         "2847a50e95aca5c31c3b3d8d9d7f986a"
       ]
     },
     "Acc-ord-C#5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-N-N.wav",
         "1ded9ea8425133193a2078db1ff11b11"
       ]
     },
     "Acc-ord-C#5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt1-N.wav",
         "17472354d2ddfc34e9369a076b243639"
       ]
     },
     "Acc-ord-C#5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt2-N.wav",
         "8d951707935ae5757e38bc6ccc8e5894"
       ]
     },
     "Acc-ord-C#5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt3-N.wav",
         "38207089080dd216748e28c4455df30c"
       ]
     },
     "Acc-ord-C#5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-mf-alt4-N.wav",
         "eac71133714fef6776e78a49becf8820"
       ]
     },
     "Acc-ord-D5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-mf-N-N.wav",
         "ef3bf7e626cd4da2f30fc2ddd14188b6"
       ]
     },
     "Acc-ord-D5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt1-N.wav",
         "1c536c2b3228c65a78f37f62f936b9d1"
       ]
     },
     "Acc-ord-D5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt2-N.wav",
         "5725edba2443a9b310a9247a48d38b87"
       ]
     },
     "Acc-ord-D5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt3-N.wav",
         "6c1b8042f72e83ea673795088e2c4dd3"
       ]
     },
     "Acc-ord-D5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-mf-alt4-N.wav",
         "dade98c5a6579901e27a27438e2f8ecf"
       ]
     },
     "Acc-ord-D#5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-N-N.wav",
         "9500da93999767d953c324399d467646"
       ]
     },
     "Acc-ord-D#5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt1-N.wav",
         "7d7ae62caf91a0d18321c146a19422b7"
       ]
     },
     "Acc-ord-D#5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt2-N.wav",
         "6f10f2360624692d5bcb3ab008c1fb21"
       ]
     },
     "Acc-ord-D#5-mf-alt3-T10d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt3-T10d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt3-T10d.wav",
         "2d9abbad082a7a765cc5cd51c1e6760d"
       ]
     },
     "Acc-ord-D#5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-mf-alt4-N.wav",
         "b75575f000cecd46c985b2361410f280"
       ]
     },
     "Acc-ord-E5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-mf-N-N.wav",
         "911e25cf79c3ff989973c86f9b5d0ae1"
       ]
     },
     "Acc-ord-E5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt1-N.wav",
         "66e0bc33691962d659f175bcab8d8502"
       ]
     },
     "Acc-ord-E5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt2-N.wav",
         "22e2bcd993c1793b706908dd339ce8cc"
       ]
     },
     "Acc-ord-E5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt3-N.wav",
         "a3c63c4fe1f202df19190eda333afde4"
       ]
     },
     "Acc-ord-E5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt4-N.wav",
         "5488f256e6d2574da6a657a7cdf4e614"
       ]
     },
     "Acc-ord-E5-mf-alt5-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt5-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-mf-alt5-N.wav",
         "a74933b6975ccd4372ef6cff51c19783"
       ]
     },
     "Acc-ord-F5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-mf-N-N.wav",
         "6f9147cc2739d3d6f701bf7113d8622b"
       ]
     },
     "Acc-ord-F5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt1-N.wav",
         "4dccf74d5652244660f730782695f771"
       ]
     },
     "Acc-ord-F5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt2-N.wav",
         "10964bf0a94820f0675bb701b16d7308"
       ]
     },
     "Acc-ord-F5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt3-N.wav",
         "845cec4539c07306cde811c1dd860fd9"
       ]
     },
     "Acc-ord-F5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-mf-alt4-N.wav",
         "201c9000e46f855af8ee3bbe4410b1ec"
       ]
     },
     "Acc-ord-F#5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-N-N.wav",
         "ac8a7ba6f060d27f2d80cfa7e79beda9"
       ]
     },
     "Acc-ord-F#5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt1-N.wav",
         "fa2baa77a1fae905167a22a13549b253"
       ]
     },
     "Acc-ord-F#5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt2-N.wav",
         "8e107b12837d55babb6cc31796b50c25"
       ]
     },
     "Acc-ord-F#5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt3-N.wav",
         "59fa98d485492d252dd3b62e8c47a659"
       ]
     },
     "Acc-ord-F#5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-mf-alt4-N.wav",
         "62d90d746d2530ef12d418172531d931"
       ]
     },
     "Acc-ord-G5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-mf-N-N.wav",
         "6b5b6e688710c151b5e0d0d691367802"
       ]
     },
     "Acc-ord-G5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt1-N.wav",
         "b92187c11b6c20cfd1e65ef8892de50d"
       ]
     },
     "Acc-ord-G5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt2-N.wav",
         "47e80b52a70c7ed52d016b0a51d47904"
       ]
     },
     "Acc-ord-G5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt3-N.wav",
         "0033edeb09f3525cb055c4a3e0ced997"
       ]
     },
     "Acc-ord-G5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-mf-alt4-N.wav",
         "a7d2549dcc32745741d4f9592430032b"
       ]
     },
     "Acc-ord-G#5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-N-N.wav",
         "abc10b8e726c259e55f4c2dc1fd468dd"
       ]
     },
     "Acc-ord-G#5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt1-N.wav",
         "de22078e77ddace7c5d7f847f3b1d576"
       ]
     },
     "Acc-ord-G#5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt2-N.wav",
         "45374d3a80f3e74105b35683b6158ae8"
       ]
     },
     "Acc-ord-G#5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt3-N.wav",
         "2170e68acae623eaf9143cb01e94b9fc"
       ]
     },
     "Acc-ord-G#5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-mf-alt4-N.wav",
         "baddea666c5fd2a37dc11b1a6109566e"
       ]
     },
     "Acc-ord-A5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-mf-N-N.wav",
         "ad40ae1d80749b229c460e20360ab746"
       ]
     },
     "Acc-ord-A5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt1-N.wav",
         "4f6f0f05b623c2f936cf7f6b30b9b55c"
       ]
     },
     "Acc-ord-A5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt2-N.wav",
         "f8213bbba88fed857b8824518a74a43d"
       ]
     },
     "Acc-ord-A5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt3-N.wav",
         "911a61b8ccf541262cb7fc24cc48c484"
       ]
     },
     "Acc-ord-A5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-mf-alt4-N.wav",
         "591c1cbdc149fc9e3b7e87781ee2913b"
       ]
     },
     "Acc-ord-A#5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-N-N.wav",
         "f3afee190c1e0056faf52c757827709a"
       ]
     },
     "Acc-ord-A#5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt1-N.wav",
         "fcf8eec3dc24f0b6406ee838d84332d0"
       ]
     },
     "Acc-ord-A#5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt2-N.wav",
         "78efbeefac7485ecf54e8a264a728346"
       ]
     },
     "Acc-ord-A#5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt3-N.wav",
         "fae4d912523719bf97a75604f071a33a"
       ]
     },
     "Acc-ord-A#5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-mf-alt4-N.wav",
         "02dcd799266973ab447761e85b9b37a2"
       ]
     },
     "Acc-ord-B5-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-mf-N-N.wav",
         "50108c91ab00512d7ed3564f3ecf6323"
       ]
     },
     "Acc-ord-B5-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt1-N.wav",
         "3b066d32bb90ae1125f3b844db2b5990"
       ]
     },
     "Acc-ord-B5-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt2-N.wav",
         "99b848846d5967a999d491115ce6608f"
       ]
     },
     "Acc-ord-B5-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt3-N.wav",
         "1bc6fb0adeafe3d7b05da5fbca10c7e3"
       ]
     },
     "Acc-ord-B5-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-mf-alt4-N.wav",
         "7ca25fd616362ae5cd9f670b4113adc3"
       ]
     },
     "Acc-ord-C6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-mf-N-N.wav",
         "9ea7c5b70b5d763eae2103c9bd7cedf5"
       ]
     },
     "Acc-ord-C6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt1-N.wav",
         "7c1695787a7e77558cb15cc7de8742ea"
       ]
     },
     "Acc-ord-C6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt2-N.wav",
         "8ae094834be343aa5bf90789d455d32e"
       ]
     },
     "Acc-ord-C6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt3-N.wav",
         "a8da52e543b7f47da31ca13d551287f7"
       ]
     },
     "Acc-ord-C6-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-mf-alt4-N.wav",
         "5f824276a931e7afe46578201c4c7b32"
       ]
     },
     "Acc-ord-C#6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-N-N.wav",
         "8293c7915056650e2277fde0ce33ce4a"
       ]
     },
     "Acc-ord-C#6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt1-N.wav",
         "d31e4ac1a4814b8b932ae10325a2b7d3"
       ]
     },
     "Acc-ord-C#6-mf-alt2-T10d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt2-T10d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt2-T10d.wav",
         "23274aa4e74218c2df039f4d422a6982"
       ]
     },
     "Acc-ord-C#6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt3-N.wav",
         "2b02d575f10f4e783f3f6800c81592e7"
       ]
     },
     "Acc-ord-C#6-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-mf-alt4-N.wav",
         "5bdb2baaa2eb8f91e1be74dfb05b5d4e"
       ]
     },
     "Acc-ord-D6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-mf-N-N.wav",
         "60cf34b94b7b7f408a2d9cf264d2962e"
       ]
     },
     "Acc-ord-D6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-mf-alt1-N.wav",
         "0d47b73c2a2f9de241422e84bcb31855"
       ]
     },
     "Acc-ord-D6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-mf-alt2-N.wav",
         "4ddb4d6f2c940fd55622b37dad409ff1"
       ]
     },
     "Acc-ord-D6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-mf-alt3-N.wav",
         "92a54caae7ebce0d4e777713147de997"
       ]
     },
     "Acc-ord-D#6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-N-N.wav",
         "38157ce5821cfb6391f567b8b410fce1"
       ]
     },
     "Acc-ord-D#6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-alt1-N.wav",
         "bc4f3ad535cd2ab57685e99344bb29c8"
       ]
     },
     "Acc-ord-D#6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-alt2-N.wav",
         "a1efa7cc06f8ad108642286b09b0f7f8"
       ]
     },
     "Acc-ord-D#6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-mf-alt3-N.wav",
         "fdbdff1656f4ee0d6afb0d74f04211ae"
       ]
     },
     "Acc-ord-E6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-mf-N-N.wav",
         "ab409c9b7a2dc99698e9f5ca3badde10"
       ]
     },
     "Acc-ord-E6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt1-N.wav",
         "31938d9aa2c8d267e7a7b1437ba8cb17"
       ]
     },
     "Acc-ord-E6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt2-N.wav",
         "e16b06c04474c2d36162f5252a6e3746"
       ]
     },
     "Acc-ord-E6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt3-N.wav",
         "cb73d94b57e5b872140fbaf24712d5e4"
       ]
     },
     "Acc-ord-E6-mf-alt4-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt4-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-mf-alt4-N.wav",
         "4ce728c15244e24e310c5d1b8a621c8d"
       ]
     },
     "Acc-ord-F6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-mf-N-N.wav",
         "3557e6de02368567e3512382b45c8478"
       ]
     },
     "Acc-ord-F6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-mf-alt1-N.wav",
         "55d9fa08a260e8170fc5973d03cc90a6"
       ]
     },
     "Acc-ord-F6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-mf-alt2-N.wav",
         "d80eef6ec7751870245cc45871b02bec"
       ]
     },
     "Acc-ord-F6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-mf-alt3-N.wav",
         "60ca8418f3e57d12e9f5d460a437737d"
       ]
     },
     "Acc-ord-F#6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-N-N.wav",
         "6670c8541fc8f0bd1cc4dab7ef156719"
       ]
     },
     "Acc-ord-F#6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-alt1-N.wav",
         "7f6c60a5318ea3ac61db6750dba4c453"
       ]
     },
     "Acc-ord-F#6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-alt2-N.wav",
         "a363fe5dc77dd13d62ee45ee29671a78"
       ]
     },
     "Acc-ord-F#6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-mf-alt3-N.wav",
         "b99aa4a4faf5cb843bce3e92988e7a56"
       ]
     },
     "Acc-ord-G6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-mf-N-N.wav",
         "d521588f919e68f6781c148f4a37b9e8"
       ]
     },
     "Acc-ord-G6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-mf-alt1-N.wav",
         "95c0c451b2c2973a654c9d405305e259"
       ]
     },
     "Acc-ord-G6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-mf-alt2-N.wav",
         "4e7bd3ade79bec255857468a18da5d2b"
       ]
     },
     "Acc-ord-G6-mf-alt3-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-mf-alt3-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-mf-alt3-N.wav",
         "0c46f0ca7e4086140105f5a62df83a83"
       ]
     },
     "Acc-ord-G#6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-mf-N-N.wav",
         "6dcc2e5c69fd58cbdf00044ead5e5edf"
       ]
     },
     "Acc-ord-G#6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-mf-alt1-N.wav",
         "2e388f7c1a9fea87a16e9c6b5175fc1d"
       ]
     },
     "Acc-ord-G#6-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-mf-alt2-N.wav",
         "83cafda3123cb5d1362beb1c278547c6"
       ]
     },
     "Acc-ord-A6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A6-mf-N-N.wav",
         "7e3081a92994002c501ceca476ace212"
       ]
     },
     "Acc-ord-A6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A6-mf-alt1-N.wav",
         "39133be6285f618d82357e318946de0c"
       ]
     },
     "Acc-ord-A#6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-mf-N-N.wav",
         "e580b4041fa36feb9298884a46f3a63e"
       ]
     },
     "Acc-ord-A#6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-mf-alt1-N.wav",
         "5d0dfe4293a014cfe9e4b179e70bab59"
       ]
     },
     "Acc-ord-B6-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-mf-N-N.wav",
         "a3ae86c131c2dfbccf5e6bd0d5a796e5"
       ]
     },
     "Acc-ord-B6-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-mf-alt1-N.wav",
         "2b03eefd6d71710f1e5913f4f9691aff"
       ]
     },
     "Acc-ord-C7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-mf-N-N.wav",
         "5e8c2be8ccf338601170935e4abb0a0c"
       ]
     },
     "Acc-ord-C7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-mf-alt1-N.wav",
         "4ca57213ba492291ee17c77069661a04"
       ]
     },
     "Acc-ord-C#7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-mf-N-N.wav",
         "85f54211e50b063c7d10744dc0197453"
       ]
     },
     "Acc-ord-C#7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-mf-alt1-N.wav",
         "03066408cdc388e2c97d7a05fc26e49e"
       ]
     },
     "Acc-ord-D7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-mf-N-N.wav",
         "3937bc1f2f80cccd2786efda2c7d19f8"
       ]
     },
     "Acc-ord-D7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-mf-alt1-N.wav",
         "2d90a8082d0a5293bf2c58d9621abffe"
       ]
     },
     "Acc-ord-D#7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-mf-N-N.wav",
         "d18537db599e57d8961d355018c4c211"
       ]
     },
     "Acc-ord-D#7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-mf-alt1-N.wav",
         "3e49d6f542b920a172590e0bd2ab9694"
       ]
     },
     "Acc-ord-E7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-mf-N-N.wav",
         "f8c31a71b35c2e1f810edd53fd88ff7d"
       ]
     },
     "Acc-ord-E7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-mf-alt1-N.wav",
         "d5f7f63746cb65e4942adb8eb4003110"
       ]
     },
     "Acc-ord-E7-mf-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-mf-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-mf-alt2-N.wav",
         "3f43dd1f59396763d07fe14ba5603eb4"
       ]
     },
     "Acc-ord-F7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-mf-N-N.wav",
         "0f139c4d829c940c9c727c7090a9e56d"
       ]
     },
     "Acc-ord-F7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-mf-alt1-N.wav",
         "e21acda202598ed85471fc4ac2dd685a"
       ]
     },
     "Acc-ord-F#7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-mf-N-N.wav",
         "7a66ffcb0d0754b82790e06fc988e400"
       ]
     },
     "Acc-ord-F#7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-mf-alt1-N.wav",
         "33faa57b37680aa3f3feb8243a45821f"
       ]
     },
     "Acc-ord-G7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-mf-N-N.wav",
         "b265eb2382608ac385fea564dfbae157"
       ]
     },
     "Acc-ord-G7-mf-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-mf-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-mf-alt1-N.wav",
         "56e54a64982d8d0c0ff95389b9bb250c"
       ]
     },
     "Acc-ord-G#7-mf-N-T10d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#7-mf-N-T10d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#7-mf-N-T10d.wav",
         "a49cdab2ad6badee6b39de0be2227540"
       ]
     },
     "Acc-ord-A7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A7-mf-N-N.wav",
         "5a237c343ec1ef8543459218c65902ab"
       ]
     },
     "Acc-ord-A#7-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#7-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#7-mf-N-N.wav",
         "9fccbc5fb9285446ada03cd7416b8dad"
       ]
     },
     "Acc-ord-B7-mf-N-T13d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B7-mf-N-T13d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B7-mf-N-T13d.wav",
         "6eb0f23339b9b48742c74236565e2da9"
       ]
     },
     "Acc-ord-C8-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C8-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C8-mf-N-N.wav",
         "98e744b6112a8616868d8a6b96703eed"
       ]
     },
     "Acc-ord-C#8-mf-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#8-mf-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#8-mf-N-N.wav",
         "68623116d01fb9e8a085c4cbaee19f12"
       ]
     },
     "Acc-ord-E1-ff-N-T20u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E1-ff-N-T20u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E1-ff-N-T20u.wav",
         "f423b17718aa958d330d8054c1940ab3"
       ]
     },
     "Acc-ord-F1-ff-N-T30u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F1-ff-N-T30u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F1-ff-N-T30u.wav",
         "199327192dee5a80bdc24e56c117fb6a"
       ]
     },
     "Acc-ord-F#1-ff-N-T29u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#1-ff-N-T29u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#1-ff-N-T29u.wav",
         "7a3d3f4cfa634813e10c22450e28ee92"
       ]
     },
     "Acc-ord-G1-ff-N-T20u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G1-ff-N-T20u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G1-ff-N-T20u.wav",
         "cc2e3c4c9bc0935d754d090e9cd4797f"
       ]
     },
     "Acc-ord-G#1-ff-N-T16u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#1-ff-N-T16u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#1-ff-N-T16u.wav",
         "26c6f301fcf73132f0a7e616331fe9a8"
       ]
     },
     "Acc-ord-A1-ff-N-T22u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A1-ff-N-T22u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A1-ff-N-T22u.wav",
         "52a01981a2893d95f19627ccc5a6e879"
       ]
     },
     "Acc-ord-A#1-ff-N-T12u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#1-ff-N-T12u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#1-ff-N-T12u.wav",
         "7342ad96cc46cbaf2f13726bd698d935"
       ]
     },
     "Acc-ord-B1-ff-N-T11u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B1-ff-N-T11u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B1-ff-N-T11u.wav",
         "3257d29d0c0252628a6a9794501a45c9"
       ]
     },
     "Acc-ord-C2-ff-N-T12u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C2-ff-N-T12u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C2-ff-N-T12u.wav",
         "78936f54c58073d63601bb38aa4ffcd4"
       ]
     },
     "Acc-ord-C#2-ff-N-T12u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#2-ff-N-T12u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#2-ff-N-T12u.wav",
         "285afeaf743fd18d85fe0894b2a0af8a"
       ]
     },
     "Acc-ord-D2-ff-N-T15u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D2-ff-N-T15u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D2-ff-N-T15u.wav",
         "08b39506c27327cfe5818f2a86adbe87"
       ]
     },
     "Acc-ord-D#2-ff-N-T11u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#2-ff-N-T11u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#2-ff-N-T11u.wav",
         "f5ad77555fbc6e6046a86087ccc5b8f5"
       ]
     },
     "Acc-ord-E2-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-ff-N-N.wav",
         "6cb7d9daac57387c1720780d9346d497"
       ]
     },
     "Acc-ord-E2-ff-alt1-T10u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E2-ff-alt1-T10u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E2-ff-alt1-T10u.wav",
         "d06750c2a9d34da74528182d9eea464f"
       ]
     },
     "Acc-ord-F2-ff-N-T14u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-ff-N-T14u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-ff-N-T14u.wav",
         "948b29bc538d8b83754bd17b3c36bc5b"
       ]
     },
     "Acc-ord-F2-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F2-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F2-ff-alt1-N.wav",
         "7224e53c8176a986a5616cc65fd157c3"
       ]
     },
     "Acc-ord-F#2-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-ff-N-N.wav",
         "16cacc9b596006a3597e17b0ad536581"
       ]
     },
     "Acc-ord-F#2-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#2-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#2-ff-alt1-N.wav",
         "66e2ec388f91cd3c321d30b3c320ca6f"
       ]
     },
     "Acc-ord-G2-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-ff-N-N.wav",
         "81fc77ba4d5928c87d776bc9e34636c7"
       ]
     },
     "Acc-ord-G2-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G2-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G2-ff-alt1-N.wav",
         "955e0f7c7327a0af403bd1a471bb9e51"
       ]
     },
     "Acc-ord-G#2-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-ff-N-N.wav",
         "2189bdf3eeb84514b39003cc31983549"
       ]
     },
     "Acc-ord-G#2-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#2-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#2-ff-alt1-N.wav",
         "4b0ab23c97c3fb6375bf37429dfe23b8"
       ]
     },
     "Acc-ord-A2-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-ff-N-N.wav",
         "f11ad86682b014fabe09288c0836c99b"
       ]
     },
     "Acc-ord-A2-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A2-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A2-ff-alt1-N.wav",
         "fa5b5c7300a445675b518af0136893a6"
       ]
     },
     "Acc-ord-A#2-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-ff-N-N.wav",
         "91c8eba9bb7a17423be88b67d9e11db0"
       ]
     },
     "Acc-ord-A#2-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#2-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#2-ff-alt1-N.wav",
         "a717643fcbc76fcbbc10e1b1d1d6ada6"
       ]
     },
     "Acc-ord-B2-ff-N-T14u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-ff-N-T14u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-ff-N-T14u.wav",
         "ab33c67616b73223e81c71c3c0b97db4"
       ]
     },
     "Acc-ord-B2-ff-alt1-T13u": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B2-ff-alt1-T13u.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B2-ff-alt1-T13u.wav",
         "73a2ccaf37f57e26dc05c0259c25b1aa"
       ]
     },
     "Acc-ord-C3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-ff-N-N.wav",
         "53d915284baa9f7423b0947dec9a699b"
       ]
     },
     "Acc-ord-C3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C3-ff-alt1-N.wav",
         "10457ab050a81c6840d719e9e0bc0deb"
       ]
     },
     "Acc-ord-C#3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-ff-N-N.wav",
         "21a3b826bc1a934a6eca4c2f03a1bd2c"
       ]
     },
     "Acc-ord-C#3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#3-ff-alt1-N.wav",
         "e9f94573a076c96884343caf5909fe2b"
       ]
     },
     "Acc-ord-D3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-ff-N-N.wav",
         "e8b8bd5ef501bd7190fc27207254e926"
       ]
     },
     "Acc-ord-D3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D3-ff-alt1-N.wav",
         "bdc51f0692c1878df3efbdeb3a3579e4"
       ]
     },
     "Acc-ord-D#3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-ff-N-N.wav",
         "3a4a673fc8d1b4bbad81e63ec29c8130"
       ]
     },
     "Acc-ord-D#3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#3-ff-alt1-N.wav",
         "172d9efdc88248d1f3f2fa912f573230"
       ]
     },
     "Acc-ord-E3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-ff-N-N.wav",
         "755dd8fef3a5cf48b02bbb7990168e55"
       ]
     },
     "Acc-ord-E3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-ff-alt1-N.wav",
         "2a649adb6ff280e0af30cad3a016d71d"
       ]
     },
     "Acc-ord-E3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E3-ff-alt2-N.wav",
         "f6c66f1e822dff55596de3042347792f"
       ]
     },
     "Acc-ord-F3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-ff-N-N.wav",
         "8ff99d50f29b55ce145571326f4c2da3"
       ]
     },
     "Acc-ord-F3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-ff-alt1-N.wav",
         "4361bbf682c3e127c8f424c844241e32"
       ]
     },
     "Acc-ord-F3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F3-ff-alt2-N.wav",
         "bb826e83f2148b560bf83e9df893e1d8"
       ]
     },
     "Acc-ord-F#3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-ff-N-N.wav",
         "4fc0a32c8b7116af90e6910e58906a70"
       ]
     },
     "Acc-ord-F#3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-ff-alt1-N.wav",
         "b540623f42f0a392830f2a2b33f7d747"
       ]
     },
     "Acc-ord-F#3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#3-ff-alt2-N.wav",
         "ad81f2a41e5a945d57e5408c6b2e12f2"
       ]
     },
     "Acc-ord-G3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-ff-N-N.wav",
         "c3b5ae7e8a0156bd7f3e884ac81804af"
       ]
     },
     "Acc-ord-G3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-ff-alt1-N.wav",
         "00fc35dba280a4ce612268c973e2e6d6"
       ]
     },
     "Acc-ord-G3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G3-ff-alt2-N.wav",
         "697b0f4cb55680f878b22c36fa885908"
       ]
     },
     "Acc-ord-G#3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-ff-N-N.wav",
         "e392a85d3d7a562b80f6b30e15d2a3a8"
       ]
     },
     "Acc-ord-G#3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-ff-alt1-N.wav",
         "bdf1fbdc3d8e59e79deb8dfb59e01656"
       ]
     },
     "Acc-ord-G#3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#3-ff-alt2-N.wav",
         "ebf876579b5052b30adad02fa994036e"
       ]
     },
     "Acc-ord-A3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-ff-N-N.wav",
         "6eafe3741f0ae1927867d607f51973fc"
       ]
     },
     "Acc-ord-A3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-ff-alt1-N.wav",
         "73ee6c3acc0ce4558aa570cf46a162ae"
       ]
     },
     "Acc-ord-A3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A3-ff-alt2-N.wav",
         "eabd1953f05e42e5bba86d864152c663"
       ]
     },
     "Acc-ord-A#3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-ff-N-N.wav",
         "7070bc3fcc76babe6b2a4c29abe8c86c"
       ]
     },
     "Acc-ord-A#3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-ff-alt1-N.wav",
         "c631a771949deb036955a4adb7cb60aa"
       ]
     },
     "Acc-ord-A#3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#3-ff-alt2-N.wav",
         "f1b1904693c93a58a59acbc5ddc3c8ff"
       ]
     },
     "Acc-ord-B3-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-ff-N-N.wav",
         "4534444cc3370ad3814e843ec78de403"
       ]
     },
     "Acc-ord-B3-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-ff-alt1-N.wav",
         "7bb33fbb92e7494d292391bbfa6c142f"
       ]
     },
     "Acc-ord-B3-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B3-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B3-ff-alt2-N.wav",
         "011ef137cf5f67f20a0bbd5209fce224"
       ]
     },
     "Acc-ord-C4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-ff-N-N.wav",
         "ae5765ce8ccf44493d993eb7bf7e6fd6"
       ]
     },
     "Acc-ord-C4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-ff-alt1-N.wav",
         "93c9976db400f81530c4a77c87c8baee"
       ]
     },
     "Acc-ord-C4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C4-ff-alt2-N.wav",
         "2a382c473d819249a7bbf23877f75382"
       ]
     },
     "Acc-ord-C#4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-ff-N-N.wav",
         "8e8614589bd2334e142a0986ea8bc276"
       ]
     },
     "Acc-ord-C#4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-ff-alt1-N.wav",
         "1c43c09e75ef949a687edde35455128e"
       ]
     },
     "Acc-ord-C#4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#4-ff-alt2-N.wav",
         "d9be62c64f138e4608939814d49af130"
       ]
     },
     "Acc-ord-D4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-ff-N-N.wav",
         "7a40512b54020f3b4d8e06d3cfe5a852"
       ]
     },
     "Acc-ord-D4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-ff-alt1-N.wav",
         "b0ea71134dd9807385ef8141b0441136"
       ]
     },
     "Acc-ord-D4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D4-ff-alt2-N.wav",
         "1838954f0d71026b22e7f4ff461c9411"
       ]
     },
     "Acc-ord-D#4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-ff-N-N.wav",
         "c1ee3d4827e3888dc215b36a5ffc87e5"
       ]
     },
     "Acc-ord-D#4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-ff-alt1-N.wav",
         "cfe30eb1b33e5b89094f408c497e22ff"
       ]
     },
     "Acc-ord-D#4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#4-ff-alt2-N.wav",
         "bd392a72516acd8df86ed5bd502f55e6"
       ]
     },
     "Acc-ord-E4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-ff-N-N.wav",
         "110590c084e795751aa20b0281201316"
       ]
     },
     "Acc-ord-E4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-ff-alt1-N.wav",
         "49f6c03c4d3bab21cfc397bcf8ebf058"
       ]
     },
     "Acc-ord-E4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E4-ff-alt2-N.wav",
         "7142c25e8b466aca5a5220cbd6f1355f"
       ]
     },
     "Acc-ord-F4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-ff-N-N.wav",
         "569976b5542178b87a30c2afd84e1afa"
       ]
     },
     "Acc-ord-F4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-ff-alt1-N.wav",
         "c2814536bf745b720f09014c77737354"
       ]
     },
     "Acc-ord-F4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F4-ff-alt2-N.wav",
         "fe7b57bec2ed391d05b1904ab2072b03"
       ]
     },
     "Acc-ord-F#4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-ff-N-N.wav",
         "d66c2842824b3eed33aad8fbce9b0ef0"
       ]
     },
     "Acc-ord-F#4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-ff-alt1-N.wav",
         "50da61507d279490aa580b1bb60e966a"
       ]
     },
     "Acc-ord-F#4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#4-ff-alt2-N.wav",
         "5b4a89e975f13122bce5ed18951871ac"
       ]
     },
     "Acc-ord-G4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-ff-N-N.wav",
         "bc27ea223d49003d19e905641ce3cfaf"
       ]
     },
     "Acc-ord-G4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-ff-alt1-N.wav",
         "31db6428887fc8e181227ba7254262ff"
       ]
     },
     "Acc-ord-G4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G4-ff-alt2-N.wav",
         "faeb7419aa361cec8d6c216c92947780"
       ]
     },
     "Acc-ord-G#4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-ff-N-N.wav",
         "39830b5261f9375f185ea50c84d77a7f"
       ]
     },
     "Acc-ord-G#4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-ff-alt1-N.wav",
         "f7f2615c72ffebd8215bcd7dba4fd0b0"
       ]
     },
     "Acc-ord-G#4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#4-ff-alt2-N.wav",
         "c45af5f00c38cc44946d8d9d51ed5039"
       ]
     },
     "Acc-ord-A4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-ff-N-N.wav",
         "c2c6001fce794220b96727275a1bff2a"
       ]
     },
     "Acc-ord-A4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-ff-alt1-N.wav",
         "da90dc396ef8e01b727433434c66bbe9"
       ]
     },
     "Acc-ord-A4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A4-ff-alt2-N.wav",
         "8e2f0bf19cc99517a862159cf3d2a2af"
       ]
     },
     "Acc-ord-A#4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-ff-N-N.wav",
         "179f60634bffd6104d9528d745cd1aa1"
       ]
     },
     "Acc-ord-A#4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-ff-alt1-N.wav",
         "c2d26fbdfc62696944e482e203312e09"
       ]
     },
     "Acc-ord-A#4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#4-ff-alt2-N.wav",
         "83097f224f974725f7cdd2a30fb6787b"
       ]
     },
     "Acc-ord-B4-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-ff-N-N.wav",
         "daee1bac0e8824094a38b4e2d16a0b68"
       ]
     },
     "Acc-ord-B4-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-ff-alt1-N.wav",
         "93b6b08a1d9875e422f92230844adf50"
       ]
     },
     "Acc-ord-B4-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B4-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B4-ff-alt2-N.wav",
         "a00050bfe9310a648ab958e770fa2914"
       ]
     },
     "Acc-ord-C5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-ff-N-N.wav",
         "737f96ed11504d4cd4c9a3b70e63eca4"
       ]
     },
     "Acc-ord-C5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-ff-alt1-N.wav",
         "af0f757264a3f169d70037a0c7032279"
       ]
     },
     "Acc-ord-C5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C5-ff-alt2-N.wav",
         "ee82d55fd1a171fb09232150fbdf58cb"
       ]
     },
     "Acc-ord-C#5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-ff-N-N.wav",
         "90bca1bf121599aa077a3751304b5967"
       ]
     },
     "Acc-ord-C#5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-ff-alt1-N.wav",
         "0577c24567ab276ca94c798f34723b2b"
       ]
     },
     "Acc-ord-C#5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#5-ff-alt2-N.wav",
         "6794b823773fe456bd18327a00a7e004"
       ]
     },
     "Acc-ord-D5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-ff-N-N.wav",
         "376a9c114dca905acc961da98ea929f6"
       ]
     },
     "Acc-ord-D5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-ff-alt1-N.wav",
         "a71df8183f008191c5dc427cd7b18f25"
       ]
     },
     "Acc-ord-D5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D5-ff-alt2-N.wav",
         "65e891668813c0c1b7a6a62d21d302c0"
       ]
     },
     "Acc-ord-D#5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-ff-N-N.wav",
         "3089b646cf43c9b37717d95886c5d707"
       ]
     },
     "Acc-ord-D#5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-ff-alt1-N.wav",
         "6f1bee8b5464048982af3c7602f1cf0c"
       ]
     },
     "Acc-ord-D#5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#5-ff-alt2-N.wav",
         "2912e7e18161d5cbd96037e61794464c"
       ]
     },
     "Acc-ord-E5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-ff-N-N.wav",
         "a86b052833fdfc47732c289b55871a58"
       ]
     },
     "Acc-ord-E5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-ff-alt1-N.wav",
         "aeabc342171a6dfe9add4d0085806440"
       ]
     },
     "Acc-ord-E5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E5-ff-alt2-N.wav",
         "93f123183fad182aad516d0c582f5d85"
       ]
     },
     "Acc-ord-F5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-ff-N-N.wav",
         "f96283075fcef9e8ed05139971b68346"
       ]
     },
     "Acc-ord-F5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-ff-alt1-N.wav",
         "aac5fd12a3a93b54a9021bb092e74099"
       ]
     },
     "Acc-ord-F5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F5-ff-alt2-N.wav",
         "06ff1c26f1c48862bf5676ab27c66673"
       ]
     },
     "Acc-ord-F#5-ff-N-T10d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-ff-N-T10d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-ff-N-T10d.wav",
         "76aa20a6861f51917307d3eee46b055a"
       ]
     },
     "Acc-ord-F#5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-ff-alt1-N.wav",
         "0ccb65dfc81f6b31e35703bdc4ffdfe0"
       ]
     },
     "Acc-ord-F#5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#5-ff-alt2-N.wav",
         "6a0fe72219823aa0849c41ffa9f05c57"
       ]
     },
     "Acc-ord-G5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-ff-N-N.wav",
         "5396baf9da2b13df2798aaba8ee447c4"
       ]
     },
     "Acc-ord-G5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-ff-alt1-N.wav",
         "66ef5a09bcadc75d4d500b62172e5014"
       ]
     },
     "Acc-ord-G5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G5-ff-alt2-N.wav",
         "489babe8ef89ad1bf7c99515aa8f8904"
       ]
     },
     "Acc-ord-G#5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-ff-N-N.wav",
         "eb7a5e1806dc0c7c51fe46366ee2faca"
       ]
     },
     "Acc-ord-G#5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-ff-alt1-N.wav",
         "9341be99fcde31474365aad9d73dd85e"
       ]
     },
     "Acc-ord-G#5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#5-ff-alt2-N.wav",
         "7e79392e6e8dcb50d79df84ba55a60af"
       ]
     },
     "Acc-ord-A5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-ff-N-N.wav",
         "7adaa1bca3e0c7efc59b4d27d6dc8ad3"
       ]
     },
     "Acc-ord-A5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-ff-alt1-N.wav",
         "7832989e2148ce4b52a9d1cca95920dc"
       ]
     },
     "Acc-ord-A5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A5-ff-alt2-N.wav",
         "d61d23659e13e4d59e461c81a086ab29"
       ]
     },
     "Acc-ord-A#5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-ff-N-N.wav",
         "73f63c5448795b8733335162bd135678"
       ]
     },
     "Acc-ord-A#5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-ff-alt1-N.wav",
         "6840ed180e18239012d4929103c52259"
       ]
     },
     "Acc-ord-A#5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#5-ff-alt2-N.wav",
         "38862c837338614510f39d61a16e3c66"
       ]
     },
     "Acc-ord-B5-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-ff-N-N.wav",
         "1f0428bfbdbdd9681edecdddd137b6ff"
       ]
     },
     "Acc-ord-B5-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-ff-alt1-N.wav",
         "bc50076d4ed125e08e4a5a049fe92602"
       ]
     },
     "Acc-ord-B5-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B5-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B5-ff-alt2-N.wav",
         "95ca3683814885091a904e8328aab9bf"
       ]
     },
     "Acc-ord-C6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-ff-N-N.wav",
         "a16637fcadfaa049f20fbac6f0504df4"
       ]
     },
     "Acc-ord-C6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-ff-alt1-N.wav",
         "55873f1907d610dfda40772fdb722ef3"
       ]
     },
     "Acc-ord-C6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C6-ff-alt2-N.wav",
         "ecdbe23659ae255bd7819641c0640581"
       ]
     },
     "Acc-ord-C#6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-ff-N-N.wav",
         "6f4a3490c4657b8878d89a5befc1e191"
       ]
     },
     "Acc-ord-C#6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-ff-alt1-N.wav",
         "b31d08679439dce6a43ba90edbffde9c"
       ]
     },
     "Acc-ord-C#6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#6-ff-alt2-N.wav",
         "4668c92797f331e5c6d148a5d659250c"
       ]
     },
     "Acc-ord-D6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-ff-N-N.wav",
         "d0110566fa8ff012c71811857ad6ea9d"
       ]
     },
     "Acc-ord-D6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-ff-alt1-N.wav",
         "c3b17e35e29704a20b73464f473ad81c"
       ]
     },
     "Acc-ord-D6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D6-ff-alt2-N.wav",
         "2b829744920a306f1f2497a3480e90a3"
       ]
     },
     "Acc-ord-D#6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-ff-N-N.wav",
         "0706a8c3688c6ee3864c896f9ae265ff"
       ]
     },
     "Acc-ord-D#6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-ff-alt1-N.wav",
         "6defc3c0d2d38e7b9586176caae1a42f"
       ]
     },
     "Acc-ord-D#6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#6-ff-alt2-N.wav",
         "dbde03cadbdd1a2f92e391204a34f3f3"
       ]
     },
     "Acc-ord-E6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-ff-N-N.wav",
         "b109a5d99441c01c578f4a45f4525851"
       ]
     },
     "Acc-ord-E6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-ff-alt1-N.wav",
         "7c32f8245351ad4eb4e1c353078e9c6e"
       ]
     },
     "Acc-ord-E6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E6-ff-alt2-N.wav",
         "6ddd6f543857d84aeeacf098d7ab455a"
       ]
     },
     "Acc-ord-F6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-ff-N-N.wav",
         "4ce98553b09c22d382739201e4a6b741"
       ]
     },
     "Acc-ord-F6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-ff-alt1-N.wav",
         "6326b96e759afde22ac5e9329af5afb0"
       ]
     },
     "Acc-ord-F6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F6-ff-alt2-N.wav",
         "adca7812343f5f926f6c66661a44fd3d"
       ]
     },
     "Acc-ord-F#6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-ff-N-N.wav",
         "90d39c056c1ae687b431b82c60443874"
       ]
     },
     "Acc-ord-F#6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-ff-alt1-N.wav",
         "930ae5a8ab70c50eab50b691ecd9d951"
       ]
     },
     "Acc-ord-F#6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#6-ff-alt2-N.wav",
         "90e7c74340bd4fbc0db7ae804483af29"
       ]
     },
     "Acc-ord-G6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-ff-N-N.wav",
         "e8444950e72e26e42c29e47fde16d156"
       ]
     },
     "Acc-ord-G6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-ff-alt1-N.wav",
         "c69c9309727ded8b53d651c25bd2b8d4"
       ]
     },
     "Acc-ord-G6-ff-alt2-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G6-ff-alt2-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G6-ff-alt2-N.wav",
         "7223863f3ef1c0c5e77ae0e740bb09d8"
       ]
     },
     "Acc-ord-G#6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-ff-N-N.wav",
         "efb5975ec8b4c49c31203d2c8f0de144"
       ]
     },
     "Acc-ord-G#6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#6-ff-alt1-N.wav",
         "1df5ae19f838b8e6c8df314e4b40655b"
       ]
     },
     "Acc-ord-A6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A6-ff-N-N.wav",
         "01f68cf8b5c4ae5bf063f73dca54e13c"
       ]
     },
     "Acc-ord-A#6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-ff-N-N.wav",
         "e61640972d7fa2bae4edd8d00303f121"
       ]
     },
     "Acc-ord-A#6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#6-ff-alt1-N.wav",
         "c0c921f9996bfe7d88b9e9a63e05eece"
       ]
     },
     "Acc-ord-B6-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-ff-N-N.wav",
         "e4413013942490cd5a55ed71fadaea74"
       ]
     },
     "Acc-ord-B6-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B6-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B6-ff-alt1-N.wav",
         "0ca18e20661be84438c32fe015b2be05"
       ]
     },
     "Acc-ord-C7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-ff-N-N.wav",
         "c9d053106bb34b30e25bde9aa7ca24ac"
       ]
     },
     "Acc-ord-C7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C7-ff-alt1-N.wav",
         "506d6db036a5b844c58a79c4a3b4b3da"
       ]
     },
     "Acc-ord-C#7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-ff-N-N.wav",
         "a4bfd9b99d5f3a14977dfd61a248562b"
       ]
     },
     "Acc-ord-C#7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#7-ff-alt1-N.wav",
         "d2aeb674eeebd13b9f2d5d639f2ae886"
       ]
     },
     "Acc-ord-D7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-ff-N-N.wav",
         "25d4f2196df7ad3d74f04b1044228995"
       ]
     },
     "Acc-ord-D7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D7-ff-alt1-N.wav",
         "4bdac7d0da9a1dddc95b8955c7465763"
       ]
     },
     "Acc-ord-D#7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-ff-N-N.wav",
         "e6bd789211291ca166b27efc1d5285d1"
       ]
     },
     "Acc-ord-D#7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-D#7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-D#7-ff-alt1-N.wav",
         "d6d31801cfa45afda24efc230899dee6"
       ]
     },
     "Acc-ord-E7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-ff-N-N.wav",
         "e4ee31738e2a61f34f4810e22c9ab875"
       ]
     },
     "Acc-ord-E7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-E7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-E7-ff-alt1-N.wav",
         "b33c90109b4bb20ad79e30106f74fe92"
       ]
     },
     "Acc-ord-F7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-ff-N-N.wav",
         "9a075d1935d25ccb1d80bf20e040c246"
       ]
     },
     "Acc-ord-F7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F7-ff-alt1-N.wav",
         "cf6fe2395c349ea1c97b9ea59d9ccf3c"
       ]
     },
     "Acc-ord-F#7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-ff-N-N.wav",
         "82e0c649ef0c596219c78f0cdb0d5713"
       ]
     },
     "Acc-ord-F#7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-F#7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-F#7-ff-alt1-N.wav",
         "a0e8c23f5273c653b51d92633bd823bd"
       ]
     },
     "Acc-ord-G7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-ff-N-N.wav",
         "fefd4d30d4b70b5fb9a520b6ff50c731"
       ]
     },
     "Acc-ord-G7-ff-alt1-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G7-ff-alt1-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G7-ff-alt1-N.wav",
         "a3f1e4c84f224d4e1c8f3f9a0c362651"
       ]
     },
     "Acc-ord-G#7-ff-N-T13d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-G#7-ff-N-T13d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-G#7-ff-N-T13d.wav",
         "1b9f6fa7d7cab5492b6b9946958b8b2a"
       ]
     },
     "Acc-ord-A7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A7-ff-N-N.wav",
         "fb77a1e102d23e2bd2b560a35b8cf668"
       ]
     },
     "Acc-ord-A#7-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-A#7-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-A#7-ff-N-N.wav",
         "dc1301c113ffb93d27549efa78b4b087"
       ]
     },
     "Acc-ord-B7-ff-N-T13d": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-B7-ff-N-T13d.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-B7-ff-N-T13d.wav",
         "90212d51cf1c8b0563bf9a143847e34d"
       ]
     },
     "Acc-ord-C8-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C8-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C8-ff-N-N.wav",
         "64ac3175a633d1505775645a74146718"
       ]
     },
     "Acc-ord-C#8-ff-N-N": {
       "audio": [
-        "Keyboards/Accordion/ordinario/Acc-ord-C#8-ff-N-N.wav",
+        "audio/Keyboards/Accordion/ordinario/Acc-ord-C#8-ff-N-N.wav",
         "e950cf9c4ae2e9666ae4d809f17e65da"
       ]
     },
     "Vc-ord-C2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C2-pp-4c-N.wav",
         "ee4364b5f45aefdf2a01f00ca790fbb4"
       ]
     },
     "Vc-ord-C#2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#2-pp-4c-N.wav",
         "4615a64280079a52716ca787948d6b4f"
       ]
     },
     "Vc-ord-D2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D2-pp-4c-N.wav",
         "235b2fb12bcf5bf557d5164b3183de1c"
       ]
     },
     "Vc-ord-D#2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#2-pp-4c-N.wav",
         "110bf3fddc476aad3ffb191224e365b5"
       ]
     },
     "Vc-ord-E2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E2-pp-4c-N.wav",
         "ed1041d99f2e7f1404df2527aeec31a2"
       ]
     },
     "Vc-ord-F2-pp-4c-T19u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F2-pp-4c-T19u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F2-pp-4c-T19u.wav",
         "f5c478a0b7f526e0124c07c832ad25a4"
       ]
     },
     "Vc-ord-F#2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#2-pp-4c-N.wav",
         "4f41e30e3d2653cdf4f3aeb6bf2f7cbd"
       ]
     },
     "Vc-ord-G2-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G2-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G2-pp-3c-N.wav",
         "e1b9cea6100c65d8ce81d6109ffa9094"
       ]
     },
     "Vc-ord-G2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G2-pp-4c-N.wav",
         "7c9e9316b6e8f4661b8cb9548190b343"
       ]
     },
     "Vc-ord-G#2-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#2-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#2-pp-3c-N.wav",
         "db3453022f4b275718a3819e868bae05"
       ]
     },
     "Vc-ord-G#2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#2-pp-4c-N.wav",
         "808c8263832a4a777f0c91d6a2b101c6"
       ]
     },
     "Vc-ord-A2-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A2-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A2-pp-3c-N.wav",
         "becd631585c13def0db4aeab52cda392"
       ]
     },
     "Vc-ord-A2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A2-pp-4c-N.wav",
         "30b2d7243e2ce57b7f0a95df700cb336"
       ]
     },
     "Vc-ord-A#2-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#2-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#2-pp-3c-N.wav",
         "240f87b71907a5053308f2159e185c4a"
       ]
     },
     "Vc-ord-A#2-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#2-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#2-pp-4c-N.wav",
         "dfc67defd9fec5bdeb5c43df1573a1c8"
       ]
     },
     "Vc-ord-B2-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B2-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B2-pp-3c-N.wav",
         "4ef4254ccf78daf93569c78a78998bfc"
       ]
     },
     "Vc-ord-B2-pp-4c-T16u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B2-pp-4c-T16u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B2-pp-4c-T16u.wav",
         "b341842ea90b02347f3dcf8e8a4ccb89"
       ]
     },
     "Vc-ord-C3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C3-pp-3c-N.wav",
         "465f0347024f9d98244add7fb709eb49"
       ]
     },
     "Vc-ord-C3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C3-pp-4c-N.wav",
         "06438d5c4850bc151191353a6f5f389a"
       ]
     },
     "Vc-ord-C#3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#3-pp-3c-N.wav",
         "02e06b021980e586fb573d4c5509fca3"
       ]
     },
     "Vc-ord-C#3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#3-pp-4c-N.wav",
         "de9fe6c68fa5741acb86baac599c1ff8"
       ]
     },
     "Vc-ord-D3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-pp-2c-N.wav",
         "cca03f9e68aeccb9929b8b9517fe13b8"
       ]
     },
     "Vc-ord-D3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-pp-3c-N.wav",
         "c8bbb633d167089e15612929ad133b98"
       ]
     },
     "Vc-ord-D3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-pp-4c-N.wav",
         "5ca925aa29713ef096d7603d32caf9cc"
       ]
     },
     "Vc-ord-D#3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-pp-2c-N.wav",
         "b9552898dce21f3ceb38686a477ef36c"
       ]
     },
     "Vc-ord-D#3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-pp-3c-N.wav",
         "8598965d8c0952fc97b8b5338ff5b5a4"
       ]
     },
     "Vc-ord-D#3-pp-4c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-pp-4c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-pp-4c-T11u.wav",
         "7374d9bf02ab35bbac000515da3ca9ec"
       ]
     },
     "Vc-ord-E3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-pp-2c-N.wav",
         "1b3e553aad8c210ead5d4f66d05d9fa4"
       ]
     },
     "Vc-ord-E3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-pp-3c-N.wav",
         "e4dac5b7dd9c5f9a777a5f62d829e7eb"
       ]
     },
     "Vc-ord-E3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-pp-4c-N.wav",
         "09a027107ebe5a80c911a2484d81af3a"
       ]
     },
     "Vc-ord-F3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-pp-2c-N.wav",
         "c17e662086283bc9cf462d5210133a4b"
       ]
     },
     "Vc-ord-F3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-pp-3c-N.wav",
         "eeb7ae2f9c3edbc9b6b1ba3ffba80ce9"
       ]
     },
     "Vc-ord-F3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-pp-4c-N.wav",
         "9ff0b5bad62da529ab6b1b02a890218d"
       ]
     },
     "Vc-ord-F#3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-pp-2c-N.wav",
         "035f4a03b395a82d90464d2cf6bc3ff1"
       ]
     },
     "Vc-ord-F#3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-pp-3c-N.wav",
         "15364a5f9993f8800e2eb02a12b98d69"
       ]
     },
     "Vc-ord-F#3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-pp-4c-N.wav",
         "50c307979abc3e8f8c60aad135989331"
       ]
     },
     "Vc-ord-G3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-pp-2c-N.wav",
         "71e57709ff21e5403a6bc40ad4259627"
       ]
     },
     "Vc-ord-G3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-pp-3c-N.wav",
         "e7903548e6f6523681e3c01a899fa93e"
       ]
     },
     "Vc-ord-G3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-pp-4c-N.wav",
         "9a51cc39dedc75bdbdd762c7bf89c014"
       ]
     },
     "Vc-ord-G#3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-pp-2c-N.wav",
         "fe1ab49786ab8e32996bb3342426aae3"
       ]
     },
     "Vc-ord-G#3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-pp-3c-N.wav",
         "1fa965db0ff7493673d104039bc31ed2"
       ]
     },
     "Vc-ord-G#3-pp-4c-T24u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-pp-4c-T24u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-pp-4c-T24u.wav",
         "4cce5c63beba493dc9fc155fc899776f"
       ]
     },
     "Vc-ord-A3-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-pp-1c-N.wav",
         "797b2c584b202c01985968337850ef20"
       ]
     },
     "Vc-ord-A3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-pp-2c-N.wav",
         "29a757333451fd60f99776815179594e"
       ]
     },
     "Vc-ord-A3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-pp-3c-N.wav",
         "42eb681b80ac9ec72b44b3cea2511089"
       ]
     },
     "Vc-ord-A3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-pp-4c-N.wav",
         "5df2f76977989b6cee57b93349e35ffd"
       ]
     },
     "Vc-ord-A#3-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-pp-1c-N.wav",
         "5f8d80c9bda18d9cbe9efeb506be934c"
       ]
     },
     "Vc-ord-A#3-pp-2c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-pp-2c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-pp-2c-T12u.wav",
         "1403088593277b927b6bef413fc87e5f"
       ]
     },
     "Vc-ord-A#3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-pp-3c-N.wav",
         "4bdb0a88121b2983d0609e01ad39c3df"
       ]
     },
     "Vc-ord-A#3-pp-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-pp-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-pp-4c-N.wav",
         "0f31622781624a6314286cd3e44cb9ba"
       ]
     },
     "Vc-ord-B3-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-pp-1c-N.wav",
         "8415e877b95c5b449d96087154bed568"
       ]
     },
     "Vc-ord-B3-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-pp-2c-N.wav",
         "ffd09349f245736701c9ccfab2dd0b5b"
       ]
     },
     "Vc-ord-B3-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-pp-3c-N.wav",
         "6d4a743f4b029203e6ab17507260ef12"
       ]
     },
     "Vc-ord-C4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-pp-1c-N.wav",
         "e949bd28bfe01cb430e6bbd23dd20859"
       ]
     },
     "Vc-ord-C4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-pp-2c-N.wav",
         "aa3eda6878ca6405f107a48661ca3c65"
       ]
     },
     "Vc-ord-C4-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-pp-3c-N.wav",
         "a7e0b3c278c2fcf96f1e657a2b57339a"
       ]
     },
     "Vc-ord-C#4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-pp-1c-N.wav",
         "f22fca44ac00039ac073c5bad100df8f"
       ]
     },
     "Vc-ord-C#4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-pp-2c-N.wav",
         "25ab8c95971f9ab9ff52f3f393bf70b6"
       ]
     },
     "Vc-ord-C#4-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-pp-3c-N.wav",
         "50be9b8131d3ac365b1847810aa10ac2"
       ]
     },
     "Vc-ord-D4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-pp-1c-N.wav",
         "c2910720eec8820df3ef13f01e404806"
       ]
     },
     "Vc-ord-D4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-pp-2c-N.wav",
         "d52c2de416698ffe808a38d07873dcd8"
       ]
     },
     "Vc-ord-D4-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-pp-3c-N.wav",
         "3b1bbc86c6b316f766cd10232ad771cc"
       ]
     },
     "Vc-ord-D#4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-pp-1c-N.wav",
         "bdd6882e7850a8706bffce19592bb179"
       ]
     },
     "Vc-ord-D#4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-pp-2c-N.wav",
         "debc0f49d5e64e02523e839808dc0e9f"
       ]
     },
     "Vc-ord-D#4-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-pp-3c-N.wav",
         "b39000155cf1bf798b8ec30d8e243f90"
       ]
     },
     "Vc-ord-E4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-pp-1c-N.wav",
         "e846aba8ec1f8afca68ef3cfef43607f"
       ]
     },
     "Vc-ord-E4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-pp-2c-N.wav",
         "ac23675cd46d3be3d72fed4751481260"
       ]
     },
     "Vc-ord-E4-pp-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-pp-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-pp-3c-N.wav",
         "af80f4e58ba164f3184749c9ee10eb63"
       ]
     },
     "Vc-ord-F4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-pp-1c-N.wav",
         "1b5edb0ab02a7e65887e1eac8291d2ab"
       ]
     },
     "Vc-ord-F4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-pp-2c-N.wav",
         "62573c4ea2beb85a7f1829de120957ce"
       ]
     },
     "Vc-ord-F4-pp-3c-T18u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-pp-3c-T18u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-pp-3c-T18u.wav",
         "cf5fdcc99b5974fe5b003ad80b301ba6"
       ]
     },
     "Vc-ord-F#4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#4-pp-1c-N.wav",
         "5423cb7d2cfa6d1017c86e709f99929e"
       ]
     },
     "Vc-ord-F#4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#4-pp-2c-N.wav",
         "d85f31b19d15d801ed55bd0674e8a85e"
       ]
     },
     "Vc-ord-G4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G4-pp-1c-N.wav",
         "493367beeb9426f070f9431125a8149b"
       ]
     },
     "Vc-ord-G4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G4-pp-2c-N.wav",
         "3c24b2c0b7658551eeb37737ec189681"
       ]
     },
     "Vc-ord-G#4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#4-pp-1c-N.wav",
         "6c968cf0afb70db5a107b4fa44165d47"
       ]
     },
     "Vc-ord-G#4-pp-2c-T13u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#4-pp-2c-T13u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#4-pp-2c-T13u.wav",
         "a1093dea206fa89a1f534d693d0cb8f0"
       ]
     },
     "Vc-ord-A4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A4-pp-1c-N.wav",
         "26eaeb5f1caf912c4f313483f7b7f2d7"
       ]
     },
     "Vc-ord-A4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A4-pp-2c-N.wav",
         "7ecc915a6bdaaf39501fb8389879d28a"
       ]
     },
     "Vc-ord-A#4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#4-pp-1c-N.wav",
         "43bf1e4f48a6014c45fce0d40578c2f2"
       ]
     },
     "Vc-ord-A#4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#4-pp-2c-N.wav",
         "1c4073dc1d43bfe0c880164b0ca72961"
       ]
     },
     "Vc-ord-B4-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B4-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B4-pp-1c-N.wav",
         "beaa72ece47d8fbcc1d2a60a08b758ab"
       ]
     },
     "Vc-ord-B4-pp-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B4-pp-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B4-pp-2c-N.wav",
         "92dcbe796c93b70452f32bcceff2c976"
       ]
     },
     "Vc-ord-C5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C5-pp-1c-N.wav",
         "662c3a2e3284fda5d792785ce6c66413"
       ]
     },
     "Vc-ord-C5-pp-2c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C5-pp-2c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C5-pp-2c-T12u.wav",
         "b91d90d61db6a069a8783a2649afd299"
       ]
     },
     "Vc-ord-C#5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#5-pp-1c-N.wav",
         "e8aadddbc33dc61f8ce16f77becf70a3"
       ]
     },
     "Vc-ord-D5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D5-pp-1c-N.wav",
         "b98e828908a304184e407a01b1b6247b"
       ]
     },
     "Vc-ord-D#5-pp-1c-T10d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#5-pp-1c-T10d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#5-pp-1c-T10d.wav",
         "748c7ca3a2cceefe376be92fa9217390"
       ]
     },
     "Vc-ord-E5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E5-pp-1c-N.wav",
         "f4b962dcd59f5bead5dce111b85eefcb"
       ]
     },
     "Vc-ord-F5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F5-pp-1c-N.wav",
         "da5f6b7e7f47708cd1ceaabfb2b6727e"
       ]
     },
     "Vc-ord-F#5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#5-pp-1c-N.wav",
         "3796d09b0137860b04dbb5a17f9698b4"
       ]
     },
     "Vc-ord-G5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G5-pp-1c-N.wav",
         "7142f3169ac06a82616763dc12bf67a4"
       ]
     },
     "Vc-ord-G#5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#5-pp-1c-N.wav",
         "d56c10369a83e003b5e4eb5005292532"
       ]
     },
     "Vc-ord-A5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A5-pp-1c-N.wav",
         "54bd6d45ccf5c2c9a4e3df0ce07bc262"
       ]
     },
     "Vc-ord-A#5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#5-pp-1c-N.wav",
         "1370f2bfe837ecffa0ce29a013f85610"
       ]
     },
     "Vc-ord-B5-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B5-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B5-pp-1c-N.wav",
         "f281d449b4a15a54d2a35c9481f5ee31"
       ]
     },
     "Vc-ord-C6-pp-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C6-pp-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C6-pp-1c-N.wav",
         "6ea646f1b101f7c26ef4b839b3b90a35"
       ]
     },
     "Vc-ord-C2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C2-mf-4c-N.wav",
         "391aabdcc42cf61725a3a4286ae40086"
       ]
     },
     "Vc-ord-C#2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#2-mf-4c-N.wav",
         "be09f20f857c364bc9dfd422f0b3fcf7"
       ]
     },
     "Vc-ord-D2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D2-mf-4c-N.wav",
         "c08b7b0e274ea34892532e01e39e53a9"
       ]
     },
     "Vc-ord-D#2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#2-mf-4c-N.wav",
         "6bb5f16aa2086c9deedefd5aae7b21da"
       ]
     },
     "Vc-ord-E2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E2-mf-4c-N.wav",
         "cec3a1f7eff71c6d530d1096d1c67976"
       ]
     },
     "Vc-ord-F2-mf-4c-T17u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F2-mf-4c-T17u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F2-mf-4c-T17u.wav",
         "4a0610ad7dff44b82c3e9fa4361e170b"
       ]
     },
     "Vc-ord-F#2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#2-mf-4c-N.wav",
         "0b0de0b6f50a4e80ca19f1568f59830b"
       ]
     },
     "Vc-ord-G2-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G2-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G2-mf-3c-N.wav",
         "4a8d76009b0143a71c00d140e2ccfcdf"
       ]
     },
     "Vc-ord-G2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G2-mf-4c-N.wav",
         "525ff2885b2c67d828e7b60ad888e404"
       ]
     },
     "Vc-ord-G#2-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#2-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#2-mf-3c-N.wav",
         "88dc8dc097dd6f669c81e9ecd523dc72"
       ]
     },
     "Vc-ord-G#2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#2-mf-4c-N.wav",
         "5642f5ab28e2cc335267ab65dd6efa25"
       ]
     },
     "Vc-ord-A2-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A2-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A2-mf-3c-N.wav",
         "a8ac39b67049a7e7cccaddc4302177d4"
       ]
     },
     "Vc-ord-A2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A2-mf-4c-N.wav",
         "f88a318640ef5b3bcbb7a3af14cdfb19"
       ]
     },
     "Vc-ord-A#2-mf-3c-T13u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#2-mf-3c-T13u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#2-mf-3c-T13u.wav",
         "16f8ce2a2f68e36226d947fdd3f8de27"
       ]
     },
     "Vc-ord-A#2-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#2-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#2-mf-4c-N.wav",
         "02adbf8da15815d5a5056790e01792a5"
       ]
     },
     "Vc-ord-B2-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B2-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B2-mf-3c-N.wav",
         "784afe953ba9cda45f7ac741755ba578"
       ]
     },
     "Vc-ord-B2-mf-4c-T20u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B2-mf-4c-T20u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B2-mf-4c-T20u.wav",
         "1011c1aaeccbb0a97732a17ffcedfa4b"
       ]
     },
     "Vc-ord-C3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C3-mf-3c-N.wav",
         "ff059d3aaf5f441d82ac49a6a4092d0f"
       ]
     },
     "Vc-ord-C3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C3-mf-4c-N.wav",
         "9770e195bab629f981833299c3f99d95"
       ]
     },
     "Vc-ord-C#3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#3-mf-3c-N.wav",
         "75237359c146fcb9665f9d1557a205c1"
       ]
     },
     "Vc-ord-C#3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#3-mf-4c-N.wav",
         "9c89453ef33daa28b78dbb564c4741a6"
       ]
     },
     "Vc-ord-D3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-mf-2c-N.wav",
         "2d066aa1064c7aa034082a044439ba08"
       ]
     },
     "Vc-ord-D3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-mf-3c-N.wav",
         "d23a5f92ddd3fb55333fac9678ce29e7"
       ]
     },
     "Vc-ord-D3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-mf-4c-N.wav",
         "00655b2fb83736f2863f6bc44ec98cc1"
       ]
     },
     "Vc-ord-D#3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-mf-2c-N.wav",
         "c5cab0750e6af0de9cc6429ec5524d98"
       ]
     },
     "Vc-ord-D#3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-mf-3c-N.wav",
         "230b49cf5473e66e6efa99baf29eeef2"
       ]
     },
     "Vc-ord-D#3-mf-4c-T13u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-mf-4c-T13u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-mf-4c-T13u.wav",
         "dde102f52d9c79e5e444443e67e5396e"
       ]
     },
     "Vc-ord-E3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-mf-2c-N.wav",
         "0845a80a783875e05307fc70c2bc3a1e"
       ]
     },
     "Vc-ord-E3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-mf-3c-N.wav",
         "d4725becd80ddd330571e0cf5b1dbc85"
       ]
     },
     "Vc-ord-E3-mf-4c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-mf-4c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-mf-4c-T11u.wav",
         "55fd5f8494af99b00f68a4d90995b627"
       ]
     },
     "Vc-ord-F3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-mf-2c-N.wav",
         "3b9b537dda83108bd985c55fd75ac48f"
       ]
     },
     "Vc-ord-F3-mf-3c-T11d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-mf-3c-T11d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-mf-3c-T11d.wav",
         "367f78938cdb10f19ea91132a08f9b63"
       ]
     },
     "Vc-ord-F3-mf-4c-T17u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-mf-4c-T17u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-mf-4c-T17u.wav",
         "8d2c83179e54ee9dfeadcf6786d0d111"
       ]
     },
     "Vc-ord-F#3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-mf-2c-N.wav",
         "f6ba19dfb6693ab36d4ffe7d23bdc5c4"
       ]
     },
     "Vc-ord-F#3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-mf-3c-N.wav",
         "aad84238b7ecaa39b028c5b72a317c95"
       ]
     },
     "Vc-ord-F#3-mf-4c-T15u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-mf-4c-T15u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-mf-4c-T15u.wav",
         "cf78dd4939b5940006abde15a59cc53e"
       ]
     },
     "Vc-ord-G3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-mf-2c-N.wav",
         "76e04f1e51bb916d3621a1a18ad363a9"
       ]
     },
     "Vc-ord-G3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-mf-3c-N.wav",
         "5ba66d9d703ac6324a947bb028584ec3"
       ]
     },
     "Vc-ord-G3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-mf-4c-N.wav",
         "f7daf78efdd6711ce94352d1bc1d0879"
       ]
     },
     "Vc-ord-G#3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-mf-2c-N.wav",
         "570a58e83e03ebea05e8bd9ab8ec3879"
       ]
     },
     "Vc-ord-G#3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-mf-3c-N.wav",
         "cd4752a955fafaefb2750af3d36b2ec8"
       ]
     },
     "Vc-ord-G#3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-mf-4c-N.wav",
         "c5bf9a1fcedbaa404401a4abd50991c1"
       ]
     },
     "Vc-ord-A3-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-mf-1c-N.wav",
         "41a9b14acc8c8ff76da3ec78c4feaa7e"
       ]
     },
     "Vc-ord-A3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-mf-2c-N.wav",
         "68f224390ee2104c4d7fdcc591e6fd43"
       ]
     },
     "Vc-ord-A3-mf-3c-T16d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-mf-3c-T16d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-mf-3c-T16d.wav",
         "f0d12bd9e199bb4cfccef4e8f9cc8956"
       ]
     },
     "Vc-ord-A3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-mf-4c-N.wav",
         "3b68edb1b35821a34f640b53e7e21ff5"
       ]
     },
     "Vc-ord-A#3-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-mf-1c-N.wav",
         "a2bbeeee518437541f1a6f6b490f8451"
       ]
     },
     "Vc-ord-A#3-mf-2c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-mf-2c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-mf-2c-T12u.wav",
         "d7a372c4ef0e8f89204d44000b7c04fe"
       ]
     },
     "Vc-ord-A#3-mf-3c-T16d_R100u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-mf-3c-T16d_R100u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-mf-3c-T16d_R100u.wav",
         "dd02378e852c8b0b49d41de508de0104"
       ]
     },
     "Vc-ord-A#3-mf-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-mf-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-mf-4c-N.wav",
         "b776f7738c821c432702c4e9c8e04cb0"
       ]
     },
     "Vc-ord-B3-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-mf-1c-N.wav",
         "585e89db05c64c21c1c68bd53a669e63"
       ]
     },
     "Vc-ord-B3-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-mf-2c-N.wav",
         "f2647be346c303093926127929831084"
       ]
     },
     "Vc-ord-B3-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-mf-3c-N.wav",
         "e29958dd972a9c98e71d65a76f46ec43"
       ]
     },
     "Vc-ord-C4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-mf-1c-N.wav",
         "0bbc1d10bbe28d1c5d8c6b0a22f3283d"
       ]
     },
     "Vc-ord-C4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-mf-2c-N.wav",
         "d013729392a22b693f360862ab1966ac"
       ]
     },
     "Vc-ord-C4-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-mf-3c-N.wav",
         "e6682fa1b306086c059392da2a447af2"
       ]
     },
     "Vc-ord-C#4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-mf-1c-N.wav",
         "c6ae5000db715fe2f7040fbcfdfb9c99"
       ]
     },
     "Vc-ord-C#4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-mf-2c-N.wav",
         "0396aebc435981c07dac0708082e0079"
       ]
     },
     "Vc-ord-C#4-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-mf-3c-N.wav",
         "9a10c2336d94e0d127da8b968a25100b"
       ]
     },
     "Vc-ord-D4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-mf-1c-N.wav",
         "e2752cfb871d3dd235170cf65ee9decd"
       ]
     },
     "Vc-ord-D4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-mf-2c-N.wav",
         "fa8026cfe776ef09afb8036efa3ff801"
       ]
     },
     "Vc-ord-D4-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-mf-3c-N.wav",
         "965b607a706a8a2b3c6b0c9b405f8a82"
       ]
     },
     "Vc-ord-D#4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-mf-1c-N.wav",
         "0c6ed209dee3e8d83d23b6a1be40fa19"
       ]
     },
     "Vc-ord-D#4-mf-2c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-mf-2c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-mf-2c-T12u.wav",
         "6a06ff4bff812e4ddc56e98b0b316b32"
       ]
     },
     "Vc-ord-D#4-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-mf-3c-N.wav",
         "1f1792d047477c99ea195f5dd2994010"
       ]
     },
     "Vc-ord-E4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-mf-1c-N.wav",
         "81543209553c565e66ac8fe57fcfa3ae"
       ]
     },
     "Vc-ord-E4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-mf-2c-N.wav",
         "25d8fe0b75aaa8ee3cc88593dd45096f"
       ]
     },
     "Vc-ord-E4-mf-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-mf-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-mf-3c-N.wav",
         "7e2cd182e5223f96af320a8dd5d7ec09"
       ]
     },
     "Vc-ord-F4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-mf-1c-N.wav",
         "5493ba595b34b80e1876fd8b488fb84f"
       ]
     },
     "Vc-ord-F4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-mf-2c-N.wav",
         "c9d13df002fd5afba54873d3b7a54003"
       ]
     },
     "Vc-ord-F4-mf-3c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-mf-3c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-mf-3c-T11u.wav",
         "8d1702ec63bed90eff35abb97ecc4fc6"
       ]
     },
     "Vc-ord-F#4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#4-mf-1c-N.wav",
         "afe00bf3205f11c8bc8f0c60e7c26a59"
       ]
     },
     "Vc-ord-F#4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#4-mf-2c-N.wav",
         "c8c67c9bfe1ef04d98ec389b206f882c"
       ]
     },
     "Vc-ord-G4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G4-mf-1c-N.wav",
         "00b09d4a77a8c192f65185f256331d21"
       ]
     },
     "Vc-ord-G4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G4-mf-2c-N.wav",
         "90c0f4ea06c17b71a5d27bd5bc1232ad"
       ]
     },
     "Vc-ord-G#4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#4-mf-1c-N.wav",
         "45a8c302ef593106b2300d9ac6a4091c"
       ]
     },
     "Vc-ord-G#4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#4-mf-2c-N.wav",
         "0390af784906d8f05113a54cdb3beb4a"
       ]
     },
     "Vc-ord-A4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A4-mf-1c-N.wav",
         "9e399c4edebdbdc10fe86d48af960406"
       ]
     },
     "Vc-ord-A4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A4-mf-2c-N.wav",
         "387f8fbb7fea70db0584abdb697f353e"
       ]
     },
     "Vc-ord-A#4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#4-mf-1c-N.wav",
         "509eb50cdc41152323fd49f2c3213dce"
       ]
     },
     "Vc-ord-A#4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#4-mf-2c-N.wav",
         "a2ade47b3f89222efa9358bf3851b9ec"
       ]
     },
     "Vc-ord-B4-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B4-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B4-mf-1c-N.wav",
         "6b7c5ed9393f31eb7b01a56cb824cc65"
       ]
     },
     "Vc-ord-B4-mf-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B4-mf-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B4-mf-2c-N.wav",
         "9a43932892c0892660bd57d8abcfc3f9"
       ]
     },
     "Vc-ord-C5-mf-1c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C5-mf-1c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C5-mf-1c-T11u.wav",
         "8652dca61a087f05b58134fbff32a6a6"
       ]
     },
     "Vc-ord-C5-mf-2c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C5-mf-2c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C5-mf-2c-T11u.wav",
         "b889a29e839d29111e635df2cab0bfd5"
       ]
     },
     "Vc-ord-C#5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#5-mf-1c-N.wav",
         "395a0a9a34b006a64ac1f529efbc67f3"
       ]
     },
     "Vc-ord-D5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D5-mf-1c-N.wav",
         "67fc06f7314783cb54c057b78e9997c2"
       ]
     },
     "Vc-ord-D#5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#5-mf-1c-N.wav",
         "e3d818b7049ebacb38c4dc3c30f4986f"
       ]
     },
     "Vc-ord-E5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E5-mf-1c-N.wav",
         "a8838fe4cbbf8d1a6a7e7f5e97be9f4f"
       ]
     },
     "Vc-ord-F5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F5-mf-1c-N.wav",
         "84102a31d40ce8d76ce1743c9e3c93c5"
       ]
     },
     "Vc-ord-F#5-mf-1c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#5-mf-1c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#5-mf-1c-T12u.wav",
         "f763ff9e860cbb788003b2c121734a4a"
       ]
     },
     "Vc-ord-G5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G5-mf-1c-N.wav",
         "edbd36420780d7b4d639d02d19d77045"
       ]
     },
     "Vc-ord-G#5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#5-mf-1c-N.wav",
         "9203a365c08d8b54ddf965f5e6774bbf"
       ]
     },
     "Vc-ord-A5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A5-mf-1c-N.wav",
         "ea0adcf167f61134095eb615cb29a04e"
       ]
     },
     "Vc-ord-A#5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#5-mf-1c-N.wav",
         "de29ecf0799403b3d03c3b783625ddab"
       ]
     },
     "Vc-ord-B5-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B5-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B5-mf-1c-N.wav",
         "1166b43e28f305f0aa7fccbea5d4155d"
       ]
     },
     "Vc-ord-C6-mf-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C6-mf-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C6-mf-1c-N.wav",
         "057aba6332f63c471c3cd39d9fe29554"
       ]
     },
     "Vc-ord-C2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C2-ff-4c-N.wav",
         "0a10c8316e5910a8ea354ee22e96e2d6"
       ]
     },
     "Vc-ord-C#2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#2-ff-4c-N.wav",
         "5354874b3eb7c93594c06aed41b9e3fd"
       ]
     },
     "Vc-ord-D2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D2-ff-4c-N.wav",
         "1e9425b84920382bb13f7db093feab18"
       ]
     },
     "Vc-ord-D#2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#2-ff-4c-N.wav",
         "a01798af4375c3e71a0646817f67ce07"
       ]
     },
     "Vc-ord-E2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E2-ff-4c-N.wav",
         "f4696bd57ac6503d730374b16b49aff0"
       ]
     },
     "Vc-ord-F2-ff-4c-T17u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F2-ff-4c-T17u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F2-ff-4c-T17u.wav",
         "f6dbbd598cd0a7f12f485386ea27f582"
       ]
     },
     "Vc-ord-F#2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#2-ff-4c-N.wav",
         "e565aa1b9dbec010f68299c4186d0fc9"
       ]
     },
     "Vc-ord-G2-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G2-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G2-ff-3c-N.wav",
         "6034971e1951a273b76b05f61aec3643"
       ]
     },
     "Vc-ord-G2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G2-ff-4c-N.wav",
         "3e83c69fe5f8fb734e4594a0e21c466d"
       ]
     },
     "Vc-ord-G#2-ff-3c-T10d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#2-ff-3c-T10d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#2-ff-3c-T10d.wav",
         "d4eb4a48834275f624a57f76c58308a2"
       ]
     },
     "Vc-ord-G#2-ff-4c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#2-ff-4c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#2-ff-4c-T12u.wav",
         "1e61da9e7895b855802b34108c621223"
       ]
     },
     "Vc-ord-A2-ff-3c-T19d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A2-ff-3c-T19d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A2-ff-3c-T19d.wav",
         "4c19552ee0bd9b514e215aef1969a12a"
       ]
     },
     "Vc-ord-A2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A2-ff-4c-N.wav",
         "942dd3da70af9b24e5826989327a761c"
       ]
     },
     "Vc-ord-A#2-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#2-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#2-ff-3c-N.wav",
         "d780ef8e33e3cd49ad4fcdd792195885"
       ]
     },
     "Vc-ord-A#2-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#2-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#2-ff-4c-N.wav",
         "c3a72f67e446bd8e8d91d61c3eaf9256"
       ]
     },
     "Vc-ord-B2-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B2-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B2-ff-3c-N.wav",
         "2d15550c19ea030bb6c3e9b942e67a1c"
       ]
     },
     "Vc-ord-B2-ff-4c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B2-ff-4c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B2-ff-4c-T11u.wav",
         "ddb736809cf3af0716672d7b9a501167"
       ]
     },
     "Vc-ord-C3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C3-ff-3c-N.wav",
         "9e552fdda4188a85fdcd5ccc8bbb4953"
       ]
     },
     "Vc-ord-C3-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C3-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C3-ff-4c-N.wav",
         "293210dea414c8968b63491789ae0f23"
       ]
     },
     "Vc-ord-C#3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#3-ff-3c-N.wav",
         "dc93e8585df1f3fa0e6b5390fd609920"
       ]
     },
     "Vc-ord-C#3-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#3-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#3-ff-4c-N.wav",
         "655441bbf85068169d5a7ff9254485a4"
       ]
     },
     "Vc-ord-D3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-ff-2c-N.wav",
         "9bd597584e3a84b0bf9769e55e2c333e"
       ]
     },
     "Vc-ord-D3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-ff-3c-N.wav",
         "9820d946483f08488609e1ee38c4dca5"
       ]
     },
     "Vc-ord-D3-ff-4c-T10d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D3-ff-4c-T10d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D3-ff-4c-T10d.wav",
         "d8cc86e47eea19142946c901b49134d0"
       ]
     },
     "Vc-ord-D#3-ff-2c-T16d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-ff-2c-T16d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-ff-2c-T16d.wav",
         "8fee382b9a52673262255b39c5d14552"
       ]
     },
     "Vc-ord-D#3-ff-3c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-ff-3c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-ff-3c-T12u.wav",
         "ee4b0982d2083e628e4e722d70fb9a2e"
       ]
     },
     "Vc-ord-D#3-ff-4c-T16u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#3-ff-4c-T16u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#3-ff-4c-T16u.wav",
         "b8eaf35aa924a687a8b3051774583223"
       ]
     },
     "Vc-ord-E3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-ff-2c-N.wav",
         "f59cc4ac6a243777995a11ed44d5f3c0"
       ]
     },
     "Vc-ord-E3-ff-3c-T11d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-ff-3c-T11d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-ff-3c-T11d.wav",
         "658162b2529d280b466f16f1f00b24c0"
       ]
     },
     "Vc-ord-E3-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E3-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E3-ff-4c-N.wav",
         "41fbc24691b7600dad20e2c2cf6d93ee"
       ]
     },
     "Vc-ord-F3-ff-2c-T17d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-ff-2c-T17d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-ff-2c-T17d.wav",
         "5e8105520cd56866303c613f00780177"
       ]
     },
     "Vc-ord-F3-ff-3c-T17d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-ff-3c-T17d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-ff-3c-T17d.wav",
         "d52ac443e296c28e55ced58ebc47d54a"
       ]
     },
     "Vc-ord-F3-ff-4c-T14u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F3-ff-4c-T14u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F3-ff-4c-T14u.wav",
         "9b720482e1df3014ff3baffdb77d90ba"
       ]
     },
     "Vc-ord-F#3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-ff-2c-N.wav",
         "f0d076050e512b0953b5028ba7e9d69e"
       ]
     },
     "Vc-ord-F#3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-ff-3c-N.wav",
         "b019dc23102549a228ebde3bde376ebe"
       ]
     },
     "Vc-ord-F#3-ff-4c-T14u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#3-ff-4c-T14u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#3-ff-4c-T14u.wav",
         "5cccd9c39e073483819dceb9414c632a"
       ]
     },
     "Vc-ord-G3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-ff-2c-N.wav",
         "96d24cd8bc9eb66132ad0c97a49be255"
       ]
     },
     "Vc-ord-G3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-ff-3c-N.wav",
         "8a7673944313e1ecbbba88ef270da830"
       ]
     },
     "Vc-ord-G3-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G3-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G3-ff-4c-N.wav",
         "6a9eb22ea4f83dc0b33ebb67b29010a2"
       ]
     },
     "Vc-ord-G#3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-ff-2c-N.wav",
         "fb8e83cf726fa0fe0af5dc32acd4f90c"
       ]
     },
     "Vc-ord-G#3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-ff-3c-N.wav",
         "c1210c4b90ac26b5e2d71099aa2a134a"
       ]
     },
     "Vc-ord-G#3-ff-4c-T15u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#3-ff-4c-T15u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#3-ff-4c-T15u.wav",
         "c24006547d96e4e5f7c4b29f14bcbf6d"
       ]
     },
     "Vc-ord-A3-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-ff-1c-N.wav",
         "57457c4572cafb06af983aff7ab603ce"
       ]
     },
     "Vc-ord-A3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-ff-2c-N.wav",
         "3a94c5f654318fdf56facbf6764d71aa"
       ]
     },
     "Vc-ord-A3-ff-3c-T21d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-ff-3c-T21d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-ff-3c-T21d.wav",
         "36936f8a3806f718740cfc8b3601b45d"
       ]
     },
     "Vc-ord-A3-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A3-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A3-ff-4c-N.wav",
         "223efb81704c7ed35af2ab96457a3923"
       ]
     },
     "Vc-ord-A#3-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-ff-1c-N.wav",
         "30647a86bd3b906f7b0ee318e5448e7e"
       ]
     },
     "Vc-ord-A#3-ff-2c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-ff-2c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-ff-2c-T12u.wav",
         "58a26e0151f6dc9fa5c5a1d89cdef471"
       ]
     },
     "Vc-ord-A#3-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-ff-3c-N.wav",
         "ada06f3864075ec205402c0f43afd744"
       ]
     },
     "Vc-ord-A#3-ff-4c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#3-ff-4c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#3-ff-4c-N.wav",
         "0a542faa45c183283c1dee31fc04da3c"
       ]
     },
     "Vc-ord-B3-ff-1c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-ff-1c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-ff-1c-T11u.wav",
         "8a4f22a5dfb949fa0f0180edaa8cf9d9"
       ]
     },
     "Vc-ord-B3-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-ff-2c-N.wav",
         "e72150d8cc7544d3295f2978b8918b90"
       ]
     },
     "Vc-ord-B3-ff-3c-T11u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B3-ff-3c-T11u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B3-ff-3c-T11u.wav",
         "366a2607dba3b3a9d615a23159984e02"
       ]
     },
     "Vc-ord-C4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-ff-1c-N.wav",
         "23744e5a28663bc33cb334043ed9dedf"
       ]
     },
     "Vc-ord-C4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-ff-2c-N.wav",
         "e29b7030fa816cdf143c394c08fa99fd"
       ]
     },
     "Vc-ord-C4-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C4-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C4-ff-3c-N.wav",
         "d4519d9d6607f94d32ea2355b92c514b"
       ]
     },
     "Vc-ord-C#4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-ff-1c-N.wav",
         "30fa2e73cd4163fb356827173c2c233d"
       ]
     },
     "Vc-ord-C#4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-ff-2c-N.wav",
         "8240e1796387e91292bb0f5d372b779e"
       ]
     },
     "Vc-ord-C#4-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#4-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#4-ff-3c-N.wav",
         "7ba361f317ed893e0641ecec146ae515"
       ]
     },
     "Vc-ord-D4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-ff-1c-N.wav",
         "97d7038b1b526b252554b774a23cd5f6"
       ]
     },
     "Vc-ord-D4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-ff-2c-N.wav",
         "80bd708e06a7c7510aa3611b3852a14b"
       ]
     },
     "Vc-ord-D4-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D4-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D4-ff-3c-N.wav",
         "52fd304381151e6f4949a11fe24ab46b"
       ]
     },
     "Vc-ord-D#4-ff-1c-T22u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-ff-1c-T22u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-ff-1c-T22u.wav",
         "769e1f5ab4c2971dde102aeeba21139b"
       ]
     },
     "Vc-ord-D#4-ff-2c-T12u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-ff-2c-T12u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-ff-2c-T12u.wav",
         "d926eeec5a34236ff27c5db1bc002e99"
       ]
     },
     "Vc-ord-D#4-ff-3c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#4-ff-3c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#4-ff-3c-N.wav",
         "b3f268aa163262fd7cf210491127a5c5"
       ]
     },
     "Vc-ord-E4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-ff-1c-N.wav",
         "2e373f1c2442188ceb5e5ff57329e874"
       ]
     },
     "Vc-ord-E4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-ff-2c-N.wav",
         "8bf95e238d51f480baa6fcf0c625f7ad"
       ]
     },
     "Vc-ord-E4-ff-3c-T10u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E4-ff-3c-T10u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E4-ff-3c-T10u.wav",
         "bd26c1c32c6298a6586ab184242eaee3"
       ]
     },
     "Vc-ord-F4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-ff-1c-N.wav",
         "7b3e2fce19db67f578f8c1d4ac9b54e1"
       ]
     },
     "Vc-ord-F4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-ff-2c-N.wav",
         "ddd550d24c168cd9fd64bc7eccb42c7f"
       ]
     },
     "Vc-ord-F4-ff-3c-T14u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F4-ff-3c-T14u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F4-ff-3c-T14u.wav",
         "014a314ab62133092b222c656d770c36"
       ]
     },
     "Vc-ord-F#4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#4-ff-1c-N.wav",
         "19b974e8a06edf0eeb512a8e8e98fd6c"
       ]
     },
     "Vc-ord-F#4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#4-ff-2c-N.wav",
         "9998018d98b8f337844c6f67dfb5e153"
       ]
     },
     "Vc-ord-G4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G4-ff-1c-N.wav",
         "ab5a9dca0b4b5e00177d5e9d382cf90d"
       ]
     },
     "Vc-ord-G4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G4-ff-2c-N.wav",
         "69c0bb410d4cfd63180409d22b157af4"
       ]
     },
     "Vc-ord-G#4-ff-1c-T18u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#4-ff-1c-T18u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#4-ff-1c-T18u.wav",
         "423441a37113af83d7baa10e0e87a959"
       ]
     },
     "Vc-ord-G#4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#4-ff-2c-N.wav",
         "b6d63ef44767303eb29885e41ad43371"
       ]
     },
     "Vc-ord-A4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A4-ff-1c-N.wav",
         "31e16219cf7a45971b07a1b0d30977b3"
       ]
     },
     "Vc-ord-A4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A4-ff-2c-N.wav",
         "537dffbd249da16bc3b27a9a4aee608e"
       ]
     },
     "Vc-ord-A#4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#4-ff-1c-N.wav",
         "cb3de02ff6a058f19d7b7020ad84f112"
       ]
     },
     "Vc-ord-A#4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#4-ff-2c-N.wav",
         "accb5ca2e4f526ffa60a4b04fd43edb2"
       ]
     },
     "Vc-ord-B4-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B4-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B4-ff-1c-N.wav",
         "36fd1f4ca4e8362123fbe716f56a5d33"
       ]
     },
     "Vc-ord-B4-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B4-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B4-ff-2c-N.wav",
         "9a2ea71542803bc28fc8b353385221b9"
       ]
     },
     "Vc-ord-C5-ff-1c-T16u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C5-ff-1c-T16u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C5-ff-1c-T16u.wav",
         "7c13aabf10b7b476ae5d1754a83f08cc"
       ]
     },
     "Vc-ord-C5-ff-2c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C5-ff-2c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C5-ff-2c-N.wav",
         "bf0540fd06bbe5f7eaddf3f24cc8f470"
       ]
     },
     "Vc-ord-C#5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C#5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C#5-ff-1c-N.wav",
         "155279ea46fa947795afa56c89987e80"
       ]
     },
     "Vc-ord-D5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D5-ff-1c-N.wav",
         "8d5d8f2af1e101a7ef20a4644f648042"
       ]
     },
     "Vc-ord-D#5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-D#5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-D#5-ff-1c-N.wav",
         "94cb5f1ace924f3260624d6c5fa2ec35"
       ]
     },
     "Vc-ord-E5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-E5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-E5-ff-1c-N.wav",
         "5a41f4a38d4f60bc3398791955e6c278"
       ]
     },
     "Vc-ord-F5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F5-ff-1c-N.wav",
         "e3bac0355783534838626aba4dafc6b0"
       ]
     },
     "Vc-ord-F#5-ff-1c-T33u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-F#5-ff-1c-T33u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-F#5-ff-1c-T33u.wav",
         "1751ad042803f7414ca285d155d19a51"
       ]
     },
     "Vc-ord-G5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G5-ff-1c-N.wav",
         "e7f56faeb124e038a6d14a44ee89d50b"
       ]
     },
     "Vc-ord-G#5-ff-1c-T10u": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-G#5-ff-1c-T10u.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-G#5-ff-1c-T10u.wav",
         "952911ca7b54a1d4e8e3906e963a3908"
       ]
     },
     "Vc-ord-A5-ff-1c-T13d": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A5-ff-1c-T13d.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A5-ff-1c-T13d.wav",
         "fafbfa88fce7aaeaf88f5a83f7302123"
       ]
     },
     "Vc-ord-A#5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-A#5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-A#5-ff-1c-N.wav",
         "ff30542857b4d41282aa2c5e0f4ec065"
       ]
     },
     "Vc-ord-B5-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-B5-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-B5-ff-1c-N.wav",
         "ef062d6f27cb6339a07aba9ff0bb0f15"
       ]
     },
     "Vc-ord-C6-ff-1c-N": {
       "audio": [
-        "Strings/Violoncello/ordinario/Vc-ord-C6-ff-1c-N.wav",
+        "audio/Strings/Violoncello/ordinario/Vc-ord-C6-ff-1c-N.wav",
         "eca746f6616558603664e5e728acf4d4"
       ]
     },
     "Cb-ord-E1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E1-pp-4c-N.wav",
         "b68f15d16d153964eb78223b666a1d48"
       ]
     },
     "Cb-ord-F1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F1-pp-4c-N.wav",
         "7a3652eade8713821d0b299b1d79a22f"
       ]
     },
     "Cb-ord-F#1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#1-pp-4c-N.wav",
         "d84e8c53a41df4cff9003e3cd86cb8b8"
       ]
     },
     "Cb-ord-G1-pp-4c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G1-pp-4c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G1-pp-4c-T10u.wav",
         "516a57ec7066ec47e1f30b59bffc4b0f"
       ]
     },
     "Cb-ord-G#1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#1-pp-4c-N.wav",
         "8104127baf3d1e389282f7f6961545df"
       ]
     },
     "Cb-ord-A1-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A1-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A1-pp-3c-N.wav",
         "33aedae7343adcd1ad68e26d1fc50a2d"
       ]
     },
     "Cb-ord-A1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A1-pp-4c-N.wav",
         "be64e6acd120d362cc3419dd69570111"
       ]
     },
     "Cb-ord-A#1-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#1-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#1-pp-3c-N.wav",
         "46a23f76c4acf311244afbe69c8d9c53"
       ]
     },
     "Cb-ord-A#1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#1-pp-4c-N.wav",
         "602318b11bcc5ee3dcdad43a30c50cd3"
       ]
     },
     "Cb-ord-B1-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B1-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B1-pp-3c-N.wav",
         "17603b7b3bc663cc2487115bb6c0d1ff"
       ]
     },
     "Cb-ord-B1-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B1-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B1-pp-4c-N.wav",
         "d18f1c1ff8032ec45e91f133e929d622"
       ]
     },
     "Cb-ord-C2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C2-pp-3c-N.wav",
         "45c57caebe9768971aa99d3c89890bc5"
       ]
     },
     "Cb-ord-C2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C2-pp-4c-N.wav",
         "168f5220c3227e747b491f02b8fc3767"
       ]
     },
     "Cb-ord-C#2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#2-pp-3c-N.wav",
         "cdd99dafb0f213a537d880d2966fc05d"
       ]
     },
     "Cb-ord-C#2-pp-4c-R100u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#2-pp-4c-R100u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#2-pp-4c-R100u.wav",
         "59a216773cf97bc43acc2b41653f4680"
       ]
     },
     "Cb-ord-D2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-pp-2c-N.wav",
         "8d80d26a9b779c53d130408b190124a1"
       ]
     },
     "Cb-ord-D2-pp-3c-T14d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-pp-3c-T14d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-pp-3c-T14d.wav",
         "29320d9b5bbe46392a863be5b0cb2f90"
       ]
     },
     "Cb-ord-D2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-pp-4c-N.wav",
         "a617080082f537653c7d34e4c607c11f"
       ]
     },
     "Cb-ord-D#2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-pp-2c-N.wav",
         "4438c8bb6f87f6ccc146e692054adabc"
       ]
     },
     "Cb-ord-D#2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-pp-3c-N.wav",
         "b4d56b4ef9c0218ca1d0bcd168e9ae23"
       ]
     },
     "Cb-ord-D#2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-pp-4c-N.wav",
         "440a3ce12bdf36f571997174167247a0"
       ]
     },
     "Cb-ord-E2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-pp-2c-N.wav",
         "b7bd772ece0ea64e0f2e425b2a952892"
       ]
     },
     "Cb-ord-E2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-pp-3c-N.wav",
         "4cceae559853a451d12973f1e235e595"
       ]
     },
     "Cb-ord-E2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-pp-4c-N.wav",
         "a143ddd209d448f971049889724fc8df"
       ]
     },
     "Cb-ord-F2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-pp-2c-N.wav",
         "e467cccecfef4dd8765af42978789733"
       ]
     },
     "Cb-ord-F2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-pp-3c-N.wav",
         "8e38ac34869545587f6e82289e05bf00"
       ]
     },
     "Cb-ord-F2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-pp-4c-N.wav",
         "55f62a2e70fb2e53ad681458f0871a8e"
       ]
     },
     "Cb-ord-F#2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-pp-2c-N.wav",
         "033e35d42068a9af6f968ed577091359"
       ]
     },
     "Cb-ord-F#2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-pp-3c-N.wav",
         "f1d4223824baa47a303dbd756c9cfd9f"
       ]
     },
     "Cb-ord-F#2-pp-4c-T15u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-pp-4c-T15u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-pp-4c-T15u.wav",
         "8a001ed8a4a2f98aa650890a4bede535"
       ]
     },
     "Cb-ord-G2-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-pp-1c-N.wav",
         "a655ad14c844981a092d964226a36038"
       ]
     },
     "Cb-ord-G2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-pp-2c-N.wav",
         "e308b6b680c3a20d8cee05dc0c177a56"
       ]
     },
     "Cb-ord-G2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-pp-3c-N.wav",
         "85ffddb8098064e70f63120977d18d0e"
       ]
     },
     "Cb-ord-G2-pp-4c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-pp-4c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-pp-4c-T13u.wav",
         "ba57dce12981d16981125532c57a923a"
       ]
     },
     "Cb-ord-G#2-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-pp-1c-N.wav",
         "5a73b7a755232eb7280c7e61f5d3e49d"
       ]
     },
     "Cb-ord-G#2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-pp-2c-N.wav",
         "4b4e4f55cff4bd3ac5dd014afc98252b"
       ]
     },
     "Cb-ord-G#2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-pp-3c-N.wav",
         "c7873a90e8842c2a70fd2e784aefb23b"
       ]
     },
     "Cb-ord-G#2-pp-4c-T21u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-pp-4c-T21u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-pp-4c-T21u.wav",
         "ec54c58b8ce3ebd4948bddf34d060829"
       ]
     },
     "Cb-ord-A2-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-pp-1c-N.wav",
         "bd36958675e7211512fa5b9befb2ec6c"
       ]
     },
     "Cb-ord-A2-pp-2c-T12d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-pp-2c-T12d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-pp-2c-T12d.wav",
         "f4d99764e668f9939edd180ca744749d"
       ]
     },
     "Cb-ord-A2-pp-3c-T12d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-pp-3c-T12d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-pp-3c-T12d.wav",
         "030012aff37325954f05064948cd6ed4"
       ]
     },
     "Cb-ord-A2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-pp-4c-N.wav",
         "0b19c77ca6a0ee5db8abfff5244a3db7"
       ]
     },
     "Cb-ord-A#2-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-pp-1c-N.wav",
         "2d84b0117d7faea6d36c2318648f52aa"
       ]
     },
     "Cb-ord-A#2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-pp-2c-N.wav",
         "8cea22d94166d7d97c4336ffdd687f3f"
       ]
     },
     "Cb-ord-A#2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-pp-3c-N.wav",
         "8e8d79a70db38c98b79edc85d5f0de2d"
       ]
     },
     "Cb-ord-A#2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-pp-4c-N.wav",
         "b9734773f983a229b6c77d5413289eee"
       ]
     },
     "Cb-ord-B2-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-pp-1c-N.wav",
         "383116dae25403e9de262288ef5cb808"
       ]
     },
     "Cb-ord-B2-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-pp-2c-N.wav",
         "e210953d5a241421ea9c510b24e05e71"
       ]
     },
     "Cb-ord-B2-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-pp-3c-N.wav",
         "ef74f7626ce6c1c05f0bf677962816a7"
       ]
     },
     "Cb-ord-B2-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-pp-4c-N.wav",
         "cc97fd454ef8bbd02a242ba311d74c9c"
       ]
     },
     "Cb-ord-C3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-pp-1c-N.wav",
         "36eaf7f7e3f469139dff151205d0c6dc"
       ]
     },
     "Cb-ord-C3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-pp-2c-N.wav",
         "b2638cbba447fe621bdcf717fe59923d"
       ]
     },
     "Cb-ord-C3-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-pp-3c-N.wav",
         "ab861b2e7c365f505a69138f3eab9912"
       ]
     },
     "Cb-ord-C3-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-pp-4c-N.wav",
         "725bdd68b749a16aafff42dccf37a87a"
       ]
     },
     "Cb-ord-C#3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-pp-1c-N.wav",
         "bd3517c349cb28c9bb1d38e3bbbb3067"
       ]
     },
     "Cb-ord-C#3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-pp-2c-N.wav",
         "92de318dc1418993590e927ff7fd3de0"
       ]
     },
     "Cb-ord-C#3-pp-3c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-pp-3c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-pp-3c-T10u.wav",
         "1d19fd2701a59480e33fbde38aa874e8"
       ]
     },
     "Cb-ord-C#3-pp-4c-T16d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-pp-4c-T16d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-pp-4c-T16d.wav",
         "d5280c9d2162d39365372730252cff21"
       ]
     },
     "Cb-ord-D3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-pp-1c-N.wav",
         "dc09b2586a2440d89c477bf2113bc406"
       ]
     },
     "Cb-ord-D3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-pp-2c-N.wav",
         "afae5d2df92027de56e58a09df020ebf"
       ]
     },
     "Cb-ord-D3-pp-3c-T27d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-pp-3c-T27d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-pp-3c-T27d.wav",
         "eee04078bae6ebcbcd29734c0a5441cd"
       ]
     },
     "Cb-ord-D3-pp-4c-T15u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-pp-4c-T15u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-pp-4c-T15u.wav",
         "850155e9adca80c30151ec33e6bb66ea"
       ]
     },
     "Cb-ord-D#3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-pp-1c-N.wav",
         "6138ee4b77e2b4d48d9a80cc7710549b"
       ]
     },
     "Cb-ord-D#3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-pp-2c-N.wav",
         "bd174e366332e95303fe380b92aaadbc"
       ]
     },
     "Cb-ord-D#3-pp-3c-T18d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-pp-3c-T18d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-pp-3c-T18d.wav",
         "cba8af34d9aee603ac13568784941e3e"
       ]
     },
     "Cb-ord-D#3-pp-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-pp-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-pp-4c-N.wav",
         "43ebb400214d5e771d15f6532e716f62"
       ]
     },
     "Cb-ord-E3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-pp-1c-N.wav",
         "3eedef8e995621fe5ed26ce2657e5a9f"
       ]
     },
     "Cb-ord-E3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-pp-2c-N.wav",
         "9aa179a7273bfb818424f51082fb3f42"
       ]
     },
     "Cb-ord-E3-pp-3c-T24d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-pp-3c-T24d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-pp-3c-T24d.wav",
         "65006a94c8170b2e2d094e1bb2337945"
       ]
     },
     "Cb-ord-F3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-pp-1c-N.wav",
         "4bc8b75dfca9954b0031e1086772bb37"
       ]
     },
     "Cb-ord-F3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-pp-2c-N.wav",
         "449eaaa502b39b0502f2fe4eceae2d8e"
       ]
     },
     "Cb-ord-F3-pp-3c-T35d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-pp-3c-T35d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-pp-3c-T35d.wav",
         "a8e196bcef198b7c3540f4342ec06f7b"
       ]
     },
     "Cb-ord-F#3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-pp-1c-N.wav",
         "6db4ee45e86ccde069a5130723c149f5"
       ]
     },
     "Cb-ord-F#3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-pp-2c-N.wav",
         "dc1e083624f99690fe9e72ab65793db8"
       ]
     },
     "Cb-ord-F#3-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-pp-3c-N.wav",
         "ea0ef0119f0315e1e996080dea252901"
       ]
     },
     "Cb-ord-G3-pp-1c-T11d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-pp-1c-T11d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-pp-1c-T11d.wav",
         "164fe32c544552b76057b2125cca7647"
       ]
     },
     "Cb-ord-G3-pp-2c-T13d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-pp-2c-T13d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-pp-2c-T13d.wav",
         "369260f1220bf9bc3f66db74f87d80e9"
       ]
     },
     "Cb-ord-G3-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-pp-3c-N.wav",
         "2840e4c6e975600c1dcf826d0dc6c913"
       ]
     },
     "Cb-ord-G#3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-pp-1c-N.wav",
         "6612e30be69fb52164d46d937cdbc433"
       ]
     },
     "Cb-ord-G#3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-pp-2c-N.wav",
         "812bdb1f58b193b234c6ab28e95e2bec"
       ]
     },
     "Cb-ord-G#3-pp-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-pp-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-pp-3c-N.wav",
         "144ea03ca40697ae745b022e21137d28"
       ]
     },
     "Cb-ord-A3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A3-pp-1c-N.wav",
         "5c25c3ef4729ef0cc0e1a5170187768f"
       ]
     },
     "Cb-ord-A3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A3-pp-2c-N.wav",
         "2f2e666df7e6af6b24f4f4ed9f7c9208"
       ]
     },
     "Cb-ord-A#3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#3-pp-1c-N.wav",
         "63128b7b5d9e61f73ff4197bb592031b"
       ]
     },
     "Cb-ord-A#3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#3-pp-2c-N.wav",
         "148731d759ee083bf283b4be3c05268f"
       ]
     },
     "Cb-ord-B3-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B3-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B3-pp-1c-N.wav",
         "a95a8adee02df453336111b5193518b0"
       ]
     },
     "Cb-ord-B3-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B3-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B3-pp-2c-N.wav",
         "dd4c5019889ff58c501f2a18e66951dc"
       ]
     },
     "Cb-ord-C4-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C4-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C4-pp-1c-N.wav",
         "a9ad922ff66fc4fc0bfe5e42ec3becc2"
       ]
     },
     "Cb-ord-C4-pp-2c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C4-pp-2c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C4-pp-2c-T13u.wav",
         "49223943caf890da7eceab359d6623f9"
       ]
     },
     "Cb-ord-C#4-pp-1c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#4-pp-1c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#4-pp-1c-T10u.wav",
         "288e6ea8b4b1b273b374a89826a6e766"
       ]
     },
     "Cb-ord-C#4-pp-2c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#4-pp-2c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#4-pp-2c-T10u.wav",
         "c385bb4969c28fa40ed058b299e07031"
       ]
     },
     "Cb-ord-D4-pp-1c-T12d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D4-pp-1c-T12d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D4-pp-1c-T12d.wav",
         "b17658a8d44efc437ebab71e923b28c9"
       ]
     },
     "Cb-ord-D4-pp-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D4-pp-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D4-pp-2c-N.wav",
         "9d4d40358d05747d63247acf6f4c2cb1"
       ]
     },
     "Cb-ord-D#4-pp-1c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#4-pp-1c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#4-pp-1c-T10u.wav",
         "2b39f22e660790089f07fe81441a2193"
       ]
     },
     "Cb-ord-E4-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E4-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E4-pp-1c-N.wav",
         "aa50af0c7653b34fb511ded832fc073f"
       ]
     },
     "Cb-ord-F4-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F4-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F4-pp-1c-N.wav",
         "303a882e460764536e5cd4b31855a1e6"
       ]
     },
     "Cb-ord-F#4-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#4-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#4-pp-1c-N.wav",
         "9c125d5f66b0cfbcb326cee9267dd2d5"
       ]
     },
     "Cb-ord-G4-pp-1c-T12d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G4-pp-1c-T12d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G4-pp-1c-T12d.wav",
         "e11a45b5bc92918a78f6aef498e780ff"
       ]
     },
     "Cb-ord-G#4-pp-1c-T22u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#4-pp-1c-T22u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#4-pp-1c-T22u.wav",
         "8490573e5d43a70e4813898f79f92fd1"
       ]
     },
     "Cb-ord-A4-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A4-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A4-pp-1c-N.wav",
         "d1328ed7586eb6dfc9b4339f5c50e951"
       ]
     },
     "Cb-ord-A#4-pp-1c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#4-pp-1c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#4-pp-1c-T13u.wav",
         "20f68ac38b798a7c288a7ff78c8a0deb"
       ]
     },
     "Cb-ord-B4-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B4-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B4-pp-1c-N.wav",
         "9832fc3a700878caa2301d5819f93a6f"
       ]
     },
     "Cb-ord-C5-pp-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C5-pp-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C5-pp-1c-N.wav",
         "dbf12f21d779df353b1cd32427c3a0e5"
       ]
     },
     "Cb-ord-E1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E1-mf-4c-N.wav",
         "103ef54104792cc09dd7bb4831022bf7"
       ]
     },
     "Cb-ord-F1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F1-mf-4c-N.wav",
         "1b28983b54cb87a6569a1f9c4d6b3756"
       ]
     },
     "Cb-ord-F#1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#1-mf-4c-N.wav",
         "6ee1ecfd4a7ec9347b083cc29f4ea1f5"
       ]
     },
     "Cb-ord-G1-mf-4c-R100u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G1-mf-4c-R100u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G1-mf-4c-R100u.wav",
         "74eea4fd7d960f8a9f3845b23e5634bf"
       ]
     },
     "Cb-ord-G#1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#1-mf-4c-N.wav",
         "de3fcc3b585e5309a046368ca876f3bc"
       ]
     },
     "Cb-ord-A1-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A1-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A1-mf-3c-N.wav",
         "303f35afa747b68b9d0a9819174f6e54"
       ]
     },
     "Cb-ord-A1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A1-mf-4c-N.wav",
         "53906d19905922fb58023da7bc2b286c"
       ]
     },
     "Cb-ord-A#1-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#1-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#1-mf-3c-N.wav",
         "efe988050712030509a3b3ac56379ad2"
       ]
     },
     "Cb-ord-A#1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#1-mf-4c-N.wav",
         "3fcd7965b616e73b16693a04cbed1943"
       ]
     },
     "Cb-ord-B1-mf-3c-R100u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B1-mf-3c-R100u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B1-mf-3c-R100u.wav",
         "596fa6251976561b4a76872a5b43c108"
       ]
     },
     "Cb-ord-B1-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B1-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B1-mf-4c-N.wav",
         "c9a156e7b529846862ab8df324181fb5"
       ]
     },
     "Cb-ord-C2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C2-mf-3c-N.wav",
         "abae192cfb7ae8abc3f256f65cef4ade"
       ]
     },
     "Cb-ord-C2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C2-mf-4c-N.wav",
         "f2a6667e5f52726766b95542120cb89c"
       ]
     },
     "Cb-ord-C#2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#2-mf-3c-N.wav",
         "08b9bda63097229598163745f939e1e1"
       ]
     },
     "Cb-ord-C#2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#2-mf-4c-N.wav",
         "3f2b068adf2cbeb69ab732fe3e731593"
       ]
     },
     "Cb-ord-D2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-mf-2c-N.wav",
         "10e5d054581c2e261581a1d27c09c92c"
       ]
     },
     "Cb-ord-D2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-mf-3c-N.wav",
         "27c56e35014273f817305195275f6270"
       ]
     },
     "Cb-ord-D2-mf-4c-T14u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-mf-4c-T14u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-mf-4c-T14u.wav",
         "50c8a641e9c0391bdb061e4f2b7bff77"
       ]
     },
     "Cb-ord-D#2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-mf-2c-N.wav",
         "13ffc35694d7aaf58dfab30eefb04978"
       ]
     },
     "Cb-ord-D#2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-mf-3c-N.wav",
         "79c955753e7b29b7ec7039c13ac56ba9"
       ]
     },
     "Cb-ord-D#2-mf-4c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-mf-4c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-mf-4c-T12u.wav",
         "cc2353d970ae7c7543b0a7cb46cbed73"
       ]
     },
     "Cb-ord-E2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-mf-2c-N.wav",
         "18a0c7bbb45a70eaaae996269c79ba48"
       ]
     },
     "Cb-ord-E2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-mf-3c-N.wav",
         "c1420529cf9267d64963cd20f16c30d1"
       ]
     },
     "Cb-ord-E2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-mf-4c-N.wav",
         "bf3f2ef00a8b2973d61a186f5aa3feb3"
       ]
     },
     "Cb-ord-F2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-mf-2c-N.wav",
         "42d0dc2ca970cad50908cd99e490594d"
       ]
     },
     "Cb-ord-F2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-mf-3c-N.wav",
         "c84542fd56450cfff4207be574917da5"
       ]
     },
     "Cb-ord-F2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-mf-4c-N.wav",
         "13516800b3c4ff2848c09ff72bdd9bb3"
       ]
     },
     "Cb-ord-F#2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-mf-2c-N.wav",
         "bb73f1fe87f153623a4bb37ad7f9faa1"
       ]
     },
     "Cb-ord-F#2-mf-3c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-mf-3c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-mf-3c-T12u.wav",
         "ea0dc2714e373901f5a657dc851fefb9"
       ]
     },
     "Cb-ord-F#2-mf-4c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-mf-4c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-mf-4c-T10u.wav",
         "fc5b3bc3efb7226f5f3be56abaf36aff"
       ]
     },
     "Cb-ord-G2-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-mf-1c-N.wav",
         "a7c2d66d0e1ab90d0bfd872a39422281"
       ]
     },
     "Cb-ord-G2-mf-2c-T11d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-mf-2c-T11d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-mf-2c-T11d.wav",
         "33042cd94c0ce056177112069065bdf4"
       ]
     },
     "Cb-ord-G2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-mf-3c-N.wav",
         "c6a072ead584b42040b553f435f4a16a"
       ]
     },
     "Cb-ord-G2-mf-4c-T10u_R100u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-mf-4c-T10u_R100u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-mf-4c-T10u_R100u.wav",
         "a3dce3e54180cf2c92e422379ee68ad1"
       ]
     },
     "Cb-ord-G#2-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-mf-1c-N.wav",
         "d1299d62b0601a8f7cfe325fb80d02ee"
       ]
     },
     "Cb-ord-G#2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-mf-2c-N.wav",
         "5a7cf41f6b399b85b68eb27f5301a54d"
       ]
     },
     "Cb-ord-G#2-mf-3c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-mf-3c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-mf-3c-T10u.wav",
         "ddab0626f2dd349cc4b0c956c1e41c99"
       ]
     },
     "Cb-ord-G#2-mf-4c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-mf-4c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-mf-4c-T12u.wav",
         "7b37b0f266fc40c8b242ff9994bd01cd"
       ]
     },
     "Cb-ord-A2-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-mf-1c-N.wav",
         "91b3d9980f16b2482186554d6a72d242"
       ]
     },
     "Cb-ord-A2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-mf-2c-N.wav",
         "c4378852cf101c63d9e2750d66c3cb8f"
       ]
     },
     "Cb-ord-A2-mf-3c-R100d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-mf-3c-R100d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-mf-3c-R100d.wav",
         "c2747a5d456f3baa23f74a242e07ca52"
       ]
     },
     "Cb-ord-A2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-mf-4c-N.wav",
         "4731247e828d6c826a9533c3eec3b3d6"
       ]
     },
     "Cb-ord-A#2-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-mf-1c-N.wav",
         "95e204ae6f16c69543a382100f96814e"
       ]
     },
     "Cb-ord-A#2-mf-2c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-mf-2c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-mf-2c-T13u.wav",
         "a61714e09733f49bcf38370ec251c645"
       ]
     },
     "Cb-ord-A#2-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-mf-3c-N.wav",
         "61b92966469be879f6e9b2ac32d7b081"
       ]
     },
     "Cb-ord-A#2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-mf-4c-N.wav",
         "75a2ffd867dd2520239e20090a7ff2c7"
       ]
     },
     "Cb-ord-B2-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-mf-1c-N.wav",
         "a91b47c3333178862ee024b7ae7a1e25"
       ]
     },
     "Cb-ord-B2-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-mf-2c-N.wav",
         "75df5976ea1626f2184968b02256b8af"
       ]
     },
     "Cb-ord-B2-mf-3c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-mf-3c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-mf-3c-T10u.wav",
         "04b39ebda1282b72c544b169a3262f42"
       ]
     },
     "Cb-ord-B2-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-mf-4c-N.wav",
         "740face608f2afa32e5a47df0621154e"
       ]
     },
     "Cb-ord-C3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-mf-1c-N.wav",
         "8f3d496b856be8b1cbc228864af77b12"
       ]
     },
     "Cb-ord-C3-mf-2c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-mf-2c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-mf-2c-T12u.wav",
         "3142842bd44b8a102d8a5173adef5c87"
       ]
     },
     "Cb-ord-C3-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-mf-3c-N.wav",
         "7d695e04088cda495ee267ec3fae8922"
       ]
     },
     "Cb-ord-C3-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-mf-4c-N.wav",
         "9d384f85bebb8d91300620df8c6a25e6"
       ]
     },
     "Cb-ord-C#3-mf-1c-T11u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-mf-1c-T11u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-mf-1c-T11u.wav",
         "18580c4dcf5d295d0207742c0b2d0754"
       ]
     },
     "Cb-ord-C#3-mf-2c-T17u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-mf-2c-T17u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-mf-2c-T17u.wav",
         "97b0ffa25ddfbeb42400acf4d7dc0fda"
       ]
     },
     "Cb-ord-C#3-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-mf-3c-N.wav",
         "490afb436046e7f7b8c2f35213c33c22"
       ]
     },
     "Cb-ord-C#3-mf-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-mf-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-mf-4c-N.wav",
         "0ef91e745102d313e6049a9929488e9c"
       ]
     },
     "Cb-ord-D3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-mf-1c-N.wav",
         "a3329feb9f8c98ccfc90bd924f2ad216"
       ]
     },
     "Cb-ord-D3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-mf-2c-N.wav",
         "eeb1a97b3f32c29b5b09e936a74c84c8"
       ]
     },
     "Cb-ord-D3-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-mf-3c-N.wav",
         "94202c06431da4f2accbb885c13d5d46"
       ]
     },
     "Cb-ord-D3-mf-4c-T19u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-mf-4c-T19u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-mf-4c-T19u.wav",
         "1edc1c18c74c09116046397ad4a3b093"
       ]
     },
     "Cb-ord-D#3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-mf-1c-N.wav",
         "556995b7024afc2bb35681f5e242ca2f"
       ]
     },
     "Cb-ord-D#3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-mf-2c-N.wav",
         "ef26c534b3b0398d54b059d346f34dfa"
       ]
     },
     "Cb-ord-D#3-mf-3c-T24d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-mf-3c-T24d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-mf-3c-T24d.wav",
         "ce7c98f9bf1aabb22238f46dc2e8e166"
       ]
     },
     "Cb-ord-D#3-mf-4c-T11u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-mf-4c-T11u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-mf-4c-T11u.wav",
         "6c3d1cfa165a9518857580089c0ca032"
       ]
     },
     "Cb-ord-E3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-mf-1c-N.wav",
         "c51580d04e49923e2aa7f5fa12bb50a3"
       ]
     },
     "Cb-ord-E3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-mf-2c-N.wav",
         "bd4247aef368844b03cadd9ca0db3c79"
       ]
     },
     "Cb-ord-E3-mf-3c-T14d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-mf-3c-T14d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-mf-3c-T14d.wav",
         "c67850e5694d2aaad896c569cd6a93e3"
       ]
     },
     "Cb-ord-F3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-mf-1c-N.wav",
         "2e99793f15775c51fefa235793c43c18"
       ]
     },
     "Cb-ord-F3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-mf-2c-N.wav",
         "10953121d05def79951211e9bd6b5649"
       ]
     },
     "Cb-ord-F3-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-mf-3c-N.wav",
         "3f9bf688b75e3842cf1510aee966db3e"
       ]
     },
     "Cb-ord-F#3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-mf-1c-N.wav",
         "c4ce7d6414d9854680a1e55fafe4aba9"
       ]
     },
     "Cb-ord-F#3-mf-2c-T14u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-mf-2c-T14u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-mf-2c-T14u.wav",
         "943b19fc05a30f93534359bc5d550275"
       ]
     },
     "Cb-ord-F#3-mf-3c-T15u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-mf-3c-T15u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-mf-3c-T15u.wav",
         "41668498343f5f567906b4eb7dab74fb"
       ]
     },
     "Cb-ord-G3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-mf-1c-N.wav",
         "de59c8e14a908edb23b49ec9023862f4"
       ]
     },
     "Cb-ord-G3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-mf-2c-N.wav",
         "65c78b6edb7b350afcda86c35cd779af"
       ]
     },
     "Cb-ord-G3-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-mf-3c-N.wav",
         "02f94bb9bb29d74f6a7c6cbfae91721b"
       ]
     },
     "Cb-ord-G#3-mf-1c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-mf-1c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-mf-1c-T13u.wav",
         "d184a56cb6923bb6d473a77695b92ad8"
       ]
     },
     "Cb-ord-G#3-mf-2c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-mf-2c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-mf-2c-T12u.wav",
         "8fb053828ab8e11afd953b8b5ad0d807"
       ]
     },
     "Cb-ord-G#3-mf-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-mf-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-mf-3c-N.wav",
         "31cf8addcbe546c5798e769ca7ce22f8"
       ]
     },
     "Cb-ord-A3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A3-mf-1c-N.wav",
         "ec88ee7e36c5576e6a425bf7a1eb217f"
       ]
     },
     "Cb-ord-A3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A3-mf-2c-N.wav",
         "3c463e003d44d7935059d62a4020d69d"
       ]
     },
     "Cb-ord-A#3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#3-mf-1c-N.wav",
         "9e19e3751756be47fc8f3365183bb87a"
       ]
     },
     "Cb-ord-A#3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#3-mf-2c-N.wav",
         "9d7702c3ad4b93da44ecd806570c36e3"
       ]
     },
     "Cb-ord-B3-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B3-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B3-mf-1c-N.wav",
         "a894c96a7d423426bf98cda07cea58f1"
       ]
     },
     "Cb-ord-B3-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B3-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B3-mf-2c-N.wav",
         "929a5c7dae10bbd897089447c19d2991"
       ]
     },
     "Cb-ord-C4-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C4-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C4-mf-1c-N.wav",
         "9b6eb653f7f22516f9ef6a447e5395fc"
       ]
     },
     "Cb-ord-C4-mf-2c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C4-mf-2c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C4-mf-2c-T13u.wav",
         "5789aade6f98686351f0e96a04b65bf9"
       ]
     },
     "Cb-ord-C#4-mf-1c-T29u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#4-mf-1c-T29u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#4-mf-1c-T29u.wav",
         "a4124d0763e08ecba19eb8ff3102894c"
       ]
     },
     "Cb-ord-C#4-mf-2c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#4-mf-2c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#4-mf-2c-T12u.wav",
         "f22adee24e0e290ee7808166372c6bc0"
       ]
     },
     "Cb-ord-D4-mf-1c-T13d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D4-mf-1c-T13d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D4-mf-1c-T13d.wav",
         "faac03d29574bcd1e75da65e91fc7c5f"
       ]
     },
     "Cb-ord-D4-mf-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D4-mf-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D4-mf-2c-N.wav",
         "7d7cf9decb2d709e0a27dfaef315540c"
       ]
     },
     "Cb-ord-D#4-mf-1c-T18u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#4-mf-1c-T18u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#4-mf-1c-T18u.wav",
         "5f40b39664cc3ca650394105bfe575af"
       ]
     },
     "Cb-ord-E4-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E4-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E4-mf-1c-N.wav",
         "391e0e135e8c420559f9b5fc7aca2fcb"
       ]
     },
     "Cb-ord-F4-mf-1c-T16u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F4-mf-1c-T16u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F4-mf-1c-T16u.wav",
         "2d8ef0ac6cedf6a0c6abe0135bb63c61"
       ]
     },
     "Cb-ord-F#4-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#4-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#4-mf-1c-N.wav",
         "e0026e5583b615b60c3c7a19b866b78c"
       ]
     },
     "Cb-ord-G4-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G4-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G4-mf-1c-N.wav",
         "41d3c293f271f150554e6de2495607df"
       ]
     },
     "Cb-ord-G#4-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#4-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#4-mf-1c-N.wav",
         "42a345ef883c93d252d393d710e05e8b"
       ]
     },
     "Cb-ord-A4-mf-1c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A4-mf-1c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A4-mf-1c-T10u.wav",
         "fc211c603ff32d95617758abaa09fb9d"
       ]
     },
     "Cb-ord-A#4-mf-1c-T20u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#4-mf-1c-T20u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#4-mf-1c-T20u.wav",
         "be5a0981f13ac66a3b403d6fe5f1824a"
       ]
     },
     "Cb-ord-B4-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B4-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B4-mf-1c-N.wav",
         "adce70bd22deabcbd533d02aeb4e96e5"
       ]
     },
     "Cb-ord-C5-mf-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C5-mf-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C5-mf-1c-N.wav",
         "b6d3f7205e58a3c4428ecaacea8f696e"
       ]
     },
     "Cb-ord-E1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E1-ff-4c-N.wav",
         "b7ad485583d8f2ddab7f599dd9dbcc73"
       ]
     },
     "Cb-ord-F1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F1-ff-4c-N.wav",
         "215c10b6c6b10d3f3f1d70596ff73253"
       ]
     },
     "Cb-ord-F#1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#1-ff-4c-N.wav",
         "91434c42f499b1bdd4b6de0939a04c61"
       ]
     },
     "Cb-ord-G1-ff-4c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G1-ff-4c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G1-ff-4c-T12u.wav",
         "f1513a8aea4098bb8815c0337685a557"
       ]
     },
     "Cb-ord-G#1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#1-ff-4c-N.wav",
         "d6e08dcddf8b0d7d993036f390a8bc81"
       ]
     },
     "Cb-ord-A1-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A1-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A1-ff-3c-N.wav",
         "f38625837ee5a63064e5f9da85c03b24"
       ]
     },
     "Cb-ord-A1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A1-ff-4c-N.wav",
         "a7dff527dea5dd79fd424b03c5aa4de6"
       ]
     },
     "Cb-ord-A#1-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#1-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#1-ff-3c-N.wav",
         "55a485ccfbca58de79a847341c30b8da"
       ]
     },
     "Cb-ord-A#1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#1-ff-4c-N.wav",
         "8c11cd90546b06bbb4a2bea6678cf323"
       ]
     },
     "Cb-ord-B1-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B1-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B1-ff-3c-N.wav",
         "ee3eae7c4c5637168c4ef397b7488177"
       ]
     },
     "Cb-ord-B1-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B1-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B1-ff-4c-N.wav",
         "5ca42c236c3ef0a96dca5029b899dca7"
       ]
     },
     "Cb-ord-C2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C2-ff-3c-N.wav",
         "64fe53b4afa0662254b0459734f3affa"
       ]
     },
     "Cb-ord-C2-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C2-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C2-ff-4c-N.wav",
         "2d8862325031a704809519734a6152d0"
       ]
     },
     "Cb-ord-C#2-ff-3c-T11u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#2-ff-3c-T11u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#2-ff-3c-T11u.wav",
         "3f300ab57f2359b5d81912788cf9b4e9"
       ]
     },
     "Cb-ord-C#2-ff-4c-T27u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#2-ff-4c-T27u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#2-ff-4c-T27u.wav",
         "86130fd58de9a6772999181c6fc5b226"
       ]
     },
     "Cb-ord-D2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-ff-2c-N.wav",
         "fab60923223f3c62e64bbda6fb73793e"
       ]
     },
     "Cb-ord-D2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-ff-3c-N.wav",
         "f60ea878fe37709f77bad09ce384077d"
       ]
     },
     "Cb-ord-D2-ff-4c-T24u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D2-ff-4c-T24u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D2-ff-4c-T24u.wav",
         "2fd1e742eae70f7406f2f7d3ad1827a8"
       ]
     },
     "Cb-ord-D#2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-ff-2c-N.wav",
         "dfa181eeb47a880f383d3c3afe276122"
       ]
     },
     "Cb-ord-D#2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-ff-3c-N.wav",
         "054697d7005c971103c45b7a823788b0"
       ]
     },
     "Cb-ord-D#2-ff-4c-T16u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#2-ff-4c-T16u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#2-ff-4c-T16u.wav",
         "e9eb1f945f1168d083e5c7b656bb30d2"
       ]
     },
     "Cb-ord-E2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-ff-2c-N.wav",
         "e33e3468004f341035087d0c1e2c68c0"
       ]
     },
     "Cb-ord-E2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-ff-3c-N.wav",
         "9245db0adf0fb9d930a0d12f905dbd72"
       ]
     },
     "Cb-ord-E2-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E2-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E2-ff-4c-N.wav",
         "d69b5247476fec281e9044766bc410a3"
       ]
     },
     "Cb-ord-F2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-ff-2c-N.wav",
         "3b62608c5508ed7638dc253efd6481bd"
       ]
     },
     "Cb-ord-F2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-ff-3c-N.wav",
         "e4092072402cc1fe0102074385fdeab8"
       ]
     },
     "Cb-ord-F2-ff-4c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F2-ff-4c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F2-ff-4c-T12u.wav",
         "e8be7b4adce872360aad359d2b8f3a48"
       ]
     },
     "Cb-ord-F#2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-ff-2c-N.wav",
         "2d673569752906a5d2f216eaae9365cc"
       ]
     },
     "Cb-ord-F#2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-ff-3c-N.wav",
         "10ff3b3416a9a934fe31063baf69f6ae"
       ]
     },
     "Cb-ord-F#2-ff-4c-T31u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#2-ff-4c-T31u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#2-ff-4c-T31u.wav",
         "d353f0121497441b0e0ea18bc573c9cc"
       ]
     },
     "Cb-ord-G2-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-ff-1c-N.wav",
         "89f84421766347efe9351b4715a9d7fc"
       ]
     },
     "Cb-ord-G2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-ff-2c-N.wav",
         "f7308ab41b997589f01b864030f26d7b"
       ]
     },
     "Cb-ord-G2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-ff-3c-N.wav",
         "5e7c04834536920109635f44abcdc63a"
       ]
     },
     "Cb-ord-G2-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G2-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G2-ff-4c-N.wav",
         "be4e9955124342c322b7042ba69910b0"
       ]
     },
     "Cb-ord-G#2-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-ff-1c-N.wav",
         "7097007d0a916f8058c181f35e0eb1a5"
       ]
     },
     "Cb-ord-G#2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-ff-2c-N.wav",
         "3703e5cd25599e6e1a8335da943f395a"
       ]
     },
     "Cb-ord-G#2-ff-3c-T30u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-ff-3c-T30u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-ff-3c-T30u.wav",
         "d82e4774c38ef6b2b9982f2d55217993"
       ]
     },
     "Cb-ord-G#2-ff-4c-T28u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#2-ff-4c-T28u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#2-ff-4c-T28u.wav",
         "7bb429ad4789b659dd1b80386f3d63e3"
       ]
     },
     "Cb-ord-A2-ff-1c-R100d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-ff-1c-R100d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-ff-1c-R100d.wav",
         "e349030f5ed868297ccdf0ed334edc2e"
       ]
     },
     "Cb-ord-A2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-ff-2c-N.wav",
         "b126d725be3cd0848a8aa3442b2faa24"
       ]
     },
     "Cb-ord-A2-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-ff-3c-N.wav",
         "c1a6db66c0ed02747ed62ad18598afe0"
       ]
     },
     "Cb-ord-A2-ff-4c-T17u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A2-ff-4c-T17u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A2-ff-4c-T17u.wav",
         "ce9acabb57ad013b4ad252d7daf8d769"
       ]
     },
     "Cb-ord-A#2-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-ff-1c-N.wav",
         "ec45f28918df249f1527b3ed3ee9d30a"
       ]
     },
     "Cb-ord-A#2-ff-2c-T14u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-ff-2c-T14u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-ff-2c-T14u.wav",
         "514300fd34573a707e36ea8c6d98bdf5"
       ]
     },
     "Cb-ord-A#2-ff-3c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-ff-3c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-ff-3c-T13u.wav",
         "dcc7921826f597d5d668d791f6c5aef4"
       ]
     },
     "Cb-ord-A#2-ff-4c-T21u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#2-ff-4c-T21u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#2-ff-4c-T21u.wav",
         "c9308260787e9eebb468d5d04262b9b7"
       ]
     },
     "Cb-ord-B2-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-ff-1c-N.wav",
         "e2f7518432e59554df2dcc779bcc4b64"
       ]
     },
     "Cb-ord-B2-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-ff-2c-N.wav",
         "869c659a6a7004f2a8f7dd5d671adfe5"
       ]
     },
     "Cb-ord-B2-ff-3c-T17u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-ff-3c-T17u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-ff-3c-T17u.wav",
         "3b4923b1e0a0498b083ac865d7ef2e4b"
       ]
     },
     "Cb-ord-B2-ff-4c-T25u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B2-ff-4c-T25u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B2-ff-4c-T25u.wav",
         "13ac542c366064c2bf606e7bc6db20e5"
       ]
     },
     "Cb-ord-C3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-ff-1c-N.wav",
         "dfb610c52f8757c48426d3911be2b2a3"
       ]
     },
     "Cb-ord-C3-ff-2c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-ff-2c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-ff-2c-T13u.wav",
         "67a86188d44a543300d71ae94fe4c2a1"
       ]
     },
     "Cb-ord-C3-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-ff-3c-N.wav",
         "72529d68660cad38504bf117ecb7ad00"
       ]
     },
     "Cb-ord-C3-ff-4c-T14u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C3-ff-4c-T14u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C3-ff-4c-T14u.wav",
         "6cd382cf9592f4084749be4802f03aef"
       ]
     },
     "Cb-ord-C#3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-ff-1c-N.wav",
         "16f91a067ff0ce9a643ab556036743f0"
       ]
     },
     "Cb-ord-C#3-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-ff-2c-N.wav",
         "97044b6e2e55a799098b3b4928653ab6"
       ]
     },
     "Cb-ord-C#3-ff-3c-T20u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-ff-3c-T20u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-ff-3c-T20u.wav",
         "aceb8cd1aaadd0bc86fe1434c28193b3"
       ]
     },
     "Cb-ord-C#3-ff-4c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#3-ff-4c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#3-ff-4c-N.wav",
         "fbb5310176f67f1249e9a46aff497b47"
       ]
     },
     "Cb-ord-D3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-ff-1c-N.wav",
         "60f2f8bed37317caf7fabbfcd269ae2b"
       ]
     },
     "Cb-ord-D3-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-ff-2c-N.wav",
         "c2280fafc92c2c34fa02a67a7ebf0510"
       ]
     },
     "Cb-ord-D3-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-ff-3c-N.wav",
         "4ded841b3683849288582e1c8f750bfa"
       ]
     },
     "Cb-ord-D3-ff-4c-T31u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D3-ff-4c-T31u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D3-ff-4c-T31u.wav",
         "d84d665dc952875d1accdab9a82ec632"
       ]
     },
     "Cb-ord-D#3-ff-1c-T11u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-ff-1c-T11u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-ff-1c-T11u.wav",
         "fa7045fdb9cea2fd2a49e7b2014f7779"
       ]
     },
     "Cb-ord-D#3-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-ff-2c-N.wav",
         "103530dedfe7c6b070045615877b9015"
       ]
     },
     "Cb-ord-D#3-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-ff-3c-N.wav",
         "e412fe15dc3dd8647df3721232c9b78a"
       ]
     },
     "Cb-ord-D#3-ff-4c-T31u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#3-ff-4c-T31u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#3-ff-4c-T31u.wav",
         "dbaf878afed29e85ef1e3206f20d28fd"
       ]
     },
     "Cb-ord-E3-ff-1c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-ff-1c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-ff-1c-T12u.wav",
         "a6d3ec913bcf1f349e49941f9170a2d8"
       ]
     },
     "Cb-ord-E3-ff-2c-T16u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-ff-2c-T16u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-ff-2c-T16u.wav",
         "6d261348829ffaff405071dbe3e48317"
       ]
     },
     "Cb-ord-E3-ff-3c-T17d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E3-ff-3c-T17d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E3-ff-3c-T17d.wav",
         "af5c2cec334761a0ae5c21f483419989"
       ]
     },
     "Cb-ord-F3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-ff-1c-N.wav",
         "6cb93c11c0a6e76d31b950e43a9ba8df"
       ]
     },
     "Cb-ord-F3-ff-2c-T12u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-ff-2c-T12u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-ff-2c-T12u.wav",
         "4206fd491f2303be0569d2044feeca56"
       ]
     },
     "Cb-ord-F3-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F3-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F3-ff-3c-N.wav",
         "96ab73badcf347fc0e2be8097ce512b0"
       ]
     },
     "Cb-ord-F#3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-ff-1c-N.wav",
         "7241165853c3451d5c0b69916085c7f5"
       ]
     },
     "Cb-ord-F#3-ff-2c-T19u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-ff-2c-T19u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-ff-2c-T19u.wav",
         "fab8a3cfecdc3910e7b0289d08a55644"
       ]
     },
     "Cb-ord-F#3-ff-3c-T10u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#3-ff-3c-T10u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#3-ff-3c-T10u.wav",
         "3304e9481cd9506e672c72fcb334373b"
       ]
     },
     "Cb-ord-G3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-ff-1c-N.wav",
         "90cb9d766ddb26be4aa72c3f2f4545cd"
       ]
     },
     "Cb-ord-G3-ff-2c-T22u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-ff-2c-T22u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-ff-2c-T22u.wav",
         "8e54efb874b3dd872cc622b52023c26a"
       ]
     },
     "Cb-ord-G3-ff-3c-T16u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G3-ff-3c-T16u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G3-ff-3c-T16u.wav",
         "4b6cd6e107501a37fa030212616f09e8"
       ]
     },
     "Cb-ord-G#3-ff-1c-T11u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-ff-1c-T11u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-ff-1c-T11u.wav",
         "08fba45c53f54167541b106e3f6e4b68"
       ]
     },
     "Cb-ord-G#3-ff-2c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-ff-2c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-ff-2c-T13u.wav",
         "8ad3fd548663fd88bc91a0bbd8f70b0e"
       ]
     },
     "Cb-ord-G#3-ff-3c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#3-ff-3c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#3-ff-3c-N.wav",
         "fbc5ccd9bba4571c845d84e0a4d65f6c"
       ]
     },
     "Cb-ord-A3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A3-ff-1c-N.wav",
         "f4e8b91d0ba6d24033e912439cfbddd5"
       ]
     },
     "Cb-ord-A3-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A3-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A3-ff-2c-N.wav",
         "15b4920b0e12497f14da1dcd102b9d39"
       ]
     },
     "Cb-ord-A#3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#3-ff-1c-N.wav",
         "c2d9125966c87cebb6fb108d19b8516a"
       ]
     },
     "Cb-ord-A#3-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#3-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#3-ff-2c-N.wav",
         "898788851b42432f9c5979ac7c061fff"
       ]
     },
     "Cb-ord-B3-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B3-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B3-ff-1c-N.wav",
         "a84109163291c41e130ec181a08b32ef"
       ]
     },
     "Cb-ord-B3-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B3-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B3-ff-2c-N.wav",
         "cff559230b934867c39d6c385cb7fcb6"
       ]
     },
     "Cb-ord-C4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C4-ff-1c-N.wav",
         "18b4c3356f8b61dd6a76b7f3c22e334b"
       ]
     },
     "Cb-ord-C4-ff-2c-T20u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C4-ff-2c-T20u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C4-ff-2c-T20u.wav",
         "bac7b181581c5a0ca88dc45a925b6747"
       ]
     },
     "Cb-ord-C#4-ff-1c-T22u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#4-ff-1c-T22u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#4-ff-1c-T22u.wav",
         "0bc7b0a6f3ca786c36355de9ecb3cbe8"
       ]
     },
     "Cb-ord-C#4-ff-2c-T13u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C#4-ff-2c-T13u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C#4-ff-2c-T13u.wav",
         "a34d005541e4da099a0737d85fe7d254"
       ]
     },
     "Cb-ord-D4-ff-1c-T17d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D4-ff-1c-T17d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D4-ff-1c-T17d.wav",
         "e30542a8aee790a8ef6ec69ca4e8a4e8"
       ]
     },
     "Cb-ord-D4-ff-2c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D4-ff-2c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D4-ff-2c-N.wav",
         "90ceff6f1c861f9673a6102e796fbedb"
       ]
     },
     "Cb-ord-D#4-ff-1c-T20u": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-D#4-ff-1c-T20u.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-D#4-ff-1c-T20u.wav",
         "00ec5fb25d56086e1aa80ffe49f14fcb"
       ]
     },
     "Cb-ord-E4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-E4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-E4-ff-1c-N.wav",
         "e611d9e00aef93d61903148337868d1c"
       ]
     },
     "Cb-ord-F4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F4-ff-1c-N.wav",
         "5f499c03bfe37af083d6c3fb32d3f982"
       ]
     },
     "Cb-ord-F#4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-F#4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-F#4-ff-1c-N.wav",
         "3fb75a59c327f83b8f69385a68d1fa5a"
       ]
     },
     "Cb-ord-G4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G4-ff-1c-N.wav",
         "652a12b5f6c285436453591519233ab1"
       ]
     },
     "Cb-ord-G#4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-G#4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-G#4-ff-1c-N.wav",
         "4129c7886dd2f8b2873dd0ec62b8ac09"
       ]
     },
     "Cb-ord-A4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A4-ff-1c-N.wav",
         "ba1f99c563fde7e1b50b89550829dbdd"
       ]
     },
     "Cb-ord-A#4-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-A#4-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-A#4-ff-1c-N.wav",
         "fae31f350882275e1989adb81d89a6d6"
       ]
     },
     "Cb-ord-B4-ff-1c-T15d": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-B4-ff-1c-T15d.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-B4-ff-1c-T15d.wav",
         "2823f7944c6064bab46ba67842fa3648"
       ]
     },
     "Cb-ord-C5-ff-1c-N": {
       "audio": [
-        "Strings/Contrabass/ordinario/Cb-ord-C5-ff-1c-N.wav",
+        "audio/Strings/Contrabass/ordinario/Cb-ord-C5-ff-1c-N.wav",
         "7ea9ca61f86a9bb88120b75ed372845a"
       ]
     },
     "Va-ord-C3-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C3-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C3-pp-4c-N.wav",
         "83bf62ab4e273181bcca0aef9758d4ac"
       ]
     },
     "Va-ord-C#3-pp-4c-T22u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#3-pp-4c-T22u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#3-pp-4c-T22u.wav",
         "b04c71debc4a11f62f3e05d9881edeaf"
       ]
     },
     "Va-ord-D3-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D3-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D3-pp-4c-N.wav",
         "2d54538b1f777b1f5297fc36a7f842eb"
       ]
     },
     "Va-ord-D#3-pp-4c-T17u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#3-pp-4c-T17u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#3-pp-4c-T17u.wav",
         "d328d3277fa84a4f64aee28503f528fb"
       ]
     },
     "Va-ord-E3-pp-4c-T17u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E3-pp-4c-T17u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E3-pp-4c-T17u.wav",
         "1be86e002f0a2b5afe9a6f9d601f3f05"
       ]
     },
     "Va-ord-F3-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F3-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F3-pp-4c-N.wav",
         "5ab877dc9f886034e9cf7ba0da263e2b"
       ]
     },
     "Va-ord-F#3-pp-4c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#3-pp-4c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#3-pp-4c-T11u.wav",
         "76d500d80c8525989e71ca82b91b0ade"
       ]
     },
     "Va-ord-G3-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G3-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G3-pp-3c-N.wav",
         "30639b70f8a677926091719f058e29b4"
       ]
     },
     "Va-ord-G3-pp-4c-T19u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G3-pp-4c-T19u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G3-pp-4c-T19u.wav",
         "1100c7feb0df635ac4e3fa69e72296c9"
       ]
     },
     "Va-ord-G#3-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#3-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#3-pp-3c-N.wav",
         "331ed9ae9643f4de571197ac7ad01f67"
       ]
     },
     "Va-ord-G#3-pp-4c-T18u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#3-pp-4c-T18u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#3-pp-4c-T18u.wav",
         "2b230f9e04ad338d5179a93fa436bcc5"
       ]
     },
     "Va-ord-A3-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A3-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A3-pp-3c-N.wav",
         "232d0fa2bbc87d9c46b5c864bd66fa5c"
       ]
     },
     "Va-ord-A3-pp-4c-T14u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A3-pp-4c-T14u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A3-pp-4c-T14u.wav",
         "554d22aa12ab5e463e9270807a62ba63"
       ]
     },
     "Va-ord-A#3-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#3-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#3-pp-3c-N.wav",
         "815716743e416786e6a22c0ebad9e681"
       ]
     },
     "Va-ord-A#3-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#3-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#3-pp-4c-N.wav",
         "6c9747cba124548eb07083012bfd156a"
       ]
     },
     "Va-ord-B3-pp-3c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B3-pp-3c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B3-pp-3c-T12u.wav",
         "d5ebe971bd5953346531a2b7128b7635"
       ]
     },
     "Va-ord-B3-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B3-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B3-pp-4c-N.wav",
         "f60fb91dfe75f7e4a4ddeb80b68e5fc3"
       ]
     },
     "Va-ord-C4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C4-pp-3c-N.wav",
         "0d1681db48478035c3bc5f78d8259f4a"
       ]
     },
     "Va-ord-C4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C4-pp-4c-N.wav",
         "e87c731c0e8ed8d11cc08eac7e70cfe5"
       ]
     },
     "Va-ord-C#4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#4-pp-3c-N.wav",
         "cd1fea7ca79bb0d890c083ac3cf51782"
       ]
     },
     "Va-ord-C#4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#4-pp-4c-N.wav",
         "733db911eef752ae49c8bfc07d8975fd"
       ]
     },
     "Va-ord-D4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-pp-2c-N.wav",
         "4bfea6e1832b8a380b592ba9102be963"
       ]
     },
     "Va-ord-D4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-pp-3c-N.wav",
         "6ab93217f6d120d854d67815e12d3c0e"
       ]
     },
     "Va-ord-D4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-pp-4c-N.wav",
         "2daf65ceeb602fa147c1e8a653e081ba"
       ]
     },
     "Va-ord-D#4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-pp-2c-N.wav",
         "0e3ac35c0971b1510219d83e6684ad71"
       ]
     },
     "Va-ord-D#4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-pp-3c-N.wav",
         "fa085e8378ed6d6b81be7c63bd30c4ff"
       ]
     },
     "Va-ord-D#4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-pp-4c-N.wav",
         "8e9b73da517a422bae272789edee31fb"
       ]
     },
     "Va-ord-E4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-pp-2c-N.wav",
         "b663e0743b66356fe9e4ebf26925ac29"
       ]
     },
     "Va-ord-E4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-pp-3c-N.wav",
         "70faf32a14867d51dbb99bbdb872e120"
       ]
     },
     "Va-ord-E4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-pp-4c-N.wav",
         "edfce5b96adb6aca563ada8857ca2eb4"
       ]
     },
     "Va-ord-F4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-pp-2c-N.wav",
         "4e641b660e6d71e62aa534f535f6021a"
       ]
     },
     "Va-ord-F4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-pp-3c-N.wav",
         "cab906288041d7188a9f8609d92fc835"
       ]
     },
     "Va-ord-F4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-pp-4c-N.wav",
         "c15b45c2fab88373e5248318efb43955"
       ]
     },
     "Va-ord-F#4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-pp-2c-N.wav",
         "61f3b136130c5002089ce5404233a41b"
       ]
     },
     "Va-ord-F#4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-pp-3c-N.wav",
         "acf2775993ec0a9ee586eca47c3596f8"
       ]
     },
     "Va-ord-F#4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-pp-4c-N.wav",
         "3e233797ec2b6bb2c01d2c4b3247153e"
       ]
     },
     "Va-ord-G4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-pp-2c-N.wav",
         "7597dc885eb0a84f8e661c1030b6e8a9"
       ]
     },
     "Va-ord-G4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-pp-3c-N.wav",
         "3fbab6b173976ef6de31bd4d0a48c83b"
       ]
     },
     "Va-ord-G4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-pp-4c-N.wav",
         "901878cb1cf47ed4c25b8580ebe69503"
       ]
     },
     "Va-ord-G#4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-pp-2c-N.wav",
         "6edbe47aedeccc30420c7c996e717000"
       ]
     },
     "Va-ord-G#4-pp-3c-T10d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-pp-3c-T10d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-pp-3c-T10d.wav",
         "09c6ac45a821b17231c4a17b79b2cbb0"
       ]
     },
     "Va-ord-G#4-pp-4c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-pp-4c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-pp-4c-T10u.wav",
         "144ae29002c092fd46c9b29b5cc2d000"
       ]
     },
     "Va-ord-A4-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-pp-1c-N.wav",
         "2aa6474f021b9e7356b430ffc11f4bb4"
       ]
     },
     "Va-ord-A4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-pp-2c-N.wav",
         "2952dc6464b8193c1bf04f58b138457c"
       ]
     },
     "Va-ord-A4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-pp-3c-N.wav",
         "d7e630a4dde1d666e13a4e49ef8ccca3"
       ]
     },
     "Va-ord-A4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-pp-4c-N.wav",
         "2d4f99e96bfce7990a7585a4ba35f7fb"
       ]
     },
     "Va-ord-A#4-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-pp-1c-N.wav",
         "f78e69799493da3dffe9bf1b6a3c62a2"
       ]
     },
     "Va-ord-A#4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-pp-2c-N.wav",
         "eb0b14318987eddc01866cff9ebbe57a"
       ]
     },
     "Va-ord-A#4-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-pp-3c-N.wav",
         "9e0b9937205aeaab93fae928a47d252b"
       ]
     },
     "Va-ord-A#4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-pp-4c-N.wav",
         "5631d0fc1bd9de71bf323b9af6720bb0"
       ]
     },
     "Va-ord-B4-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-pp-1c-N.wav",
         "8d9d23c50440326398dedfc69d4cd766"
       ]
     },
     "Va-ord-B4-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-pp-2c-N.wav",
         "ffd72fe094e88e699d049d7adf0277b4"
       ]
     },
     "Va-ord-B4-pp-3c-T11d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-pp-3c-T11d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-pp-3c-T11d.wav",
         "5ae0ddc731858f55fb5d1726013d357a"
       ]
     },
     "Va-ord-B4-pp-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-pp-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-pp-4c-N.wav",
         "5449fc63c78f09c1f4d9581ca34db2d2"
       ]
     },
     "Va-ord-C5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-pp-1c-N.wav",
         "777be4ccd1d61d6f6cabeb504f6ac227"
       ]
     },
     "Va-ord-C5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-pp-2c-N.wav",
         "f20bac3ab6fca72f16f3989c9f4bc91a"
       ]
     },
     "Va-ord-C5-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-pp-3c-N.wav",
         "08574317bb60144ca68b2863535d7b99"
       ]
     },
     "Va-ord-C5-pp-4c-T20u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-pp-4c-T20u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-pp-4c-T20u.wav",
         "3f871ee57a940213df5a963928b86ce6"
       ]
     },
     "Va-ord-C#5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-pp-1c-N.wav",
         "c2949a0c257b0b4ff5db50e649fda4f3"
       ]
     },
     "Va-ord-C#5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-pp-2c-N.wav",
         "cbbfd1dbfba9fb6aae58510f0c52e2cd"
       ]
     },
     "Va-ord-C#5-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-pp-3c-N.wav",
         "d1e9c470418156f83aafad8d336983f7"
       ]
     },
     "Va-ord-D5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-pp-1c-N.wav",
         "0d7f98224f4fce0d266ed31d45443fe1"
       ]
     },
     "Va-ord-D5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-pp-2c-N.wav",
         "8e8b9f123923c1f04bd88696549335d3"
       ]
     },
     "Va-ord-D5-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-pp-3c-N.wav",
         "488feb0b40927fe633c805127000f21a"
       ]
     },
     "Va-ord-D#5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-pp-1c-N.wav",
         "a9d3c3420d38e4a19f24be9876741351"
       ]
     },
     "Va-ord-D#5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-pp-2c-N.wav",
         "3ca5565a44cba5423d0fbb6309c18ddd"
       ]
     },
     "Va-ord-D#5-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-pp-3c-N.wav",
         "03ab0d0a6a5d2a75280954a56c9ef3cb"
       ]
     },
     "Va-ord-E5-pp-1c-T18u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-pp-1c-T18u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-pp-1c-T18u.wav",
         "ed4618eb14d9197ba834a67cee1edf2b"
       ]
     },
     "Va-ord-E5-pp-2c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-pp-2c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-pp-2c-T11u.wav",
         "f353d1386b651b9937cf81c3eb6b0a62"
       ]
     },
     "Va-ord-E5-pp-3c-T13u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-pp-3c-T13u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-pp-3c-T13u.wav",
         "0cd08044c0c3c06bc9312017cf75f2ea"
       ]
     },
     "Va-ord-F5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-pp-1c-N.wav",
         "04221bcd1885af110742b620f2b32d32"
       ]
     },
     "Va-ord-F5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-pp-2c-N.wav",
         "8a178a3f4dfadc1c860c909f5a9c3147"
       ]
     },
     "Va-ord-F5-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-pp-3c-N.wav",
         "57e822db1444fcf38013fcff8ea573db"
       ]
     },
     "Va-ord-F#5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-pp-1c-N.wav",
         "26bd70ca2f57e3d3bf526f7ec73b7887"
       ]
     },
     "Va-ord-F#5-pp-2c-R100u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-pp-2c-R100u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-pp-2c-R100u.wav",
         "98a3701eeb936aa8490ac1448fa2f0e8"
       ]
     },
     "Va-ord-F#5-pp-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-pp-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-pp-3c-N.wav",
         "523894c650d4c077be13b01b57809e54"
       ]
     },
     "Va-ord-G5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-pp-1c-N.wav",
         "1be4eac9b4cb4ceb16bb3dbb4f328a85"
       ]
     },
     "Va-ord-G5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-pp-2c-N.wav",
         "96759becccf9452db3c656f6d21c651a"
       ]
     },
     "Va-ord-G5-pp-3c-T15u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-pp-3c-T15u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-pp-3c-T15u.wav",
         "722df26dd3967fab64bea800e9e7f148"
       ]
     },
     "Va-ord-G#5-pp-1c-T13u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#5-pp-1c-T13u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#5-pp-1c-T13u.wav",
         "04401be1244321a89b368102d37342ce"
       ]
     },
     "Va-ord-G#5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#5-pp-2c-N.wav",
         "4f46fe0da91c16bf8512bfa7279468a4"
       ]
     },
     "Va-ord-A5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A5-pp-1c-N.wav",
         "c9b427cf4bf50dd0f6feb9a25c4a5eec"
       ]
     },
     "Va-ord-A5-pp-2c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A5-pp-2c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A5-pp-2c-T11u.wav",
         "f2c4c8bd8e889895b2925d8540c7db3d"
       ]
     },
     "Va-ord-A#5-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#5-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#5-pp-1c-N.wav",
         "4a8cdf508b186847a4242837be0e6ac6"
       ]
     },
     "Va-ord-A#5-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#5-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#5-pp-2c-N.wav",
         "b94671af834ff00b9e1ad9ef975d8208"
       ]
     },
     "Va-ord-B5-pp-1c-T14u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B5-pp-1c-T14u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B5-pp-1c-T14u.wav",
         "933de369236f3f1053a917e00ae4be78"
       ]
     },
     "Va-ord-B5-pp-2c-T20u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B5-pp-2c-T20u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B5-pp-2c-T20u.wav",
         "db24bbbafd46d0ac039c5efe4d08135d"
       ]
     },
     "Va-ord-C6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C6-pp-1c-N.wav",
         "acdfa34a150a7003ddc7f3dd117851d2"
       ]
     },
     "Va-ord-C6-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C6-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C6-pp-2c-N.wav",
         "f56663eb517dcc86fc4cce9b933e6073"
       ]
     },
     "Va-ord-C#6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#6-pp-1c-N.wav",
         "4fa52d686ce736727668455d7732c7d8"
       ]
     },
     "Va-ord-C#6-pp-2c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#6-pp-2c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#6-pp-2c-T11u.wav",
         "8756f8c78f57834c534a0ec4dd459c95"
       ]
     },
     "Va-ord-D6-pp-1c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D6-pp-1c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D6-pp-1c-T11u.wav",
         "8b8568cdf909ca675ea03324704a4223"
       ]
     },
     "Va-ord-D6-pp-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D6-pp-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D6-pp-2c-N.wav",
         "bedd46103e0b1838a522571a57639b9e"
       ]
     },
     "Va-ord-D#6-pp-1c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#6-pp-1c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#6-pp-1c-T12u.wav",
         "adf21eac0b826d127f5ce2a774987cc9"
       ]
     },
     "Va-ord-E6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E6-pp-1c-N.wav",
         "9d7dab238f0ce9b86ccd8db3367f9c3c"
       ]
     },
     "Va-ord-F6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F6-pp-1c-N.wav",
         "f1773f07360118503e14e44209fa4c66"
       ]
     },
     "Va-ord-F#6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#6-pp-1c-N.wav",
         "d9b41cef77cea47b6d3e3ec4bb97ef9e"
       ]
     },
     "Va-ord-G6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G6-pp-1c-N.wav",
         "04bb15ab8a183eb54f92528fb8f2078b"
       ]
     },
     "Va-ord-G#6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#6-pp-1c-N.wav",
         "bdb1ada743c30fe6599d97d7f0daa051"
       ]
     },
     "Va-ord-A6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A6-pp-1c-N.wav",
         "55266bb40ad34e248a64ccf6130fedb5"
       ]
     },
     "Va-ord-A#6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#6-pp-1c-N.wav",
         "0f959447e14016b786bafb9ec0f65ff0"
       ]
     },
     "Va-ord-B6-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B6-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B6-pp-1c-N.wav",
         "b09ced0ce7db9c9eb669eeb3d67c2449"
       ]
     },
     "Va-ord-C7-pp-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C7-pp-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C7-pp-1c-N.wav",
         "55a2f00af6263df4eb5059e946eb0f48"
       ]
     },
     "Va-ord-C3-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C3-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C3-mf-4c-N.wav",
         "c5b639d9c080e5a68a33d9d00810f14e"
       ]
     },
     "Va-ord-C#3-mf-4c-T24u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#3-mf-4c-T24u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#3-mf-4c-T24u.wav",
         "403dc3a0d59e4ef0bd16b22557619923"
       ]
     },
     "Va-ord-D3-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D3-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D3-mf-4c-N.wav",
         "bb819fe082f5cc705f9f0a910f3f4388"
       ]
     },
     "Va-ord-D#3-mf-4c-T22u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#3-mf-4c-T22u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#3-mf-4c-T22u.wav",
         "c52bd0e387bc453972723e93dca1181e"
       ]
     },
     "Va-ord-E3-mf-4c-T19u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E3-mf-4c-T19u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E3-mf-4c-T19u.wav",
         "13c7ca3eb5c368c8ef083fe5dab3cbec"
       ]
     },
     "Va-ord-F3-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F3-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F3-mf-4c-N.wav",
         "1d7eeffbbb1a0061e648a8abf7512e40"
       ]
     },
     "Va-ord-F#3-mf-4c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#3-mf-4c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#3-mf-4c-T12u.wav",
         "519833acdb978c590e2f0d0e7144156b"
       ]
     },
     "Va-ord-G3-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G3-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G3-mf-3c-N.wav",
         "ca9e6260c88a9b113dac255574b082fb"
       ]
     },
     "Va-ord-G3-mf-4c-T21u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G3-mf-4c-T21u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G3-mf-4c-T21u.wav",
         "986ddbbf19eda3b6104929439ddd4d9c"
       ]
     },
     "Va-ord-G#3-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#3-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#3-mf-3c-N.wav",
         "8de62e23a0a8307c0a7cdb62d36807e4"
       ]
     },
     "Va-ord-G#3-mf-4c-T23u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#3-mf-4c-T23u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#3-mf-4c-T23u.wav",
         "fa6f40916b7ed4540dac9e359637caeb"
       ]
     },
     "Va-ord-A3-mf-3c-R100d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A3-mf-3c-R100d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A3-mf-3c-R100d.wav",
         "69902ac5bee40eb314251de843697bc9"
       ]
     },
     "Va-ord-A3-mf-4c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A3-mf-4c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A3-mf-4c-T10u.wav",
         "188616fad6e4a846dcd7b53034f7dc6b"
       ]
     },
     "Va-ord-A#3-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#3-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#3-mf-3c-N.wav",
         "8f4e1f784cba3fea31234341db6eb96c"
       ]
     },
     "Va-ord-A#3-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#3-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#3-mf-4c-N.wav",
         "92bf8cf25cc4428da7a2b558bdd428a6"
       ]
     },
     "Va-ord-B3-mf-3c-T16u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B3-mf-3c-T16u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B3-mf-3c-T16u.wav",
         "6c615a2db95411a23b254f501733a733"
       ]
     },
     "Va-ord-B3-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B3-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B3-mf-4c-N.wav",
         "46bfc424f1d9cf2b3f15ac61b3358a31"
       ]
     },
     "Va-ord-C4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C4-mf-3c-N.wav",
         "b889d78c197fb5ab2106d4444541b9aa"
       ]
     },
     "Va-ord-C4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C4-mf-4c-N.wav",
         "383a9af83f8634d0eea36c1f60fbd33a"
       ]
     },
     "Va-ord-C#4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#4-mf-3c-N.wav",
         "9be30e6cb45365c2345708f92f0b1aa1"
       ]
     },
     "Va-ord-C#4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#4-mf-4c-N.wav",
         "3e2cd0f0d05cf5eb635882df3be74fe8"
       ]
     },
     "Va-ord-D4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-mf-2c-N.wav",
         "9fb5b151de44c607c28c461b0f0d80af"
       ]
     },
     "Va-ord-D4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-mf-3c-N.wav",
         "882913fd22f3e871e6761622e7edc815"
       ]
     },
     "Va-ord-D4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-mf-4c-N.wav",
         "25b368be575760ebadeaef018abde4ab"
       ]
     },
     "Va-ord-D#4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-mf-2c-N.wav",
         "e93d93f961e260c31a9a51be3c4ff3a7"
       ]
     },
     "Va-ord-D#4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-mf-3c-N.wav",
         "5f78d26f2ac96edf8fce95b5caad8c07"
       ]
     },
     "Va-ord-D#4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-mf-4c-N.wav",
         "d89f7e9c547d2d8ad942b42a77692dc7"
       ]
     },
     "Va-ord-E4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-mf-2c-N.wav",
         "870d0096df6134f70e913a559d2863fc"
       ]
     },
     "Va-ord-E4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-mf-3c-N.wav",
         "4874267feab03ddaf6bdde04df0b76bf"
       ]
     },
     "Va-ord-E4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-mf-4c-N.wav",
         "49bfed25cf47d7b78765e5782530fc9b"
       ]
     },
     "Va-ord-F4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-mf-2c-N.wav",
         "007507804b11f5993ea6c61073b59b42"
       ]
     },
     "Va-ord-F4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-mf-3c-N.wav",
         "123ec216f2fb10e2b14c7c4fd5ddd254"
       ]
     },
     "Va-ord-F4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-mf-4c-N.wav",
         "697dddfb87f392643ad6105ccd8f69fa"
       ]
     },
     "Va-ord-F#4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-mf-2c-N.wav",
         "f3db74308f77b25ac78e3dc98a41f138"
       ]
     },
     "Va-ord-F#4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-mf-3c-N.wav",
         "e24916c445eed9d3dc28be5ba3fa5f64"
       ]
     },
     "Va-ord-F#4-mf-4c-T26u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-mf-4c-T26u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-mf-4c-T26u.wav",
         "d71c2777cbae135510b3c5ac057c6dd7"
       ]
     },
     "Va-ord-G4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-mf-2c-N.wav",
         "f0e7266486c376c18f78e23b7454452f"
       ]
     },
     "Va-ord-G4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-mf-3c-N.wav",
         "82b4235a8f787148528c7680441213c8"
       ]
     },
     "Va-ord-G4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-mf-4c-N.wav",
         "a3567fcf7ce5bed4f61d126f875df108"
       ]
     },
     "Va-ord-G#4-mf-2c-T10d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-mf-2c-T10d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-mf-2c-T10d.wav",
         "f6f70104f082c43860e82c1963aa9acc"
       ]
     },
     "Va-ord-G#4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-mf-3c-N.wav",
         "bdc218388d0547181b63edae8284aa7f"
       ]
     },
     "Va-ord-G#4-mf-4c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-mf-4c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-mf-4c-T11u.wav",
         "6385d1b60a78134ab0a4bea5bca2dc67"
       ]
     },
     "Va-ord-A4-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-mf-1c-N.wav",
         "869a79742535c825d0350d7be01ff299"
       ]
     },
     "Va-ord-A4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-mf-2c-N.wav",
         "c827cb3b3d81b8a1a5a52051a1d1da6f"
       ]
     },
     "Va-ord-A4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-mf-3c-N.wav",
         "af31c23833a5d40f9fea86c754e550ec"
       ]
     },
     "Va-ord-A4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-mf-4c-N.wav",
         "f951305d1f478b2cd7be37fdece46240"
       ]
     },
     "Va-ord-A#4-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-mf-1c-N.wav",
         "9044090feee62d8f59d448d6bc221dbb"
       ]
     },
     "Va-ord-A#4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-mf-2c-N.wav",
         "75fb499d3a3065176a4a7e3ede059f4c"
       ]
     },
     "Va-ord-A#4-mf-3c-T11d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-mf-3c-T11d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-mf-3c-T11d.wav",
         "a90d9e51f807e585186071b43bd6b348"
       ]
     },
     "Va-ord-A#4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-mf-4c-N.wav",
         "2c4bdb32c4b98239d42a0f8f0f1696d7"
       ]
     },
     "Va-ord-B4-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-mf-1c-N.wav",
         "104f3e5a5a42757f3d1513f4207a75ba"
       ]
     },
     "Va-ord-B4-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-mf-2c-N.wav",
         "f79942296b09db030831d80f7a5ede12"
       ]
     },
     "Va-ord-B4-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-mf-3c-N.wav",
         "5fdfb461ec93d873c1f9d12414eb6250"
       ]
     },
     "Va-ord-B4-mf-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-mf-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-mf-4c-N.wav",
         "4de3bb9d75f1f444d69107e131b18199"
       ]
     },
     "Va-ord-C5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-mf-1c-N.wav",
         "2de284b94685c66f0bbb406e1de02518"
       ]
     },
     "Va-ord-C5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-mf-2c-N.wav",
         "5c2f6e4dfa9f0061afbc4c61be40cf19"
       ]
     },
     "Va-ord-C5-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-mf-3c-N.wav",
         "b708734b6ffd578a0ba05d2082f2d053"
       ]
     },
     "Va-ord-C5-mf-4c-T21u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-mf-4c-T21u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-mf-4c-T21u.wav",
         "e7a27999264214405aaefa60c5f42596"
       ]
     },
     "Va-ord-C#5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-mf-1c-N.wav",
         "d988d1009ac0a2e834a8465eb54a67e4"
       ]
     },
     "Va-ord-C#5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-mf-2c-N.wav",
         "7666c4188e6fe0d5803907ee1d0ade59"
       ]
     },
     "Va-ord-C#5-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-mf-3c-N.wav",
         "06aea0f0d3f30a17f5c7775cd49cefff"
       ]
     },
     "Va-ord-D5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-mf-1c-N.wav",
         "402df7471e0ee0f32db7bf93a0e0e07b"
       ]
     },
     "Va-ord-D5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-mf-2c-N.wav",
         "93504397e1db81ffb30b3200f06c202d"
       ]
     },
     "Va-ord-D5-mf-3c-T10d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-mf-3c-T10d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-mf-3c-T10d.wav",
         "7c5645c8e5ecdeb80792c3ccd8de524c"
       ]
     },
     "Va-ord-D#5-mf-1c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-mf-1c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-mf-1c-T11u.wav",
         "4b3973945f5e25dd95398e0ce9dc7bce"
       ]
     },
     "Va-ord-D#5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-mf-2c-N.wav",
         "72ce2015608f833f7c5e445682246892"
       ]
     },
     "Va-ord-D#5-mf-3c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-mf-3c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-mf-3c-T11u.wav",
         "1fd86c595bd0dc10c856ae9c99a4cbb4"
       ]
     },
     "Va-ord-E5-mf-1c-T16u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-mf-1c-T16u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-mf-1c-T16u.wav",
         "211b5092eebe4a8c13e818b95ea0f28b"
       ]
     },
     "Va-ord-E5-mf-2c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-mf-2c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-mf-2c-T11u.wav",
         "92775ad4373dca864aaeda8acd9263e3"
       ]
     },
     "Va-ord-E5-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-mf-3c-N.wav",
         "d18cf5de9e810c27fd510b1a852c1aef"
       ]
     },
     "Va-ord-F5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-mf-1c-N.wav",
         "7c9b3b9ff2129eceabf6f33a555f19e2"
       ]
     },
     "Va-ord-F5-mf-2c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-mf-2c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-mf-2c-T12u.wav",
         "f416e78b9790af147d7ead975d60be4a"
       ]
     },
     "Va-ord-F5-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-mf-3c-N.wav",
         "6d10e25d37b2e94e1847860cd9879388"
       ]
     },
     "Va-ord-F#5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-mf-1c-N.wav",
         "8ad2e9b1706443f6e86629fc02e2cc26"
       ]
     },
     "Va-ord-F#5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-mf-2c-N.wav",
         "e848ee4a2d9d6368e8177aade9fc4a3d"
       ]
     },
     "Va-ord-F#5-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-mf-3c-N.wav",
         "daaa2d79989948e90171242775e0d932"
       ]
     },
     "Va-ord-G5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-mf-1c-N.wav",
         "028780a037fa60238f46e84b5ac7c856"
       ]
     },
     "Va-ord-G5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-mf-2c-N.wav",
         "7c8b871a966e7671f819feab517f9164"
       ]
     },
     "Va-ord-G5-mf-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-mf-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-mf-3c-N.wav",
         "b1c519b513323b53b4e410cc2e15a37e"
       ]
     },
     "Va-ord-G#5-mf-1c-T13u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#5-mf-1c-T13u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#5-mf-1c-T13u.wav",
         "319294f62a6aba1d4c6cd463b36aee39"
       ]
     },
     "Va-ord-G#5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#5-mf-2c-N.wav",
         "daf99e1a4e4da71214a10bb14e2333ae"
       ]
     },
     "Va-ord-A5-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A5-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A5-mf-1c-N.wav",
         "33ba72f51263b38379172951cd7f4ae2"
       ]
     },
     "Va-ord-A5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A5-mf-2c-N.wav",
         "437f9154125772b3871c36bfeefe381e"
       ]
     },
     "Va-ord-A#5-mf-1c-T16u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#5-mf-1c-T16u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#5-mf-1c-T16u.wav",
         "64e2298c122fc9f2541e57c7193d7cab"
       ]
     },
     "Va-ord-A#5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#5-mf-2c-N.wav",
         "ad64fffcb51822f0c2a192d926de8fb9"
       ]
     },
     "Va-ord-B5-mf-1c-T15u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B5-mf-1c-T15u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B5-mf-1c-T15u.wav",
         "db74a92f5975c6db7c68588f9f51e8ec"
       ]
     },
     "Va-ord-B5-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B5-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B5-mf-2c-N.wav",
         "89390af8bee1d9cfb92870dc4b0a8dcd"
       ]
     },
     "Va-ord-C6-mf-1c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C6-mf-1c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C6-mf-1c-T12u.wav",
         "34f9dc720de0bc51eac3620a0f378657"
       ]
     },
     "Va-ord-C6-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C6-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C6-mf-2c-N.wav",
         "6c9ec3c93d622f91b3222050fd3ae00a"
       ]
     },
     "Va-ord-C#6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#6-mf-1c-N.wav",
         "687e928779cfffae2b18c8b6cd2acfb3"
       ]
     },
     "Va-ord-C#6-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#6-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#6-mf-2c-N.wav",
         "de975ffcae9527d8471b9eb01d5e124f"
       ]
     },
     "Va-ord-D6-mf-1c-T15u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D6-mf-1c-T15u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D6-mf-1c-T15u.wav",
         "8e51d81cb207b03c924d49e1f5292ac3"
       ]
     },
     "Va-ord-D6-mf-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D6-mf-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D6-mf-2c-N.wav",
         "df3f85fb44af658cd4e3c5ccd93cd083"
       ]
     },
     "Va-ord-D#6-mf-1c-T13u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#6-mf-1c-T13u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#6-mf-1c-T13u.wav",
         "f7fc844bb1bc589f76313e44f4157ac2"
       ]
     },
     "Va-ord-E6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E6-mf-1c-N.wav",
         "67af40623cbf3735298882a3e03fd717"
       ]
     },
     "Va-ord-F6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F6-mf-1c-N.wav",
         "1ffe38c934e8422340eb65b2693304c4"
       ]
     },
     "Va-ord-F#6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#6-mf-1c-N.wav",
         "7890b34110b394461405975daa0a15b2"
       ]
     },
     "Va-ord-G6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G6-mf-1c-N.wav",
         "05b04ec06d8b19df6559a1bcfc9e1ce8"
       ]
     },
     "Va-ord-G#6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#6-mf-1c-N.wav",
         "60f8ef131c7b3a47b3573ed116886310"
       ]
     },
     "Va-ord-A6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A6-mf-1c-N.wav",
         "bbcee6cb41f950eae9e1622c6aefd79a"
       ]
     },
     "Va-ord-A#6-mf-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#6-mf-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#6-mf-1c-N.wav",
         "b746a0bee7064d65291fc5fa41987225"
       ]
     },
     "Va-ord-B6-mf-1c-T17u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B6-mf-1c-T17u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B6-mf-1c-T17u.wav",
         "b350b54974bf5d9d288007491efa6b27"
       ]
     },
     "Va-ord-C7-mf-1c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C7-mf-1c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C7-mf-1c-T10u.wav",
         "e9d61a68c508c6c1067f69d0a1e5b855"
       ]
     },
     "Va-ord-C3-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C3-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C3-ff-4c-N.wav",
         "2b3abb2fd678cdc6eb6f86201fea889d"
       ]
     },
     "Va-ord-C#3-ff-4c-T26u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#3-ff-4c-T26u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#3-ff-4c-T26u.wav",
         "4eb0e57c529c5a54301276af381ee84a"
       ]
     },
     "Va-ord-D3-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D3-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D3-ff-4c-N.wav",
         "1d778f89d0d62adad0c4d6e102f46e10"
       ]
     },
     "Va-ord-D#3-ff-4c-T20u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#3-ff-4c-T20u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#3-ff-4c-T20u.wav",
         "ec3180fb7868b9dcf4a93bae2ada0d08"
       ]
     },
     "Va-ord-E3-ff-4c-T23u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E3-ff-4c-T23u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E3-ff-4c-T23u.wav",
         "423e93673f502a0008b3c580603e6025"
       ]
     },
     "Va-ord-F3-ff-4c-T23u_R100u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F3-ff-4c-T23u_R100u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F3-ff-4c-T23u_R100u.wav",
         "906021ccd8b143c7e60d6c74e9dedbeb"
       ]
     },
     "Va-ord-F#3-ff-4c-T17u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#3-ff-4c-T17u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#3-ff-4c-T17u.wav",
         "30d3ff273bea8a090a451c1ff8fec853"
       ]
     },
     "Va-ord-G3-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G3-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G3-ff-3c-N.wav",
         "a0f08cc843e10140779f9982206c2800"
       ]
     },
     "Va-ord-G3-ff-4c-T22u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G3-ff-4c-T22u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G3-ff-4c-T22u.wav",
         "676a963ed8b1cb7d98b91eb2bda17f93"
       ]
     },
     "Va-ord-G#3-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#3-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#3-ff-3c-N.wav",
         "33d649f943b5ab6a3f168f7b3b20c7ba"
       ]
     },
     "Va-ord-G#3-ff-4c-T24u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#3-ff-4c-T24u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#3-ff-4c-T24u.wav",
         "1f1cbb6714a6cab21343b07d2ede7609"
       ]
     },
     "Va-ord-A3-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A3-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A3-ff-3c-N.wav",
         "52ff62b3154eca7c15b567c78f0ee34f"
       ]
     },
     "Va-ord-A3-ff-4c-T16u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A3-ff-4c-T16u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A3-ff-4c-T16u.wav",
         "52ed0202ed00194b0102e051414cf750"
       ]
     },
     "Va-ord-A#3-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#3-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#3-ff-3c-N.wav",
         "fd96e5f64f39383b5b567304b9950f83"
       ]
     },
     "Va-ord-A#3-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#3-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#3-ff-4c-N.wav",
         "660c24f14c2c8872c63f5a710172b561"
       ]
     },
     "Va-ord-B3-ff-3c-T18u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B3-ff-3c-T18u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B3-ff-3c-T18u.wav",
         "1766180138eb20c41610c7a0673bda1d"
       ]
     },
     "Va-ord-B3-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B3-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B3-ff-4c-N.wav",
         "e79652d96b3ca5f1e4f6d544ee69ec3b"
       ]
     },
     "Va-ord-C4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C4-ff-3c-N.wav",
         "0b67e064e1d1873deb70379271fe9d57"
       ]
     },
     "Va-ord-C4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C4-ff-4c-N.wav",
         "0447784a259d55342205b3482365c684"
       ]
     },
     "Va-ord-C#4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#4-ff-3c-N.wav",
         "443dd61bd0691d4f60180d4cc75ac288"
       ]
     },
     "Va-ord-C#4-ff-4c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#4-ff-4c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#4-ff-4c-T10u.wav",
         "4b0ca9f0c659bd295fb263bb2aeb8474"
       ]
     },
     "Va-ord-D4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-ff-2c-N.wav",
         "a614d0f21bfbc863df2bb37d4850c261"
       ]
     },
     "Va-ord-D4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-ff-3c-N.wav",
         "fea21ca0a7d3c9a7353da2371dcfece1"
       ]
     },
     "Va-ord-D4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D4-ff-4c-N.wav",
         "1d27651cb1c7029f5eee5036d397a753"
       ]
     },
     "Va-ord-D#4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-ff-2c-N.wav",
         "042219c215a9c4b6a605750d439505c8"
       ]
     },
     "Va-ord-D#4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-ff-3c-N.wav",
         "ed33fbb351197fb9cda00db4872a0bdf"
       ]
     },
     "Va-ord-D#4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#4-ff-4c-N.wav",
         "d97fe152c4edd4a2b29e7c44e61d1036"
       ]
     },
     "Va-ord-E4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-ff-2c-N.wav",
         "ec8c494e4988fa7202de4656176cf80b"
       ]
     },
     "Va-ord-E4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-ff-3c-N.wav",
         "647885741f2bfaa9826ae3ef50e3267d"
       ]
     },
     "Va-ord-E4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E4-ff-4c-N.wav",
         "402d613cb4738d1f3c4f87c92088de73"
       ]
     },
     "Va-ord-F4-ff-2c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-ff-2c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-ff-2c-T10u.wav",
         "5b66645d1fcf9db7fff71783f8f29b7f"
       ]
     },
     "Va-ord-F4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-ff-3c-N.wav",
         "525e904c257cba5184deba1923733596"
       ]
     },
     "Va-ord-F4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F4-ff-4c-N.wav",
         "7525aa6939538e37dab716bdc6c65a5e"
       ]
     },
     "Va-ord-F#4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-ff-2c-N.wav",
         "b093fceefc922077b4e6cc448537864f"
       ]
     },
     "Va-ord-F#4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-ff-3c-N.wav",
         "9937ceded7cdcd05fedee78ee52b3f46"
       ]
     },
     "Va-ord-F#4-ff-4c-T29u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#4-ff-4c-T29u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#4-ff-4c-T29u.wav",
         "cee7dd7fd178b54c9829ff83fba5d8e2"
       ]
     },
     "Va-ord-G4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-ff-2c-N.wav",
         "9af8c7ce471dd4c01291e49a2e45e1de"
       ]
     },
     "Va-ord-G4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-ff-3c-N.wav",
         "7688eb364bb8a44f6b42b8c68326b5c0"
       ]
     },
     "Va-ord-G4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G4-ff-4c-N.wav",
         "f0e1cf0961e3a75acf81fe0183398162"
       ]
     },
     "Va-ord-G#4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-ff-2c-N.wav",
         "d706a99240c59e6b167b55b63fa44eae"
       ]
     },
     "Va-ord-G#4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-ff-3c-N.wav",
         "226c5f91e6244c4b97134b45887b59e3"
       ]
     },
     "Va-ord-G#4-ff-4c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#4-ff-4c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#4-ff-4c-T10u.wav",
         "398ace6b7eb51619402630c7528a5d97"
       ]
     },
     "Va-ord-A4-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-ff-1c-N.wav",
         "ae636abdef6a0a9a4acc36af70014b38"
       ]
     },
     "Va-ord-A4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-ff-2c-N.wav",
         "6e89ea54edeeb6dca4b40180c6158b20"
       ]
     },
     "Va-ord-A4-ff-3c-R100d": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-ff-3c-R100d.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-ff-3c-R100d.wav",
         "cc24481f6537671c926f042f34e3cbc5"
       ]
     },
     "Va-ord-A4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A4-ff-4c-N.wav",
         "81f9922a98abdc73198825fe6d1931bf"
       ]
     },
     "Va-ord-A#4-ff-1c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-ff-1c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-ff-1c-T12u.wav",
         "66e062c33055fd5adc32d47d682209d5"
       ]
     },
     "Va-ord-A#4-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-ff-2c-N.wav",
         "f7d84bb2883af3dc266ee822eaf404cd"
       ]
     },
     "Va-ord-A#4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-ff-3c-N.wav",
         "02073b9077c6c464db0c9e2122e2e65c"
       ]
     },
     "Va-ord-A#4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#4-ff-4c-N.wav",
         "b90abc19af50a6dd08092b74f21030a6"
       ]
     },
     "Va-ord-B4-ff-1c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-ff-1c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-ff-1c-T10u.wav",
         "fcfbe2a97c1ae3e5c6cbd29fa8941997"
       ]
     },
     "Va-ord-B4-ff-2c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-ff-2c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-ff-2c-T11u.wav",
         "0cf363621742308fb2eb5b96b4f40f5b"
       ]
     },
     "Va-ord-B4-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-ff-3c-N.wav",
         "90ffb7d6e7e792ac7642201b4805aec6"
       ]
     },
     "Va-ord-B4-ff-4c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B4-ff-4c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B4-ff-4c-N.wav",
         "129b6e4a6635e97ebb392d38d5e6ace2"
       ]
     },
     "Va-ord-C5-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-ff-1c-N.wav",
         "a34022f14429a2889c9b7d8691e4b2cd"
       ]
     },
     "Va-ord-C5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-ff-2c-N.wav",
         "e88d11b1a6ed2bb17baec4369673e27a"
       ]
     },
     "Va-ord-C5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-ff-3c-N.wav",
         "1d21b96d0531c4950d1e9a589b50aa95"
       ]
     },
     "Va-ord-C5-ff-4c-T17u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C5-ff-4c-T17u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C5-ff-4c-T17u.wav",
         "dbb48259c18fec9f201d54484c38f256"
       ]
     },
     "Va-ord-C#5-ff-1c-R100u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-ff-1c-R100u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-ff-1c-R100u.wav",
         "95fbf3dd4c83c2cbcb4f9174975bc5ae"
       ]
     },
     "Va-ord-C#5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-ff-2c-N.wav",
         "a7b3e63cce1a15107596a5457c7bbd77"
       ]
     },
     "Va-ord-C#5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#5-ff-3c-N.wav",
         "4c3a03df243ca7e2fbe3283c81714370"
       ]
     },
     "Va-ord-D5-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-ff-1c-N.wav",
         "96109691ac9fe285af7b8bee0c0ce3cd"
       ]
     },
     "Va-ord-D5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-ff-2c-N.wav",
         "c1b4f7091447272b9d3dbf0cb022df8e"
       ]
     },
     "Va-ord-D5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D5-ff-3c-N.wav",
         "1c2986ee530f66843e7755a2b2338ef2"
       ]
     },
     "Va-ord-D#5-ff-1c-T12u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-ff-1c-T12u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-ff-1c-T12u.wav",
         "393370dca02ad5e46e21d224290a2e67"
       ]
     },
     "Va-ord-D#5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-ff-2c-N.wav",
         "dfd455fa4395110476ed7939b2cfabe4"
       ]
     },
     "Va-ord-D#5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#5-ff-3c-N.wav",
         "93c02e77c58f946022d30902e30b4efd"
       ]
     },
     "Va-ord-E5-ff-1c-T13u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-ff-1c-T13u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-ff-1c-T13u.wav",
         "e145747a66fe215e187b7b6da9e60151"
       ]
     },
     "Va-ord-E5-ff-2c-T16u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-ff-2c-T16u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-ff-2c-T16u.wav",
         "d57086f12ddee215049d746a55307f3e"
       ]
     },
     "Va-ord-E5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E5-ff-3c-N.wav",
         "4f6a15b173baf1d471562e4f0e47ff6e"
       ]
     },
     "Va-ord-F5-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-ff-1c-N.wav",
         "02a015e7e2bc687e0ea289696b99d396"
       ]
     },
     "Va-ord-F5-ff-2c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-ff-2c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-ff-2c-T11u.wav",
         "6028ee0d1780e61722437c369f1de570"
       ]
     },
     "Va-ord-F5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F5-ff-3c-N.wav",
         "8aca3305c03edf25f8d86c3c2e145c51"
       ]
     },
     "Va-ord-F#5-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-ff-1c-N.wav",
         "aedeaee68f3808c7148a1911a0f515a2"
       ]
     },
     "Va-ord-F#5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-ff-2c-N.wav",
         "c414e70465cb53730a38876fdad3a078"
       ]
     },
     "Va-ord-F#5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#5-ff-3c-N.wav",
         "a83d8874a5957a32fb3c63b0c6a701b8"
       ]
     },
     "Va-ord-G5-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-ff-1c-N.wav",
         "a918815b00d36e918ef430cff54a24f5"
       ]
     },
     "Va-ord-G5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-ff-2c-N.wav",
         "dbb120d214d28f60e402bd9d20981e6a"
       ]
     },
     "Va-ord-G5-ff-3c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G5-ff-3c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G5-ff-3c-N.wav",
         "7245e2e60e1b0449d7c37912d9f32a4a"
       ]
     },
     "Va-ord-G#5-ff-1c-T15u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#5-ff-1c-T15u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#5-ff-1c-T15u.wav",
         "70b3a6d4cbdb330a82f9edd8773de0e4"
       ]
     },
     "Va-ord-G#5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#5-ff-2c-N.wav",
         "5416246831460d37ead664e96b188982"
       ]
     },
     "Va-ord-A5-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A5-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A5-ff-1c-N.wav",
         "69dd6db7b18e6ffaceb786e39c1af9f4"
       ]
     },
     "Va-ord-A5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A5-ff-2c-N.wav",
         "25d03f470601f3c1bc21c41fe8e6fe0c"
       ]
     },
     "Va-ord-A#5-ff-1c-T15u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#5-ff-1c-T15u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#5-ff-1c-T15u.wav",
         "4df8f5749515e9e8b5253830c9299e0e"
       ]
     },
     "Va-ord-A#5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#5-ff-2c-N.wav",
         "1ef639496f5720d4b98d9f417bbb1cda"
       ]
     },
     "Va-ord-B5-ff-1c-T18u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B5-ff-1c-T18u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B5-ff-1c-T18u.wav",
         "3387b75a4abdabc1597e97ec0d079761"
       ]
     },
     "Va-ord-B5-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B5-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B5-ff-2c-N.wav",
         "d4fdf3bb2d8ac232f34b782ecf4c7ac2"
       ]
     },
     "Va-ord-C6-ff-1c-T17u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C6-ff-1c-T17u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C6-ff-1c-T17u.wav",
         "3444ba45e1eb78b0cee9e8b3bcb73c90"
       ]
     },
     "Va-ord-C6-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C6-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C6-ff-2c-N.wav",
         "26159813a25f8e56c70a5be15f7ab8dd"
       ]
     },
     "Va-ord-C#6-ff-1c-T10u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#6-ff-1c-T10u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#6-ff-1c-T10u.wav",
         "e62222d05793fca3434336684aa00f62"
       ]
     },
     "Va-ord-C#6-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C#6-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C#6-ff-2c-N.wav",
         "1a12f70e157637a5b94d7b0bbbea494f"
       ]
     },
     "Va-ord-D6-ff-1c-T18u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D6-ff-1c-T18u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D6-ff-1c-T18u.wav",
         "5934410c465b7554f31d5b793c8c25a9"
       ]
     },
     "Va-ord-D6-ff-2c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D6-ff-2c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D6-ff-2c-N.wav",
         "2dce57abdcbcdf4a145f0f2e3771ad2c"
       ]
     },
     "Va-ord-D#6-ff-1c-T14u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-D#6-ff-1c-T14u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-D#6-ff-1c-T14u.wav",
         "0c8107256aa15d10b143d0bcf14e76db"
       ]
     },
     "Va-ord-E6-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-E6-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-E6-ff-1c-N.wav",
         "d559d7960667c50092be353edac0c0d4"
       ]
     },
     "Va-ord-F6-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F6-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F6-ff-1c-N.wav",
         "a9b01af1e1e462738fb7c4362c05e5ec"
       ]
     },
     "Va-ord-F#6-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-F#6-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-F#6-ff-1c-N.wav",
         "48a8d9e03a8ef51c421a284968f17d01"
       ]
     },
     "Va-ord-G6-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G6-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G6-ff-1c-N.wav",
         "00262e116137bbc14a668d38561191cf"
       ]
     },
     "Va-ord-G#6-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-G#6-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-G#6-ff-1c-N.wav",
         "8e856c1e2cbe0bb1f6328503fc92bb38"
       ]
     },
     "Va-ord-A6-ff-1c-T11u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A6-ff-1c-T11u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A6-ff-1c-T11u.wav",
         "a2805c627ef26e165d590aa3fc150c29"
       ]
     },
     "Va-ord-A#6-ff-1c-N": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-A#6-ff-1c-N.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-A#6-ff-1c-N.wav",
         "a215aee843a566c77691b5ad2b2ea608"
       ]
     },
     "Va-ord-B6-ff-1c-T13u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-B6-ff-1c-T13u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-B6-ff-1c-T13u.wav",
         "fbd6bb7e05c395f6e52ba9a31b3e36be"
       ]
     },
     "Va-ord-C7-ff-1c-T16u": {
       "audio": [
-        "Strings/Viola/ordinario/Va-ord-C7-ff-1c-T16u.wav",
+        "audio/Strings/Viola/ordinario/Va-ord-C7-ff-1c-T16u.wav",
         "8e134870ffad3eea6fd99aa5ea699875"
       ]
     },
     "Vn-ord-G3-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G3-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G3-pp-4c-N.wav",
         "b625e20009b0c7cde491730ae271039c"
       ]
     },
     "Vn-ord-G#3-pp-4c-T15u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#3-pp-4c-T15u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#3-pp-4c-T15u.wav",
         "6790805e2b94108427b44847402f7db5"
       ]
     },
     "Vn-ord-A3-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A3-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A3-pp-4c-N.wav",
         "570fbf9226b355a41c3ec0da5ebb838b"
       ]
     },
     "Vn-ord-A#3-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#3-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#3-pp-4c-N.wav",
         "3f64e39e3aa97168cb538914b2097154"
       ]
     },
     "Vn-ord-B3-pp-4c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B3-pp-4c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B3-pp-4c-T10u.wav",
         "af6205deb6cdbeb6ea042f6cef06b659"
       ]
     },
     "Vn-ord-C4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C4-pp-4c-N.wav",
         "d02ede42c09c42d7a80d5165189808b1"
       ]
     },
     "Vn-ord-C#4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#4-pp-4c-N.wav",
         "b135a2231b64746f0afb312ad377c483"
       ]
     },
     "Vn-ord-D4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D4-pp-3c-N.wav",
         "c5b636e39d8abc34209fce1ce5a54014"
       ]
     },
     "Vn-ord-D4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D4-pp-4c-N.wav",
         "8663337edc1f6bbf6fb8ee58fef75ea3"
       ]
     },
     "Vn-ord-D#4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#4-pp-3c-N.wav",
         "a2c4c93ab3f309038b59772f0ae597bf"
       ]
     },
     "Vn-ord-D#4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#4-pp-4c-N.wav",
         "76569b72ec3ccfd8f65d83ae3e20fd60"
       ]
     },
     "Vn-ord-E4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E4-pp-3c-N.wav",
         "96994c3bf173d6481e79ca40d358ba8f"
       ]
     },
     "Vn-ord-E4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E4-pp-4c-N.wav",
         "fbcebb68cb95ab84b0488487ad1fc1e4"
       ]
     },
     "Vn-ord-F4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F4-pp-3c-N.wav",
         "8cf771eaa840e406c72c9a94030ef3a6"
       ]
     },
     "Vn-ord-F4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F4-pp-4c-N.wav",
         "10ec2305104db55a3789155421107b9c"
       ]
     },
     "Vn-ord-F#4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#4-pp-3c-N.wav",
         "fbfd8fbe767e21532899e71be9c76709"
       ]
     },
     "Vn-ord-F#4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#4-pp-4c-N.wav",
         "0b36c97a6a61a9b91aeeadb127f48cff"
       ]
     },
     "Vn-ord-G4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G4-pp-3c-N.wav",
         "4a7a05685ca6411db2f6271daa136890"
       ]
     },
     "Vn-ord-G4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G4-pp-4c-N.wav",
         "6d611926991fe1882a4abd10f4e7c75e"
       ]
     },
     "Vn-ord-G#4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#4-pp-3c-N.wav",
         "8ef72484615041ef3b004e16a05806b9"
       ]
     },
     "Vn-ord-G#4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#4-pp-4c-N.wav",
         "1b45e99087932afa4027ba850542ef30"
       ]
     },
     "Vn-ord-A4-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-pp-2c-N.wav",
         "03d4f3bdc078083052098e955dab9e6e"
       ]
     },
     "Vn-ord-A4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-pp-3c-N.wav",
         "9d73ed94094bbcef21c101c681ca8462"
       ]
     },
     "Vn-ord-A4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-pp-4c-N.wav",
         "488e6f0e5b7e86fe838df4bd44b3c365"
       ]
     },
     "Vn-ord-A#4-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-pp-2c-N.wav",
         "bed9d5e424e65b9efbcdc9dcd9ad133c"
       ]
     },
     "Vn-ord-A#4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-pp-3c-N.wav",
         "c6a4bf65751dba392411d60dad3e2609"
       ]
     },
     "Vn-ord-A#4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-pp-4c-N.wav",
         "1cc06b6049981992eb5e4a87e7cf0e00"
       ]
     },
     "Vn-ord-B4-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-pp-2c-N.wav",
         "1910a8de30a214f9496439b4aaa387c3"
       ]
     },
     "Vn-ord-B4-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-pp-3c-N.wav",
         "e933bbfab97662e09617a6528747e4c7"
       ]
     },
     "Vn-ord-B4-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-pp-4c-N.wav",
         "c414af4dc0ba144074b5693e79a19600"
       ]
     },
     "Vn-ord-C5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-pp-2c-N.wav",
         "d1c0f5b110c3dd5091c164314ef3ddf8"
       ]
     },
     "Vn-ord-C5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-pp-3c-N.wav",
         "3a4f904ab8dd1748d36fed78594520a3"
       ]
     },
     "Vn-ord-C5-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-pp-4c-N.wav",
         "9ec23d54e33b90e216aa1cd81c207eb1"
       ]
     },
     "Vn-ord-C#5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-pp-2c-N.wav",
         "615310aa04c1055aa49979fe0b61362f"
       ]
     },
     "Vn-ord-C#5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-pp-3c-N.wav",
         "c8f2ca2bc2bfa1399a1f67c79e32813a"
       ]
     },
     "Vn-ord-C#5-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-pp-4c-N.wav",
         "b7e176721343c5afbf68ecb600aa08b2"
       ]
     },
     "Vn-ord-D5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-pp-2c-N.wav",
         "235bbc0634e42c821f709665667c4866"
       ]
     },
     "Vn-ord-D5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-pp-3c-N.wav",
         "f25db540694619a33c9582e16ed080f4"
       ]
     },
     "Vn-ord-D5-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-pp-4c-N.wav",
         "7ed9a387b303ed4a53f8945c94b48820"
       ]
     },
     "Vn-ord-D#5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-pp-2c-N.wav",
         "cf50ad47860c232918a898a9994a16f0"
       ]
     },
     "Vn-ord-D#5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-pp-3c-N.wav",
         "b8ea417a139e9f7e727371ce1316c497"
       ]
     },
     "Vn-ord-D#5-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-pp-4c-N.wav",
         "7f6eca880dd4fa5581b85e240d0b6f99"
       ]
     },
     "Vn-ord-E5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-pp-1c-N.wav",
         "1e67de7b73b2f0ba2ebc17cd9efeba3a"
       ]
     },
     "Vn-ord-E5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-pp-2c-N.wav",
         "a1c3e914e910d0ef65d756beabf5a521"
       ]
     },
     "Vn-ord-E5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-pp-3c-N.wav",
         "f097992d072cab06c13a8ca0ef396441"
       ]
     },
     "Vn-ord-E5-pp-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-pp-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-pp-4c-N.wav",
         "0fc7fa335e464fd4b65639e8d2896134"
       ]
     },
     "Vn-ord-F5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-pp-1c-N.wav",
         "14be6ec248a47578f8ae55a954a9103c"
       ]
     },
     "Vn-ord-F5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-pp-2c-N.wav",
         "2f398a251060d2fee1185a387c39cfe3"
       ]
     },
     "Vn-ord-F5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-pp-3c-N.wav",
         "eacb42c486cacb1cfb775c66274721fe"
       ]
     },
     "Vn-ord-F#5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-pp-1c-N.wav",
         "c9b1239d2a183a3179a345879dc3e5a4"
       ]
     },
     "Vn-ord-F#5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-pp-2c-N.wav",
         "a42065ca743410f2b05e789ec83f9b74"
       ]
     },
     "Vn-ord-F#5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-pp-3c-N.wav",
         "d7b47be3c5d3464602a140e13b3b6a87"
       ]
     },
     "Vn-ord-G5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-pp-1c-N.wav",
         "04ea7b9713c754bcce9f7abfe836e5a4"
       ]
     },
     "Vn-ord-G5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-pp-2c-N.wav",
         "e39d25a8853a68da7eb7947e77fb6cd6"
       ]
     },
     "Vn-ord-G5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-pp-3c-N.wav",
         "923c9a0def4acb55c3d07f09963b2506"
       ]
     },
     "Vn-ord-G#5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-pp-1c-N.wav",
         "7e95bdd5ff0fcc17ce45f0fa6564e2fa"
       ]
     },
     "Vn-ord-G#5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-pp-2c-N.wav",
         "a540d3fb47f63d735e0825de87dbde2d"
       ]
     },
     "Vn-ord-G#5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-pp-3c-N.wav",
         "9a693e94c577e78a444ba7660a2f9dd6"
       ]
     },
     "Vn-ord-A5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-pp-1c-N.wav",
         "91fd72d584dcf910042e4fe60a56d6f6"
       ]
     },
     "Vn-ord-A5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-pp-2c-N.wav",
         "bbcbcf6cc26b1b2a528df56043596733"
       ]
     },
     "Vn-ord-A5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-pp-3c-N.wav",
         "123338794415b3375d4a3d3c76d7241a"
       ]
     },
     "Vn-ord-A#5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-pp-1c-N.wav",
         "63e1a637d32403879a55b164e3c3753b"
       ]
     },
     "Vn-ord-A#5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-pp-2c-N.wav",
         "5fc77656af1fa268f2c0d3b7b41b565e"
       ]
     },
     "Vn-ord-A#5-pp-3c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-pp-3c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-pp-3c-T10u.wav",
         "597d44a707af36ab13660198cc5ec921"
       ]
     },
     "Vn-ord-B5-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-pp-1c-N.wav",
         "67dedc07d0fe2a248e3cfd54a820d366"
       ]
     },
     "Vn-ord-B5-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-pp-2c-N.wav",
         "e928ec1bd7cf4c5f3c0167cb35a1fc85"
       ]
     },
     "Vn-ord-B5-pp-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-pp-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-pp-3c-N.wav",
         "22401952e4db0a972755140d72717f66"
       ]
     },
     "Vn-ord-C6-pp-1c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-pp-1c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-pp-1c-T11d.wav",
         "c8b240dc7dc3159de90cc49b0d1f6e45"
       ]
     },
     "Vn-ord-C6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-pp-2c-N.wav",
         "a164383245fc705b0e055da01d8f739e"
       ]
     },
     "Vn-ord-C6-pp-3c-T14d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-pp-3c-T14d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-pp-3c-T14d.wav",
         "c68b3c247542d56cf89a9542187f9d95"
       ]
     },
     "Vn-ord-C#6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#6-pp-1c-N.wav",
         "79c47185d80c2114ca8cfbb80a1db8a0"
       ]
     },
     "Vn-ord-C#6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#6-pp-2c-N.wav",
         "3a21f8bbc176d7b477a0f5e8145291fa"
       ]
     },
     "Vn-ord-D6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D6-pp-1c-N.wav",
         "54764381016697421edd13e7454d6941"
       ]
     },
     "Vn-ord-D6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D6-pp-2c-N.wav",
         "b11bc7a4473399a0132072494d5e20d6"
       ]
     },
     "Vn-ord-D#6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#6-pp-1c-N.wav",
         "ea8fc6c7f1025eccb5c85422cb46963b"
       ]
     },
     "Vn-ord-D#6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#6-pp-2c-N.wav",
         "d8177b7ead47227d3af4f280339d0737"
       ]
     },
     "Vn-ord-E6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E6-pp-1c-N.wav",
         "0c673074992f3d1ae6bb28fe1870517e"
       ]
     },
     "Vn-ord-E6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E6-pp-2c-N.wav",
         "5f5ecfd5a459f6764275c98a1f877066"
       ]
     },
     "Vn-ord-F6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F6-pp-1c-N.wav",
         "50adb6b4423c005fc0511baf664b656c"
       ]
     },
     "Vn-ord-F6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F6-pp-2c-N.wav",
         "d6d3e8a021026379fe52b0ea055739f6"
       ]
     },
     "Vn-ord-F#6-pp-1c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#6-pp-1c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#6-pp-1c-T12d.wav",
         "8b2e25f8635183377250e58cfb80ed3c"
       ]
     },
     "Vn-ord-F#6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#6-pp-2c-N.wav",
         "021ca8aef2963b6ee5ce1f26ba74b015"
       ]
     },
     "Vn-ord-G6-pp-1c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G6-pp-1c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G6-pp-1c-T12d.wav",
         "3971bf945cbfd7ef8abcf1f2ce5c6d0d"
       ]
     },
     "Vn-ord-G6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G6-pp-2c-N.wav",
         "33ea4d74705bbf2fbc53c9e4b0779f06"
       ]
     },
     "Vn-ord-G#6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#6-pp-1c-N.wav",
         "71c54bd64fae5c4901728ef3c5f3d27c"
       ]
     },
     "Vn-ord-G#6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#6-pp-2c-N.wav",
         "4e8fedaa7c81d9cb67b4693bef0b5a61"
       ]
     },
     "Vn-ord-A6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A6-pp-1c-N.wav",
         "a24aaf6f49aa3fa13084e8347d9c184b"
       ]
     },
     "Vn-ord-A6-pp-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A6-pp-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A6-pp-2c-N.wav",
         "4d2f59a184ddd663cad246e19a7ecd2a"
       ]
     },
     "Vn-ord-A#6-pp-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#6-pp-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#6-pp-1c-N.wav",
         "4a6e38b3ad11dbaa970838c71328bd23"
       ]
     },
     "Vn-ord-B6-pp-1c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B6-pp-1c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B6-pp-1c-T12d.wav",
         "6ef8fcee78f449beb2df4933e74db3c0"
       ]
     },
     "Vn-ord-C7-pp-1c-T28d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C7-pp-1c-T28d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C7-pp-1c-T28d.wav",
         "858a3836b9bb943391dcdb0015361b6e"
       ]
     },
     "Vn-ord-C#7-pp-1c-T15d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#7-pp-1c-T15d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#7-pp-1c-T15d.wav",
         "cf939a63ace63a45e1195d2c9c63939b"
       ]
     },
     "Vn-ord-D7-pp-1c-T17d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D7-pp-1c-T17d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D7-pp-1c-T17d.wav",
         "67584b77594bfa8f7b168cc128637aeb"
       ]
     },
     "Vn-ord-D#7-pp-1c-T16d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#7-pp-1c-T16d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#7-pp-1c-T16d.wav",
         "7fb312e95a7642551de2eae04ec83b2d"
       ]
     },
     "Vn-ord-E7-pp-1c-T21d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E7-pp-1c-T21d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E7-pp-1c-T21d.wav",
         "ac4e9152ecf0fcb9012742e11b1199d6"
       ]
     },
     "Vn-ord-G3-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G3-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G3-mf-4c-N.wav",
         "bfb96eb0b3febf19b5249dd010a3aa91"
       ]
     },
     "Vn-ord-G#3-mf-4c-T13u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#3-mf-4c-T13u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#3-mf-4c-T13u.wav",
         "51179ec5866dcdc656a43f53d842cd88"
       ]
     },
     "Vn-ord-A3-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A3-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A3-mf-4c-N.wav",
         "566f5be76be914dcf1639b088a7bfb1e"
       ]
     },
     "Vn-ord-A#3-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#3-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#3-mf-4c-N.wav",
         "fae083650bb4c4d6e5bb31b878c4c29a"
       ]
     },
     "Vn-ord-B3-mf-4c-T15u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B3-mf-4c-T15u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B3-mf-4c-T15u.wav",
         "677829514775ae218b84c668bb0b4878"
       ]
     },
     "Vn-ord-C4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C4-mf-4c-N.wav",
         "2f56386a2b2184ad3df3903ce5422244"
       ]
     },
     "Vn-ord-C#4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#4-mf-4c-N.wav",
         "006da4b4ee21e67282da092fe8e19626"
       ]
     },
     "Vn-ord-D4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D4-mf-3c-N.wav",
         "6da578f3c8f6ea784ae766488eb21c20"
       ]
     },
     "Vn-ord-D4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D4-mf-4c-N.wav",
         "314855400fa376a1719f8062985a8142"
       ]
     },
     "Vn-ord-D#4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#4-mf-3c-N.wav",
         "ae1682e9325384ff46fcd670ae0de264"
       ]
     },
     "Vn-ord-D#4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#4-mf-4c-N.wav",
         "539f0b3f9acca161ecf3e54dcf994cb3"
       ]
     },
     "Vn-ord-E4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E4-mf-3c-N.wav",
         "507614cbfab1fe707264ab75f063775b"
       ]
     },
     "Vn-ord-E4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E4-mf-4c-N.wav",
         "5f096ffe999a62ead8981724b86c14a9"
       ]
     },
     "Vn-ord-F4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F4-mf-3c-N.wav",
         "29481c8ef0395ef8915181cfb2b7d67d"
       ]
     },
     "Vn-ord-F4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F4-mf-4c-N.wav",
         "1337dbdf6f291939f6fd9618555eda9f"
       ]
     },
     "Vn-ord-F#4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#4-mf-3c-N.wav",
         "42f42659c40b2e0d3bd8aa96956c19a3"
       ]
     },
     "Vn-ord-F#4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#4-mf-4c-N.wav",
         "44bf1e1205d5375138b90e552acf3abf"
       ]
     },
     "Vn-ord-G4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G4-mf-3c-N.wav",
         "39ad970374aa61503b3b21e94164a13f"
       ]
     },
     "Vn-ord-G4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G4-mf-4c-N.wav",
         "d4683b8051aedb0b6cf8ceb29f7d0636"
       ]
     },
     "Vn-ord-G#4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#4-mf-3c-N.wav",
         "6dfcaf7f1cd71d9f8c0e5f50a9e07de0"
       ]
     },
     "Vn-ord-G#4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#4-mf-4c-N.wav",
         "f6510c188874a82a92c839b80ccac349"
       ]
     },
     "Vn-ord-A4-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-mf-2c-N.wav",
         "f1725631b3c97ef6409de56b64b8d3a2"
       ]
     },
     "Vn-ord-A4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-mf-3c-N.wav",
         "80481cb80f844068fdb4490c89916222"
       ]
     },
     "Vn-ord-A4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-mf-4c-N.wav",
         "1422f98a7978afad9994e7d17b532c5b"
       ]
     },
     "Vn-ord-A#4-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-mf-2c-N.wav",
         "56120842c54881715183658ff707e1df"
       ]
     },
     "Vn-ord-A#4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-mf-3c-N.wav",
         "3743553180c65f5122c73ad1123f3bf9"
       ]
     },
     "Vn-ord-A#4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-mf-4c-N.wav",
         "712eaf3756b52aa7501cd2c7f17cb9d7"
       ]
     },
     "Vn-ord-B4-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-mf-2c-N.wav",
         "2594a7eafafb7d4b72aec5515d567f6f"
       ]
     },
     "Vn-ord-B4-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-mf-3c-N.wav",
         "0401ddba3b47f70bc53d65b840d7f32e"
       ]
     },
     "Vn-ord-B4-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-mf-4c-N.wav",
         "f45b32dd01d8182cfb3fd4b9b9886e2d"
       ]
     },
     "Vn-ord-C5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-mf-2c-N.wav",
         "277cc158d89bd9fcc65250f7308a258b"
       ]
     },
     "Vn-ord-C5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-mf-3c-N.wav",
         "4d1acb70fba95e246bb8905c13e6ec49"
       ]
     },
     "Vn-ord-C5-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-mf-4c-N.wav",
         "cf7c666f347c2d3176708ac545b9c127"
       ]
     },
     "Vn-ord-C#5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-mf-2c-N.wav",
         "ae94df6203a5f14bf4b9a00f0feaa20f"
       ]
     },
     "Vn-ord-C#5-mf-3c-T11u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-mf-3c-T11u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-mf-3c-T11u.wav",
         "3187848255775b2fc18ac8f01e824029"
       ]
     },
     "Vn-ord-C#5-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-mf-4c-N.wav",
         "d6dffce64bf9625323014df01ad62011"
       ]
     },
     "Vn-ord-D5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-mf-2c-N.wav",
         "48ee27e13d27c64d2558b1506efeae54"
       ]
     },
     "Vn-ord-D5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-mf-3c-N.wav",
         "06abac795f16a655c0d43f9c0ae3debd"
       ]
     },
     "Vn-ord-D5-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-mf-4c-N.wav",
         "6d3351cc6fe3d7aee5bbb248039e77f3"
       ]
     },
     "Vn-ord-D#5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-mf-2c-N.wav",
         "50158fb846a608ee8d39b66b9847a4f4"
       ]
     },
     "Vn-ord-D#5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-mf-3c-N.wav",
         "12db8692f487bafb394c3e9f43d1c074"
       ]
     },
     "Vn-ord-D#5-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-mf-4c-N.wav",
         "45e43311f16b5c74ce63ee14b1d77fac"
       ]
     },
     "Vn-ord-E5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-mf-1c-N.wav",
         "7dd5bf2a8c6c0d2880bcaead1f0289a7"
       ]
     },
     "Vn-ord-E5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-mf-2c-N.wav",
         "43bf37ae1b563198bdca3e260b393fdb"
       ]
     },
     "Vn-ord-E5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-mf-3c-N.wav",
         "2d72518113e9da83a5b4fe091a9452f8"
       ]
     },
     "Vn-ord-E5-mf-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-mf-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-mf-4c-N.wav",
         "44f47d84d576013736b80714b43b2b67"
       ]
     },
     "Vn-ord-F5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-mf-1c-N.wav",
         "2750a67e2568d6b5379754655f256c33"
       ]
     },
     "Vn-ord-F5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-mf-2c-N.wav",
         "c44d24856e6f225a61fe461db294ecfb"
       ]
     },
     "Vn-ord-F5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-mf-3c-N.wav",
         "899735f20bbe73546c42c19f9dd6beec"
       ]
     },
     "Vn-ord-F#5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-mf-1c-N.wav",
         "c24d23d2e82d8f465f656ee99ebf50fe"
       ]
     },
     "Vn-ord-F#5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-mf-2c-N.wav",
         "602808d4dcafecbeecf3393b331cb182"
       ]
     },
     "Vn-ord-F#5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-mf-3c-N.wav",
         "8baf13e876dfccb979175b17fbb9183f"
       ]
     },
     "Vn-ord-G5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-mf-1c-N.wav",
         "1bf57f1bb23831fce3af9d577da114c3"
       ]
     },
     "Vn-ord-G5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-mf-2c-N.wav",
         "99763208a9bae23ebd66be0a1eff0a47"
       ]
     },
     "Vn-ord-G5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-mf-3c-N.wav",
         "6c337d3dab76539af78dfdad8ae68fd9"
       ]
     },
     "Vn-ord-G#5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-mf-1c-N.wav",
         "56dd70361eaa3b6217714b989fa193fe"
       ]
     },
     "Vn-ord-G#5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-mf-2c-N.wav",
         "9e5372249df28b316a3766cec7fd2c11"
       ]
     },
     "Vn-ord-G#5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-mf-3c-N.wav",
         "0a6b010524a437cf9914d85b67894233"
       ]
     },
     "Vn-ord-A5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-mf-1c-N.wav",
         "17fe0be4b0361cf320da608e6d21de0a"
       ]
     },
     "Vn-ord-A5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-mf-2c-N.wav",
         "ed4546f00d1377b805e5b4dddc190b2c"
       ]
     },
     "Vn-ord-A5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-mf-3c-N.wav",
         "f05daac3412a3e9e1763386ef91fc720"
       ]
     },
     "Vn-ord-A#5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-mf-1c-N.wav",
         "84933a2329e58af924f67ce2341aff98"
       ]
     },
     "Vn-ord-A#5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-mf-2c-N.wav",
         "3dc7ac5024d23400b2fee87f485c0f39"
       ]
     },
     "Vn-ord-A#5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-mf-3c-N.wav",
         "0e49fc623087e83c857ae566d063090f"
       ]
     },
     "Vn-ord-B5-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-mf-1c-N.wav",
         "7ff6a88a3c49fc06866697db7c66f5e1"
       ]
     },
     "Vn-ord-B5-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-mf-2c-N.wav",
         "ce9127e4627e29ba2072efe77a8949af"
       ]
     },
     "Vn-ord-B5-mf-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-mf-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-mf-3c-N.wav",
         "b397441743eff772ea6482feb23f5f4d"
       ]
     },
     "Vn-ord-C6-mf-1c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-mf-1c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-mf-1c-T12d.wav",
         "c8442c59abe6e5d2b162c872281ad4f8"
       ]
     },
     "Vn-ord-C6-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-mf-2c-N.wav",
         "4faea732d918592e45e5ea700fc15075"
       ]
     },
     "Vn-ord-C6-mf-3c-T13d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-mf-3c-T13d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-mf-3c-T13d.wav",
         "aff425bb1923e57f656292ef29fa00d1"
       ]
     },
     "Vn-ord-C#6-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#6-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#6-mf-1c-N.wav",
         "672b34929d3648030779bb51d7df8d7d"
       ]
     },
     "Vn-ord-C#6-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#6-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#6-mf-2c-N.wav",
         "4af1194f0df46131863a24d9fae9866b"
       ]
     },
     "Vn-ord-D6-mf-1c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D6-mf-1c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D6-mf-1c-T12d.wav",
         "09403dc9729bba87a1dcb47920b6690b"
       ]
     },
     "Vn-ord-D6-mf-2c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D6-mf-2c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D6-mf-2c-T12d.wav",
         "0501e6c4ce4107d6c6f763424d2de113"
       ]
     },
     "Vn-ord-D#6-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#6-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#6-mf-1c-N.wav",
         "c71ef061c22640774d8fa6252b55cd88"
       ]
     },
     "Vn-ord-D#6-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#6-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#6-mf-2c-N.wav",
         "34376cfbb817403156b9431a8467d702"
       ]
     },
     "Vn-ord-E6-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E6-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E6-mf-1c-N.wav",
         "15e58067d34bc35af62e7ed5c050292c"
       ]
     },
     "Vn-ord-E6-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E6-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E6-mf-2c-N.wav",
         "b982f817ed3e5d96210b69f43b0c8f3c"
       ]
     },
     "Vn-ord-F6-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F6-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F6-mf-1c-N.wav",
         "b72646b4b8a05b02633df06248a0bcb4"
       ]
     },
     "Vn-ord-F6-mf-2c-T17d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F6-mf-2c-T17d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F6-mf-2c-T17d.wav",
         "3016a95abe5b096216e3e712b2a4d66e"
       ]
     },
     "Vn-ord-F#6-mf-1c-T10d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#6-mf-1c-T10d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#6-mf-1c-T10d.wav",
         "79e97365b5a84c6ff882e7a733e04c51"
       ]
     },
     "Vn-ord-F#6-mf-2c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#6-mf-2c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#6-mf-2c-T11d.wav",
         "66f51cf9e63301e7a5d822415566c501"
       ]
     },
     "Vn-ord-G6-mf-1c-T15d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G6-mf-1c-T15d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G6-mf-1c-T15d.wav",
         "b83a67b33dc5a53268232b7a02fc38e5"
       ]
     },
     "Vn-ord-G6-mf-2c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G6-mf-2c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G6-mf-2c-T12d.wav",
         "7bbc8f224a3c5138f58f32a99cddb793"
       ]
     },
     "Vn-ord-G#6-mf-1c-T11d_R100d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#6-mf-1c-T11d_R100d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#6-mf-1c-T11d_R100d.wav",
         "be8ebb2d2c2344b09803535dc6d0b4e5"
       ]
     },
     "Vn-ord-G#6-mf-2c-T21d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#6-mf-2c-T21d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#6-mf-2c-T21d.wav",
         "9756218ed1770f750bbc2465bfa189ca"
       ]
     },
     "Vn-ord-A6-mf-1c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A6-mf-1c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A6-mf-1c-T11d.wav",
         "fd25516b496fc307334e5a967a4fdfb9"
       ]
     },
     "Vn-ord-A6-mf-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A6-mf-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A6-mf-2c-N.wav",
         "f5025cb9ff0fb7b3c050ffb7fbcd788d"
       ]
     },
     "Vn-ord-A#6-mf-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#6-mf-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#6-mf-1c-N.wav",
         "47beff84cbb054090cf903a959133c47"
       ]
     },
     "Vn-ord-B6-mf-1c-T15d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B6-mf-1c-T15d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B6-mf-1c-T15d.wav",
         "59abd852b4bdd3e7755ae563bda094c1"
       ]
     },
     "Vn-ord-C7-mf-1c-T27d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C7-mf-1c-T27d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C7-mf-1c-T27d.wav",
         "cf4fe7ea46125702c73ae8b003f96272"
       ]
     },
     "Vn-ord-C#7-mf-1c-T22d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#7-mf-1c-T22d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#7-mf-1c-T22d.wav",
         "692c0a42be03183040495cacba9cb091"
       ]
     },
     "Vn-ord-D7-mf-1c-T22d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D7-mf-1c-T22d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D7-mf-1c-T22d.wav",
         "f04e59412fc9934e99ca7f26335278bd"
       ]
     },
     "Vn-ord-D#7-mf-1c-T22d_R100u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#7-mf-1c-T22d_R100u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#7-mf-1c-T22d_R100u.wav",
         "025d83c3ba0d8cd1ce9768d831da6434"
       ]
     },
     "Vn-ord-E7-mf-1c-T22d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E7-mf-1c-T22d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E7-mf-1c-T22d.wav",
         "08a82ae7b85f829e0d15dff9c0bf5884"
       ]
     },
     "Vn-ord-G3-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G3-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G3-ff-4c-N.wav",
         "a997fda1357c7e7c876c1bad8cf623d6"
       ]
     },
     "Vn-ord-G#3-ff-4c-T16u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#3-ff-4c-T16u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#3-ff-4c-T16u.wav",
         "307bd6fff31a086e1e3618d12ab7707f"
       ]
     },
     "Vn-ord-A3-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A3-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A3-ff-4c-N.wav",
         "ce75a8c841450790218122cdcea664a2"
       ]
     },
     "Vn-ord-A#3-ff-4c-T15u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#3-ff-4c-T15u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#3-ff-4c-T15u.wav",
         "2c3b31628198583a7855fdc84b2409b2"
       ]
     },
     "Vn-ord-B3-ff-4c-T17u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B3-ff-4c-T17u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B3-ff-4c-T17u.wav",
         "8eef48ec17c99fa06a4a6e6d2670ec22"
       ]
     },
     "Vn-ord-C4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C4-ff-4c-N.wav",
         "16757349f032d0e1d275565b22246cf3"
       ]
     },
     "Vn-ord-C#4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#4-ff-4c-N.wav",
         "d0f6bb5d2afd8b0c6f6c3eb6d6aea406"
       ]
     },
     "Vn-ord-D4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D4-ff-3c-N.wav",
         "2b8589e208af5f67fbcaadcb9b576f96"
       ]
     },
     "Vn-ord-D4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D4-ff-4c-N.wav",
         "659f9f5a4f50ff81410e18554696ee82"
       ]
     },
     "Vn-ord-D#4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#4-ff-3c-N.wav",
         "9024db5d1f0847b0e25d82e9d71b342a"
       ]
     },
     "Vn-ord-D#4-ff-4c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#4-ff-4c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#4-ff-4c-T10u.wav",
         "f180807f3f1d1b227265cf231ec6e774"
       ]
     },
     "Vn-ord-E4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E4-ff-3c-N.wav",
         "d853ee8d0ab40262b09ec972fa86afb1"
       ]
     },
     "Vn-ord-E4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E4-ff-4c-N.wav",
         "1d9dc15e41b33bb63160dce225474ef0"
       ]
     },
     "Vn-ord-F4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F4-ff-3c-N.wav",
         "36e1ad92fe955b4212ae3776d6b401e7"
       ]
     },
     "Vn-ord-F4-ff-4c-T11u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F4-ff-4c-T11u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F4-ff-4c-T11u.wav",
         "8a90699a37497162a2add9cce77164dd"
       ]
     },
     "Vn-ord-F#4-ff-3c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#4-ff-3c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#4-ff-3c-T10u.wav",
         "ef48d1203d16d8ad34bf0cf2d5eaf1de"
       ]
     },
     "Vn-ord-F#4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#4-ff-4c-N.wav",
         "54ace99c0991954aa8f4f8cc076f975a"
       ]
     },
     "Vn-ord-G4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G4-ff-3c-N.wav",
         "7027c15be001ed0ef21c98cacd09a3ea"
       ]
     },
     "Vn-ord-G4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G4-ff-4c-N.wav",
         "ac54d5035882139a017a2310e0e412c4"
       ]
     },
     "Vn-ord-G#4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#4-ff-3c-N.wav",
         "6f04471575b5cba752716509c730da7f"
       ]
     },
     "Vn-ord-G#4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#4-ff-4c-N.wav",
         "8569341067fd420ad5380abb58cc3884"
       ]
     },
     "Vn-ord-A4-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-ff-2c-N.wav",
         "e7bea33792230976374f364a0e3440d9"
       ]
     },
     "Vn-ord-A4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-ff-3c-N.wav",
         "dd695c958c5a294e63f65a9438923c53"
       ]
     },
     "Vn-ord-A4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A4-ff-4c-N.wav",
         "7b2cc47ec90cbaee68b05d92f86a2729"
       ]
     },
     "Vn-ord-A#4-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-ff-2c-N.wav",
         "f018c38b12acc38379a047be0ba450ea"
       ]
     },
     "Vn-ord-A#4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-ff-3c-N.wav",
         "6d948d8c17d6208cd0773a6361215b3e"
       ]
     },
     "Vn-ord-A#4-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#4-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#4-ff-4c-N.wav",
         "deb57d3c14ccd808568ef2ea3d2a2958"
       ]
     },
     "Vn-ord-B4-ff-2c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-ff-2c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-ff-2c-T10u.wav",
         "e06d982041e1405f569004bde56a0579"
       ]
     },
     "Vn-ord-B4-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-ff-3c-N.wav",
         "5b1f2babfa0fa758d7abd60c66e688f8"
       ]
     },
     "Vn-ord-B4-ff-4c-T12u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B4-ff-4c-T12u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B4-ff-4c-T12u.wav",
         "c1527aeaa49f49fff50a4acc00ae3f77"
       ]
     },
     "Vn-ord-C5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-ff-2c-N.wav",
         "17c97b5954ca7cf9141b5f315abbd2ba"
       ]
     },
     "Vn-ord-C5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-ff-3c-N.wav",
         "3dd657b96fa1345d31d2b8efdfdfd74c"
       ]
     },
     "Vn-ord-C5-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C5-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C5-ff-4c-N.wav",
         "1788c94d80e1e6fa3a13c1c6b40c1f3a"
       ]
     },
     "Vn-ord-C#5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-ff-2c-N.wav",
         "dd615981249722ad4d6ac3705d76f497"
       ]
     },
     "Vn-ord-C#5-ff-3c-T13u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-ff-3c-T13u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-ff-3c-T13u.wav",
         "52d73f8092064181f6033ea46a8e8ada"
       ]
     },
     "Vn-ord-C#5-ff-4c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#5-ff-4c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#5-ff-4c-T10u.wav",
         "9762858bdcd95c7b086a3374a8a53f58"
       ]
     },
     "Vn-ord-D5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-ff-2c-N.wav",
         "69b192a355c3bc9bc799810dc8ca1986"
       ]
     },
     "Vn-ord-D5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-ff-3c-N.wav",
         "d30ee9cc44b749b881a8a12f7f16b74d"
       ]
     },
     "Vn-ord-D5-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D5-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D5-ff-4c-N.wav",
         "06f7485ea40fd8d0a69d584278d7a121"
       ]
     },
     "Vn-ord-D#5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-ff-2c-N.wav",
         "344f21729805871c0b9c6676d851e745"
       ]
     },
     "Vn-ord-D#5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-ff-3c-N.wav",
         "bf2e78a4137f399089bf09a577e70d57"
       ]
     },
     "Vn-ord-D#5-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#5-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#5-ff-4c-N.wav",
         "23ef01cee122f6b6ab0d1a0cdc770bb4"
       ]
     },
     "Vn-ord-E5-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-ff-1c-N.wav",
         "09ecdc44e9cbeda04ff7b4c8243dc555"
       ]
     },
     "Vn-ord-E5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-ff-2c-N.wav",
         "937006021b7258ac2485f0f49005eb6d"
       ]
     },
     "Vn-ord-E5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-ff-3c-N.wav",
         "d33282c1aa823bf88c739be4d4630304"
       ]
     },
     "Vn-ord-E5-ff-4c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E5-ff-4c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E5-ff-4c-N.wav",
         "4a0d2791e583dfaaa07b8e69b05c728c"
       ]
     },
     "Vn-ord-F5-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-ff-1c-N.wav",
         "87bf27ab08c50203afd3a0f0985fca24"
       ]
     },
     "Vn-ord-F5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-ff-2c-N.wav",
         "6b2103959e8f9b1d68fc5dda53f2aaa2"
       ]
     },
     "Vn-ord-F5-ff-3c-T15u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F5-ff-3c-T15u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F5-ff-3c-T15u.wav",
         "6b8ee7a9e5730b8d85942ba41a957e0c"
       ]
     },
     "Vn-ord-F#5-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-ff-1c-N.wav",
         "494b36b8f6029ce33f881af871defa16"
       ]
     },
     "Vn-ord-F#5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-ff-2c-N.wav",
         "08e795df090b0ac3d691cbd7d0ce8e2a"
       ]
     },
     "Vn-ord-F#5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#5-ff-3c-N.wav",
         "3b6579a317c51c435df02687a159fa98"
       ]
     },
     "Vn-ord-G5-ff-1c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-ff-1c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-ff-1c-T11d.wav",
         "b71c37107162c3fc5985d71a6752d111"
       ]
     },
     "Vn-ord-G5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-ff-2c-N.wav",
         "f4bbf299fe5d16050918bfe81e521932"
       ]
     },
     "Vn-ord-G5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G5-ff-3c-N.wav",
         "f36b0e6ef9e1378fe286e5a38464dcda"
       ]
     },
     "Vn-ord-G#5-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-ff-1c-N.wav",
         "8838c0b50e4d77273c03bcaeaa3a1318"
       ]
     },
     "Vn-ord-G#5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-ff-2c-N.wav",
         "2e39c0f0b7ce051e3bfbcba9857136ed"
       ]
     },
     "Vn-ord-G#5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#5-ff-3c-N.wav",
         "fb7806ea3bc472c2791b5a8e2e8996af"
       ]
     },
     "Vn-ord-A5-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-ff-1c-N.wav",
         "53a87d2ec79ce68293dff344915ac4ee"
       ]
     },
     "Vn-ord-A5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-ff-2c-N.wav",
         "266ea073faca80c647215183818dbcad"
       ]
     },
     "Vn-ord-A5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A5-ff-3c-N.wav",
         "103b20a2ac9a60c85d6ba57919764706"
       ]
     },
     "Vn-ord-A#5-ff-1c-T13u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-ff-1c-T13u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-ff-1c-T13u.wav",
         "967a2d2fa3186c10f2c4bf0e53dcd770"
       ]
     },
     "Vn-ord-A#5-ff-2c-T10u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-ff-2c-T10u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-ff-2c-T10u.wav",
         "b321bb3ca4a60af866a15e710704a1e9"
       ]
     },
     "Vn-ord-A#5-ff-3c-R100u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#5-ff-3c-R100u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#5-ff-3c-R100u.wav",
         "4248ce1e147c0c2d5205f0f2b85af180"
       ]
     },
     "Vn-ord-B5-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-ff-1c-N.wav",
         "75fbab64530df65800838df4ae1e5359"
       ]
     },
     "Vn-ord-B5-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-ff-2c-N.wav",
         "b7b2c89853071f27d8d5147cef99d3bc"
       ]
     },
     "Vn-ord-B5-ff-3c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B5-ff-3c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B5-ff-3c-N.wav",
         "5e9f0dfe63c0f12620e7b9535cbb0249"
       ]
     },
     "Vn-ord-C6-ff-1c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-ff-1c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-ff-1c-T11d.wav",
         "ff8d5f4d722c99298bb4b2460b67647c"
       ]
     },
     "Vn-ord-C6-ff-2c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-ff-2c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-ff-2c-T11d.wav",
         "eca2d5deb4e71cf267affe2f0f1eebf0"
       ]
     },
     "Vn-ord-C6-ff-3c-T18d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C6-ff-3c-T18d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C6-ff-3c-T18d.wav",
         "8a7dc87910f8bfa33e626b407ffca162"
       ]
     },
     "Vn-ord-C#6-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#6-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#6-ff-1c-N.wav",
         "182fbe3647d210725a05a86160378387"
       ]
     },
     "Vn-ord-C#6-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#6-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#6-ff-2c-N.wav",
         "29f0fbd6ef226511fa9a7c1985155e9d"
       ]
     },
     "Vn-ord-D6-ff-1c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D6-ff-1c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D6-ff-1c-T11d.wav",
         "31a1a75a3ff31058c6b3ab0b0b2a1766"
       ]
     },
     "Vn-ord-D6-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D6-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D6-ff-2c-N.wav",
         "6ab54e7ec68df42fc713119dee21610b"
       ]
     },
     "Vn-ord-D#6-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#6-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#6-ff-1c-N.wav",
         "2bc748e70bd0f3e44321250013089479"
       ]
     },
     "Vn-ord-D#6-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#6-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#6-ff-2c-N.wav",
         "0fd5421e8ffdaee343312a1b146adb58"
       ]
     },
     "Vn-ord-E6-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E6-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E6-ff-1c-N.wav",
         "27ea5be115791f607927882cf0487f67"
       ]
     },
     "Vn-ord-E6-ff-2c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E6-ff-2c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E6-ff-2c-N.wav",
         "1c43cc6de53d5b7c03651d0c131bd0fb"
       ]
     },
     "Vn-ord-F6-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F6-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F6-ff-1c-N.wav",
         "24db010aa66f8c6d96083affd40e7429"
       ]
     },
     "Vn-ord-F6-ff-2c-T20d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F6-ff-2c-T20d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F6-ff-2c-T20d.wav",
         "f608580b4b9e55cec1c238f591516e1a"
       ]
     },
     "Vn-ord-F#6-ff-1c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#6-ff-1c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#6-ff-1c-T12d.wav",
         "b27aea9dc04d51f04f5e2d8ba806dd35"
       ]
     },
     "Vn-ord-F#6-ff-2c-T16d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-F#6-ff-2c-T16d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-F#6-ff-2c-T16d.wav",
         "6512a73c59810c4907b1825155873df9"
       ]
     },
     "Vn-ord-G6-ff-1c-T12d_R100u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G6-ff-1c-T12d_R100u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G6-ff-1c-T12d_R100u.wav",
         "7b4cbb19af692b8edd3352a647d6ba46"
       ]
     },
     "Vn-ord-G6-ff-2c-T12d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G6-ff-2c-T12d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G6-ff-2c-T12d.wav",
         "800912f7bddb26371d82b1ef8ad08970"
       ]
     },
     "Vn-ord-G#6-ff-1c-T24d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#6-ff-1c-T24d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#6-ff-1c-T24d.wav",
         "a48dbaf31e3bce660c4caa16d62d3cff"
       ]
     },
     "Vn-ord-G#6-ff-2c-T14d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-G#6-ff-2c-T14d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-G#6-ff-2c-T14d.wav",
         "2d60bbc11e4c21692e2e2726470e1ab5"
       ]
     },
     "Vn-ord-A6-ff-1c-T11d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A6-ff-1c-T11d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A6-ff-1c-T11d.wav",
         "dede4261dfee3e316787d51092ab758c"
       ]
     },
     "Vn-ord-A#6-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-A#6-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-A#6-ff-1c-N.wav",
         "13e5cfd64de41db9942e8bcaab62573f"
       ]
     },
     "Vn-ord-B6-ff-1c-T20d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-B6-ff-1c-T20d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-B6-ff-1c-T20d.wav",
         "c8ec2741ad5409943470ab3b5eb8faec"
       ]
     },
     "Vn-ord-C7-ff-1c-T30d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C7-ff-1c-T30d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C7-ff-1c-T30d.wav",
         "162543a61e266142be8ad328cf23a810"
       ]
     },
     "Vn-ord-C#7-ff-1c-T26d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-C#7-ff-1c-T26d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-C#7-ff-1c-T26d.wav",
         "11f56c8753f951d4a181fe5e72c9baf7"
       ]
     },
     "Vn-ord-D7-ff-1c-T23d": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D7-ff-1c-T23d.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D7-ff-1c-T23d.wav",
         "d38bd401b82bbc2509ecfd5219780984"
       ]
     },
     "Vn-ord-D#7-ff-1c-T23d_R100u": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-D#7-ff-1c-T23d_R100u.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-D#7-ff-1c-T23d_R100u.wav",
         "158769ca5de20af7c09c5745745513fd"
       ]
     },
     "Vn-ord-E7-ff-1c-N": {
       "audio": [
-        "Strings/Violin/ordinario/Vn-ord-E7-ff-1c-N.wav",
+        "audio/Strings/Violin/ordinario/Vn-ord-E7-ff-1c-N.wav",
         "7f85677aaeba9d145d9f2df709f3eed5"
       ]
     },
     "ASax-ord-C#3-pp-N-T11d": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#3-pp-N-T11d.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#3-pp-N-T11d.wav",
         "5ed68d490b31300da05fd1ff022df298"
       ]
     },
     "ASax-ord-D3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D3-pp-N-N.wav",
         "a87de52ebeef6a6a8ab74fbe022d2c48"
       ]
     },
     "ASax-ord-D#3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#3-pp-N-N.wav",
         "5b77e942bf032b9eb788c6bece3b757d"
       ]
     },
     "ASax-ord-E3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E3-pp-N-N.wav",
         "82fb5141d24f8b349fcbdbdfa4ca4831"
       ]
     },
     "ASax-ord-F3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F3-pp-N-N.wav",
         "da0e26578b65d995bd2ae9bed0cbdbed"
       ]
     },
     "ASax-ord-F#3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#3-pp-N-N.wav",
         "5d7037bc9d81fd154bd4ac1fbf507fbb"
       ]
     },
     "ASax-ord-G3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G3-pp-N-N.wav",
         "74d95cac4d8aa0b912a586d36e93c038"
       ]
     },
     "ASax-ord-G#3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#3-pp-N-N.wav",
         "27e58987f93f0b1e9145d89737cc6dce"
       ]
     },
     "ASax-ord-A3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A3-pp-N-N.wav",
         "eba3d01c0109bea88041bc9849e70a77"
       ]
     },
     "ASax-ord-A#3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A#3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A#3-pp-N-N.wav",
         "e1548cf0a25ddec1384189adebcf5caa"
       ]
     },
     "ASax-ord-B3-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-B3-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-B3-pp-N-N.wav",
         "52c84c2a36e5c212ebb9db6a1bca9d3c"
       ]
     },
     "ASax-ord-C4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C4-pp-N-N.wav",
         "778e0d8e911d39a50890545f968f16fa"
       ]
     },
     "ASax-ord-C#4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#4-pp-N-N.wav",
         "8a1d1d508723f0c559d8bca1e41464e9"
       ]
     },
     "ASax-ord-D4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D4-pp-N-N.wav",
         "02bfe97a910f52452067aadd820a9ae0"
       ]
     },
     "ASax-ord-D#4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#4-pp-N-N.wav",
         "63eb4087d634e98dbf1b494e91a73886"
       ]
     },
     "ASax-ord-E4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E4-pp-N-N.wav",
         "f15841cce6b6ff4095399ba81a76158a"
       ]
     },
     "ASax-ord-F4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F4-pp-N-N.wav",
         "d061d523a7edbc6c83722c84abffbf3e"
       ]
     },
     "ASax-ord-F#4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#4-pp-N-N.wav",
         "f58743c25c1e828c94e376014044605e"
       ]
     },
     "ASax-ord-G4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G4-pp-N-N.wav",
         "c43e05509169ab7553b2b91e16a7c74d"
       ]
     },
     "ASax-ord-G#4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#4-pp-N-N.wav",
         "d3f149c794c985d61e7640d9a1a6d725"
       ]
     },
     "ASax-ord-A4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A4-pp-N-N.wav",
         "878fac6d5f8a015fafca7fa5f5579955"
       ]
     },
     "ASax-ord-A#4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A#4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A#4-pp-N-N.wav",
         "5633bf062772c777a014c2f9f19fe33d"
       ]
     },
     "ASax-ord-B4-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-B4-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-B4-pp-N-N.wav",
         "0e9b5095294e976b2e854539c686af7a"
       ]
     },
     "ASax-ord-C5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C5-pp-N-N.wav",
         "ec39dd6de9316a93b182b28257536b95"
       ]
     },
     "ASax-ord-C#5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#5-pp-N-N.wav",
         "0ed33d125afd96a661c2487b23659cb5"
       ]
     },
     "ASax-ord-D5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D5-pp-N-N.wav",
         "23317621352259e16d8d203192d65541"
       ]
     },
     "ASax-ord-D#5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#5-pp-N-N.wav",
         "947ece085c5c87094057aa1d02de0eb0"
       ]
     },
     "ASax-ord-E5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E5-pp-N-N.wav",
         "499490124d03dcd0bd83f9cb793f455d"
       ]
     },
     "ASax-ord-F5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F5-pp-N-N.wav",
         "a5f112e52f4585f5546fdb53da825a11"
       ]
     },
     "ASax-ord-F#5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#5-pp-N-N.wav",
         "742ece003aed4c818657fd7a705d1b9f"
       ]
     },
     "ASax-ord-G5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G5-pp-N-N.wav",
         "ccbd47f1297aa73f400d9a9cd1f3c5fe"
       ]
     },
     "ASax-ord-G#5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#5-pp-N-N.wav",
         "dcd67c69f4256dae9b8f8f4f29a0f2cf"
       ]
     },
     "ASax-ord-A5-pp-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A5-pp-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A5-pp-N-N.wav",
         "fb9c664a9d53822f9e549992a6ab328c"
       ]
     },
     "ASax-ord-C#3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#3-mf-N-N.wav",
         "8633606a85b6bb45443ca98e2d4beada"
       ]
     },
     "ASax-ord-D3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D3-mf-N-N.wav",
         "c6d7ff0afa0a713015eeea6f244f4e01"
       ]
     },
     "ASax-ord-D#3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#3-mf-N-N.wav",
         "3845af0a80f388086f4ab9ee9b0b7bfd"
       ]
     },
     "ASax-ord-E3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E3-mf-N-N.wav",
         "fd693c0a95b61ed8e9fba2647b43a9d1"
       ]
     },
     "ASax-ord-F3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F3-mf-N-N.wav",
         "e30a5359025119970c25b0b703039081"
       ]
     },
     "ASax-ord-F#3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#3-mf-N-N.wav",
         "f7938fbf68f26b55a7a17ff0e9a6ac2b"
       ]
     },
     "ASax-ord-G3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G3-mf-N-N.wav",
         "740f6e86bbdd436ced59432f56499229"
       ]
     },
     "ASax-ord-G#3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#3-mf-N-N.wav",
         "de5bf553aca82c8541c27d3bf3241abb"
       ]
     },
     "ASax-ord-A3-mf-N-R100d": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A3-mf-N-R100d.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A3-mf-N-R100d.wav",
         "99be0e1e397fb04e979bbef9cbe659ca"
       ]
     },
     "ASax-ord-A#3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A#3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A#3-mf-N-N.wav",
         "f35a3be57f3f4a6bb7939b9bfa6a7e4b"
       ]
     },
     "ASax-ord-B3-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-B3-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-B3-mf-N-N.wav",
         "6f2882a16c68b79c3a097cbdd49e9f99"
       ]
     },
     "ASax-ord-C4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C4-mf-N-N.wav",
         "c81eac33e3988cf24d48b70b83f14915"
       ]
     },
     "ASax-ord-C#4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#4-mf-N-N.wav",
         "a4b9363c4d912c77b2c83d29ab5c1930"
       ]
     },
     "ASax-ord-D4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D4-mf-N-N.wav",
         "00ee553816ff9c4500edde2d1ee75a69"
       ]
     },
     "ASax-ord-D#4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#4-mf-N-N.wav",
         "b4da673d584fe4ec44afa99dca89fd69"
       ]
     },
     "ASax-ord-E4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E4-mf-N-N.wav",
         "ce41b7682e81fad4f7cdfef930cf340c"
       ]
     },
     "ASax-ord-F4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F4-mf-N-N.wav",
         "4a37fafc70ef000d8abc95056e0248e2"
       ]
     },
     "ASax-ord-F#4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#4-mf-N-N.wav",
         "3a1369444d2f7741b80f8e3cf633ca0e"
       ]
     },
     "ASax-ord-G4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G4-mf-N-N.wav",
         "e944f2e3ad8e713e3abb111cfc2a3de0"
       ]
     },
     "ASax-ord-G#4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#4-mf-N-N.wav",
         "ed1583b433080c319d5065068bde0a67"
       ]
     },
     "ASax-ord-A4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A4-mf-N-N.wav",
         "64d929344b568d17723c8056f3972988"
       ]
     },
     "ASax-ord-A#4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A#4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A#4-mf-N-N.wav",
         "fe4734161d17b3c3e90303f016c40bf8"
       ]
     },
     "ASax-ord-B4-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-B4-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-B4-mf-N-N.wav",
         "53edd503223704276e6b0d493bfa328a"
       ]
     },
     "ASax-ord-C5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C5-mf-N-N.wav",
         "2a91bf58c7575180defbc35f7aaeab3c"
       ]
     },
     "ASax-ord-C#5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#5-mf-N-N.wav",
         "dde3d04df7e6e35fb5e0fa2c9b4cbf65"
       ]
     },
     "ASax-ord-D5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D5-mf-N-N.wav",
         "4ab175c5f8d9c686db46a06e189325f9"
       ]
     },
     "ASax-ord-D#5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#5-mf-N-N.wav",
         "315a4a42cf9b8f2d769eb1287343b025"
       ]
     },
     "ASax-ord-E5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E5-mf-N-N.wav",
         "2a0b07a57e7b902678fc97de097e797f"
       ]
     },
     "ASax-ord-F5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F5-mf-N-N.wav",
         "8a611a8816229fcf05b44125ccb6db65"
       ]
     },
     "ASax-ord-F#5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#5-mf-N-N.wav",
         "3b679bdf14a017009d9ea0ac33477e87"
       ]
     },
     "ASax-ord-G5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G5-mf-N-N.wav",
         "2a05233d4fbd01ffd2b423c8719ed16d"
       ]
     },
     "ASax-ord-G#5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#5-mf-N-N.wav",
         "c887a6c62ed2462b2857bc768668420a"
       ]
     },
     "ASax-ord-A5-mf-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A5-mf-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A5-mf-N-N.wav",
         "ce8df2083e3cc3ae58acd4455a52cad3"
       ]
     },
     "ASax-ord-C#3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#3-ff-N-N.wav",
         "cc64206208870722eadf9d52477ca756"
       ]
     },
     "ASax-ord-D3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D3-ff-N-N.wav",
         "8b896e38f9a4671b35fb99d720525b1f"
       ]
     },
     "ASax-ord-D#3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#3-ff-N-N.wav",
         "b2ea66a50b86f6387c7b909ef66cf017"
       ]
     },
     "ASax-ord-E3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E3-ff-N-N.wav",
         "20d825d24723269e40b8e6ecceea13cd"
       ]
     },
     "ASax-ord-F3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F3-ff-N-N.wav",
         "c05987bb0fc788dc08afa022406e5c0a"
       ]
     },
     "ASax-ord-F#3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#3-ff-N-N.wav",
         "cfd928703b57df81e02b8880fe202a92"
       ]
     },
     "ASax-ord-G3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G3-ff-N-N.wav",
         "9cb1689f52cf0c9574572186cb028510"
       ]
     },
     "ASax-ord-G#3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#3-ff-N-N.wav",
         "0ed0edae951b037c427c1b99c8012f34"
       ]
     },
     "ASax-ord-A3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A3-ff-N-N.wav",
         "4be45a353d961c302cd965eab6a83a1c"
       ]
     },
     "ASax-ord-A#3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A#3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A#3-ff-N-N.wav",
         "5b695dc4804a17f3a66b2e5ebe9c60b7"
       ]
     },
     "ASax-ord-B3-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-B3-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-B3-ff-N-N.wav",
         "f2a17b690c84bdf7beabb6c54f182043"
       ]
     },
     "ASax-ord-C4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C4-ff-N-N.wav",
         "c6e3ebebe07c13944f77ce5c7afe0f15"
       ]
     },
     "ASax-ord-C#4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#4-ff-N-N.wav",
         "6083801b8b4c6f4b7f85df84f4dceb56"
       ]
     },
     "ASax-ord-D4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D4-ff-N-N.wav",
         "39c30f33ba66ec2c54e37799d97269d9"
       ]
     },
     "ASax-ord-D#4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#4-ff-N-N.wav",
         "c87c6fc8b2776407fe548fedd821f820"
       ]
     },
     "ASax-ord-E4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E4-ff-N-N.wav",
         "c4a21b2fc97a1974e0e758c3a2ab7c76"
       ]
     },
     "ASax-ord-F4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F4-ff-N-N.wav",
         "7f1b2095650e8350f22951c4b92ba68e"
       ]
     },
     "ASax-ord-F#4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#4-ff-N-N.wav",
         "a1be221eccbea9861e83b5cf08a835db"
       ]
     },
     "ASax-ord-G4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G4-ff-N-N.wav",
         "5f038dc23b3b22c16ce9a308741fd452"
       ]
     },
     "ASax-ord-G#4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#4-ff-N-N.wav",
         "2150b4f68733e638a14e2a63c9770667"
       ]
     },
     "ASax-ord-A4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A4-ff-N-N.wav",
         "d241e0b43369adc11ddb7d9ba17a6bac"
       ]
     },
     "ASax-ord-A#4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A#4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A#4-ff-N-N.wav",
         "36c05306ec469dd9205487dd870f81a1"
       ]
     },
     "ASax-ord-B4-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-B4-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-B4-ff-N-N.wav",
         "bc20a2da224faf12c4c0b8241ddf2f6f"
       ]
     },
     "ASax-ord-C5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C5-ff-N-N.wav",
         "b3c62444e6bced7c913b5669f8127769"
       ]
     },
     "ASax-ord-C#5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-C#5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-C#5-ff-N-N.wav",
         "b2695fc5bb7fa104f01d825342ce7162"
       ]
     },
     "ASax-ord-D5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D5-ff-N-N.wav",
         "f33c7cdff39091fcf0385e8f494e2125"
       ]
     },
     "ASax-ord-D#5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-D#5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-D#5-ff-N-N.wav",
         "58a95fe4d53ebd778ce05ffc412e8389"
       ]
     },
     "ASax-ord-E5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-E5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-E5-ff-N-N.wav",
         "158f8384896234a38d0526923fb68443"
       ]
     },
     "ASax-ord-F5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F5-ff-N-N.wav",
         "bce7274ec95d653816d83f8c2a247cf8"
       ]
     },
     "ASax-ord-F#5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-F#5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-F#5-ff-N-N.wav",
         "5e50dbc555fb42abe19f8c464190c730"
       ]
     },
     "ASax-ord-G5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G5-ff-N-N.wav",
         "9b8653deda5b2ccb97b95e51f5af4a1b"
       ]
     },
     "ASax-ord-G#5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-G#5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-G#5-ff-N-N.wav",
         "32db8f964cedc07905992be3a2206d2f"
       ]
     },
     "ASax-ord-A5-ff-N-N": {
       "audio": [
-        "Winds/Sax_Alto/ordinario/ASax-ord-A5-ff-N-N.wav",
+        "audio/Winds/Sax_Alto/ordinario/ASax-ord-A5-ff-N-N.wav",
         "ed8f9cf3e12700444745b0fca7f74926"
       ]
     },
     "Bn-ord-A#1-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#1-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#1-pp-N-N.wav",
         "73946b4396610f9b072ae1e87c35e088"
       ]
     },
     "Bn-ord-B1-pp-N-T11d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B1-pp-N-T11d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B1-pp-N-T11d.wav",
         "349c1a63386a0889c624ca31eb05afa0"
       ]
     },
     "Bn-ord-C2-pp-N-T11d_R100u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C2-pp-N-T11d_R100u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C2-pp-N-T11d_R100u.wav",
         "880118119d5eb956b9fec780a7266589"
       ]
     },
     "Bn-ord-C#2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#2-pp-N-N.wav",
         "88aea7a6a6e25ad0ba5ad75c85f56d39"
       ]
     },
     "Bn-ord-D2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D2-pp-N-N.wav",
         "072e8a44a27c50ee586bac6551248d63"
       ]
     },
     "Bn-ord-D#2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#2-pp-N-N.wav",
         "d2313bc46b8090a1ad0f67203c40facd"
       ]
     },
     "Bn-ord-E2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E2-pp-N-N.wav",
         "df0b492cfc66b4fa7d36447b3ac4138c"
       ]
     },
     "Bn-ord-F2-pp-N-T17d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F2-pp-N-T17d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F2-pp-N-T17d.wav",
         "e31ffbc1769ba94bb5759093cc77a5dd"
       ]
     },
     "Bn-ord-F#2-pp-N-T12d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#2-pp-N-T12d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#2-pp-N-T12d.wav",
         "bbb7593af76da5aa9287ade33231bf7d"
       ]
     },
     "Bn-ord-G2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G2-pp-N-N.wav",
         "0e0e9ed41c58a0a772dd90b01945fa64"
       ]
     },
     "Bn-ord-G#2-pp-N-T16d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#2-pp-N-T16d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#2-pp-N-T16d.wav",
         "00cdf56fa673198eb7ff3eea828a7694"
       ]
     },
     "Bn-ord-A2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A2-pp-N-N.wav",
         "05b4eb2e04b5347a3b3f437e1a25a26f"
       ]
     },
     "Bn-ord-A#2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#2-pp-N-N.wav",
         "b76f9b7fdb49201af28b657bfee1e482"
       ]
     },
     "Bn-ord-B2-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B2-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B2-pp-N-N.wav",
         "cbb3a1ed5adb31897ffc354cccbb4560"
       ]
     },
     "Bn-ord-C3-pp-N-T15d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C3-pp-N-T15d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C3-pp-N-T15d.wav",
         "459bc62d27f1690873e7d2f526a19b10"
       ]
     },
     "Bn-ord-C#3-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#3-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#3-pp-N-N.wav",
         "36b49f89736323ab9e99fb7cb87124c6"
       ]
     },
     "Bn-ord-D3-pp-N-T13d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D3-pp-N-T13d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D3-pp-N-T13d.wav",
         "0c0738af0f4f3ddbfa1b45270e10c957"
       ]
     },
     "Bn-ord-D#3-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#3-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#3-pp-N-N.wav",
         "887467af4c51e16acf7f820a3dd15d1b"
       ]
     },
     "Bn-ord-E3-pp-N-T13d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E3-pp-N-T13d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E3-pp-N-T13d.wav",
         "6049e16693fa03950f939506bdc6432d"
       ]
     },
     "Bn-ord-F3-pp-N-T15d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F3-pp-N-T15d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F3-pp-N-T15d.wav",
         "ef0818e75633634864846d35769d8213"
       ]
     },
     "Bn-ord-F#3-pp-N-T23d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#3-pp-N-T23d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#3-pp-N-T23d.wav",
         "c0ea9f7f46ed5220d80347c8251554d3"
       ]
     },
     "Bn-ord-G3-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G3-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G3-pp-N-N.wav",
         "2ed4a69b0607095dbcc4b14dea9014dc"
       ]
     },
     "Bn-ord-G#3-pp-N-T19d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#3-pp-N-T19d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#3-pp-N-T19d.wav",
         "a0a186d3c931ea53aea82f5c471b2f53"
       ]
     },
     "Bn-ord-A3-pp-N-T11d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A3-pp-N-T11d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A3-pp-N-T11d.wav",
         "b4f22619cb92eaf6b1e9e6c2372222a4"
       ]
     },
     "Bn-ord-A#3-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#3-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#3-pp-N-N.wav",
         "9eb5061f8f93746f658873b59bbd8298"
       ]
     },
     "Bn-ord-B3-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B3-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B3-pp-N-N.wav",
         "43022822a2efbb49eaf0dc27fe6eafa0"
       ]
     },
     "Bn-ord-C4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C4-pp-N-N.wav",
         "d5ff408f5644e4eaeb90b17571920719"
       ]
     },
     "Bn-ord-C#4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#4-pp-N-N.wav",
         "30de8c8936547ad5e7415f30f224ff31"
       ]
     },
     "Bn-ord-D4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D4-pp-N-N.wav",
         "c9b5c631b9b9fe5088fe2a780eea54e2"
       ]
     },
     "Bn-ord-D#4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#4-pp-N-N.wav",
         "d4223cb139c804f7346877991568c5eb"
       ]
     },
     "Bn-ord-E4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E4-pp-N-N.wav",
         "7004f3d951fea6dd092069a69787eae8"
       ]
     },
     "Bn-ord-F4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F4-pp-N-N.wav",
         "5a60bcc1484e3ce91cc8f3dd273d351a"
       ]
     },
     "Bn-ord-F#4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#4-pp-N-N.wav",
         "1f1e6877400827f26a38e8f7e0cad9b7"
       ]
     },
     "Bn-ord-G4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G4-pp-N-N.wav",
         "12ec5032440448252b040417f3b54886"
       ]
     },
     "Bn-ord-G#4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#4-pp-N-N.wav",
         "7ff07eac6971483860f53ac0b728f377"
       ]
     },
     "Bn-ord-A4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A4-pp-N-N.wav",
         "9966c45bbcf746cf441acede300e417b"
       ]
     },
     "Bn-ord-A#4-pp-N-T13u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#4-pp-N-T13u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#4-pp-N-T13u.wav",
         "69d13d98b4c27b9a20da92fb20493699"
       ]
     },
     "Bn-ord-B4-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B4-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B4-pp-N-N.wav",
         "f450db12eaabecb567943001c15a7f0e"
       ]
     },
     "Bn-ord-C5-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C5-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C5-pp-N-N.wav",
         "6e02860f93aa68c5a08d416e0e1619ba"
       ]
     },
     "Bn-ord-C#5-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#5-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#5-pp-N-N.wav",
         "bb88ca1f1db5c7823370e04ad61804ad"
       ]
     },
     "Bn-ord-D5-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D5-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D5-pp-N-N.wav",
         "957cc6040dd4de3430b165f363efef45"
       ]
     },
     "Bn-ord-D#5-pp-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#5-pp-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#5-pp-N-N.wav",
         "607fc3c0ee17b0fabf935239341d9a80"
       ]
     },
     "Bn-ord-A#1-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#1-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#1-mf-N-N.wav",
         "400201a7ad0cd2decb9953d0892e5c8c"
       ]
     },
     "Bn-ord-B1-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B1-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B1-mf-N-N.wav",
         "24589d91ef3cfde09ea3a724c7758516"
       ]
     },
     "Bn-ord-C2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C2-mf-N-N.wav",
         "cd344ef3c871abcd152ce8ed38d8212f"
       ]
     },
     "Bn-ord-C#2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#2-mf-N-N.wav",
         "22c6d5f5f8e6d9b41af364f4f00389f4"
       ]
     },
     "Bn-ord-D2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D2-mf-N-N.wav",
         "22f4425aad8e78edb677706a8cda3f91"
       ]
     },
     "Bn-ord-D#2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#2-mf-N-N.wav",
         "5acb6c4764ee0042c050db7f0efedde2"
       ]
     },
     "Bn-ord-E2-mf-N-T10u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E2-mf-N-T10u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E2-mf-N-T10u.wav",
         "5f8704c9cefe8c666a212c1e6c8e92c2"
       ]
     },
     "Bn-ord-F2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F2-mf-N-N.wav",
         "61badd2bc344c7fb67d0f35af15696f2"
       ]
     },
     "Bn-ord-F#2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#2-mf-N-N.wav",
         "f7dbef3180a172816a1b1fab6da92948"
       ]
     },
     "Bn-ord-G2-mf-N-T10d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G2-mf-N-T10d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G2-mf-N-T10d.wav",
         "2e78c6548f29a6cdf8edd644902a62bc"
       ]
     },
     "Bn-ord-G#2-mf-N-R100d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#2-mf-N-R100d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#2-mf-N-R100d.wav",
         "9163ece340b17fb24c6856456d712f35"
       ]
     },
     "Bn-ord-A2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A2-mf-N-N.wav",
         "79ed3d19b384eafa123a33ef3500f4a4"
       ]
     },
     "Bn-ord-A#2-mf-N-T11u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#2-mf-N-T11u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#2-mf-N-T11u.wav",
         "e151dfff65d867bce1230f71c6c6ec87"
       ]
     },
     "Bn-ord-B2-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B2-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B2-mf-N-N.wav",
         "783ae95200d675ea2d09bc7353e1af6b"
       ]
     },
     "Bn-ord-C3-mf-N-R100u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C3-mf-N-R100u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C3-mf-N-R100u.wav",
         "2b3553e109da9c376390b9efd2d90811"
       ]
     },
     "Bn-ord-C#3-mf-N-R100d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#3-mf-N-R100d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#3-mf-N-R100d.wav",
         "e725c4f57830e759401997ca7a5d91d1"
       ]
     },
     "Bn-ord-D3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D3-mf-N-N.wav",
         "8c1c7bf994f8ac769b791d2e229dcea9"
       ]
     },
     "Bn-ord-D#3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#3-mf-N-N.wav",
         "0863fae13556e2715a9e1e2bd7073454"
       ]
     },
     "Bn-ord-E3-mf-N-T11d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E3-mf-N-T11d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E3-mf-N-T11d.wav",
         "5b52b1f9f68857bcc8a4b85171579f37"
       ]
     },
     "Bn-ord-F3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F3-mf-N-N.wav",
         "da0370de3415b0736a5c88b5a05fb4a8"
       ]
     },
     "Bn-ord-F#3-mf-N-T16d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#3-mf-N-T16d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#3-mf-N-T16d.wav",
         "ab5c34871f1e4475a4fa044dc468085c"
       ]
     },
     "Bn-ord-G3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G3-mf-N-N.wav",
         "a3078eaf7242dbd653cb9a9c0bb45174"
       ]
     },
     "Bn-ord-G#3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#3-mf-N-N.wav",
         "afe0417d5be8a108569961eefc078d1d"
       ]
     },
     "Bn-ord-A3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A3-mf-N-N.wav",
         "0d8b53b92849e0bb137d60b5d11d1136"
       ]
     },
     "Bn-ord-A#3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#3-mf-N-N.wav",
         "1942741e43689cb4f978bdd68c22e957"
       ]
     },
     "Bn-ord-B3-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B3-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B3-mf-N-N.wav",
         "30fc6b8c8f2a5af5cde5cbed74aacbef"
       ]
     },
     "Bn-ord-C4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C4-mf-N-N.wav",
         "6e4396827546a5280d1d619495f89562"
       ]
     },
     "Bn-ord-C#4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#4-mf-N-N.wav",
         "1d9a7eb5fe4f137c7fa7960f3e5b105f"
       ]
     },
     "Bn-ord-D4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D4-mf-N-N.wav",
         "c9eae111a8b2a52cadb9a4da9128393a"
       ]
     },
     "Bn-ord-D#4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#4-mf-N-N.wav",
         "30a1d49f2326d1727a5c8d9b203caeb7"
       ]
     },
     "Bn-ord-E4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E4-mf-N-N.wav",
         "d4d93d0ed0a83142745794e1988644c2"
       ]
     },
     "Bn-ord-F4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F4-mf-N-N.wav",
         "e5612951458da52d54ecbaaeb5648533"
       ]
     },
     "Bn-ord-F#4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#4-mf-N-N.wav",
         "4cd095d5d1c9a4b11d9f581633761f7a"
       ]
     },
     "Bn-ord-G4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G4-mf-N-N.wav",
         "bf39666bc7cbf51ed32f3ba82a137728"
       ]
     },
     "Bn-ord-G#4-mf-N-R100u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#4-mf-N-R100u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#4-mf-N-R100u.wav",
         "62efd6af652d9f3c49053dd10fa2e87b"
       ]
     },
     "Bn-ord-A4-mf-N-T14u_R100d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A4-mf-N-T14u_R100d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A4-mf-N-T14u_R100d.wav",
         "6dadd424344f0762431a2abf7bda70fd"
       ]
     },
     "Bn-ord-A#4-mf-N-T14u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#4-mf-N-T14u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#4-mf-N-T14u.wav",
         "bdbd237dd230358700571db7310a069c"
       ]
     },
     "Bn-ord-B4-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B4-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B4-mf-N-N.wav",
         "c99b1617bc709343547632e73d9d4056"
       ]
     },
     "Bn-ord-C5-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C5-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C5-mf-N-N.wav",
         "f2d0979023687d81ccdff067b94b6d46"
       ]
     },
     "Bn-ord-C#5-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#5-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#5-mf-N-N.wav",
         "92c7829a5a7a56a31ce7e3bffa4e9bd7"
       ]
     },
     "Bn-ord-D5-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D5-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D5-mf-N-N.wav",
         "f8ec065b18706da9743141c7536b66a3"
       ]
     },
     "Bn-ord-D#5-mf-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#5-mf-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#5-mf-N-N.wav",
         "f6a9ccd4b5b66e13d6a274e0ea4e8334"
       ]
     },
     "Bn-ord-A#1-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#1-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#1-ff-N-N.wav",
         "44bb5eda4ecfa7bd2d290241392d708c"
       ]
     },
     "Bn-ord-B1-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B1-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B1-ff-N-N.wav",
         "00214e860b752316a3a81cb4249783d0"
       ]
     },
     "Bn-ord-C2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C2-ff-N-N.wav",
         "dbb8c3527e9d2bde0f6183aef9a3df70"
       ]
     },
     "Bn-ord-C#2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#2-ff-N-N.wav",
         "8c5652771fbd8ff8cb393cdd616bf8ce"
       ]
     },
     "Bn-ord-D2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D2-ff-N-N.wav",
         "4a7d76bc2f4386a37525cc48b00e9b92"
       ]
     },
     "Bn-ord-D#2-ff-N-T17d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#2-ff-N-T17d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#2-ff-N-T17d.wav",
         "5b6417a8d9f3a7aa9e471b771d5a2e0a"
       ]
     },
     "Bn-ord-E2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E2-ff-N-N.wav",
         "71129961c8504a778482e9af75435b19"
       ]
     },
     "Bn-ord-F2-ff-N-T10d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F2-ff-N-T10d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F2-ff-N-T10d.wav",
         "e9d4af07c265aadf404e1ec75d24176c"
       ]
     },
     "Bn-ord-F#2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#2-ff-N-N.wav",
         "eb1f48864c4d2692030b442f533bcddf"
       ]
     },
     "Bn-ord-G2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G2-ff-N-N.wav",
         "ec0a80a486b14a03adc900a17dbb9896"
       ]
     },
     "Bn-ord-G#2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#2-ff-N-N.wav",
         "eb282cdaad2e25a5dea8b9853ca293b8"
       ]
     },
     "Bn-ord-A2-ff-N-T11d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A2-ff-N-T11d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A2-ff-N-T11d.wav",
         "16016b345dceb362f1a4ec2fad478a73"
       ]
     },
     "Bn-ord-A#2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#2-ff-N-N.wav",
         "50a96da18ac46365b3e8149e0becaa0a"
       ]
     },
     "Bn-ord-B2-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B2-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B2-ff-N-N.wav",
         "f01aaf8e809119709617c9bf67a82939"
       ]
     },
     "Bn-ord-C3-ff-N-T12d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C3-ff-N-T12d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C3-ff-N-T12d.wav",
         "ae0ac696eaafe68cb881daa005881aeb"
       ]
     },
     "Bn-ord-C#3-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#3-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#3-ff-N-N.wav",
         "f0fb0dd9aec62e0fa26c668268397637"
       ]
     },
     "Bn-ord-D3-ff-N-T11d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D3-ff-N-T11d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D3-ff-N-T11d.wav",
         "91ccb5ee69c00e9f04b71d856f27c113"
       ]
     },
     "Bn-ord-D#3-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#3-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#3-ff-N-N.wav",
         "77e2556baf09c078eebf2a323601a53b"
       ]
     },
     "Bn-ord-E3-ff-N-R100u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E3-ff-N-R100u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E3-ff-N-R100u.wav",
         "dcd4bfb4c6e810aa5b013155e904123c"
       ]
     },
     "Bn-ord-F3-ff-N-T10d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F3-ff-N-T10d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F3-ff-N-T10d.wav",
         "dabe96e990646cb60d755ae46f2d6f66"
       ]
     },
     "Bn-ord-F#3-ff-N-T13d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#3-ff-N-T13d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#3-ff-N-T13d.wav",
         "bee45b22094996321a607ec9870719f6"
       ]
     },
     "Bn-ord-G3-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G3-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G3-ff-N-N.wav",
         "5370cdb8cbdaddb75f50eee60ce7742d"
       ]
     },
     "Bn-ord-G#3-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#3-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#3-ff-N-N.wav",
         "91244da0763a3cc4454fe8caa1fd7e15"
       ]
     },
     "Bn-ord-A3-ff-N-T14d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A3-ff-N-T14d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A3-ff-N-T14d.wav",
         "d596f8ae6a16f362e6f8de90f46dc560"
       ]
     },
     "Bn-ord-A#3-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#3-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#3-ff-N-N.wav",
         "e8995198bf74e1a5cc190814ca444802"
       ]
     },
     "Bn-ord-B3-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B3-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B3-ff-N-N.wav",
         "e825d0523a3cd080b388b857c4826210"
       ]
     },
     "Bn-ord-C4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C4-ff-N-N.wav",
         "98e1363c358ce6b0e945aa1072c53ae1"
       ]
     },
     "Bn-ord-C#4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#4-ff-N-N.wav",
         "8d8e204ae0be4ab663e65274e375c75a"
       ]
     },
     "Bn-ord-D4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D4-ff-N-N.wav",
         "3d8c950449c5a6251f9451bca1d17504"
       ]
     },
     "Bn-ord-D#4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#4-ff-N-N.wav",
         "be8f1b1b007cd601ea899e6b5c357c03"
       ]
     },
     "Bn-ord-E4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-E4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-E4-ff-N-N.wav",
         "95366b8a10e516263b38d1a73066b6df"
       ]
     },
     "Bn-ord-F4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F4-ff-N-N.wav",
         "518b12e48c44868d3d45acfe58fd311b"
       ]
     },
     "Bn-ord-F#4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-F#4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-F#4-ff-N-N.wav",
         "4b645395002ddcbcf8e476843b374f01"
       ]
     },
     "Bn-ord-G4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G4-ff-N-N.wav",
         "4f7c2326d858bc255d7e7f6d973961d3"
       ]
     },
     "Bn-ord-G#4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-G#4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-G#4-ff-N-N.wav",
         "e8d493a27fba4f0c2adf801901c2a63b"
       ]
     },
     "Bn-ord-A4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A4-ff-N-N.wav",
         "b8f3ece2ba3d88e1347157476e24a05b"
       ]
     },
     "Bn-ord-A#4-ff-N-T11u": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-A#4-ff-N-T11u.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-A#4-ff-N-T11u.wav",
         "b682e8a0a807c11899f8c6044ec80a10"
       ]
     },
     "Bn-ord-B4-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-B4-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-B4-ff-N-N.wav",
         "965ff41d0b5f4aed4bd1469fdfd61f6e"
       ]
     },
     "Bn-ord-C5-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C5-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C5-ff-N-N.wav",
         "72cf3074b15efff03348228a03d7b569"
       ]
     },
     "Bn-ord-C#5-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-C#5-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-C#5-ff-N-N.wav",
         "0558ab4aef3cc3424bf86d2a363d307d"
       ]
     },
     "Bn-ord-D5-ff-N-N": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D5-ff-N-N.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D5-ff-N-N.wav",
         "16c66733566803cd742abe76c74be27c"
       ]
     },
     "Bn-ord-D#5-ff-N-T14d": {
       "audio": [
-        "Winds/Bassoon/ordinario/Bn-ord-D#5-ff-N-T14d.wav",
+        "audio/Winds/Bassoon/ordinario/Bn-ord-D#5-ff-N-T14d.wav",
         "d9bd428fa825bb87a79ceff8079e67cf"
       ]
     },
     "ClBb-ord-D3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D3-pp-N-N.wav",
         "4a703ec8840bd6c102e65bb6c04e63b1"
       ]
     },
     "ClBb-ord-D#3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#3-pp-N-N.wav",
         "bc26239f0d4b02b24d08edfecd5f42d3"
       ]
     },
     "ClBb-ord-E3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E3-pp-N-N.wav",
         "9f40b8a3fe88dddc6e0a0477605ab3ca"
       ]
     },
     "ClBb-ord-F3-pp-N-T10d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F3-pp-N-T10d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F3-pp-N-T10d.wav",
         "3a6dcc68e872fcd02b5741a3d8a22ba3"
       ]
     },
     "ClBb-ord-F#3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#3-pp-N-N.wav",
         "4099667678f017986af3936557f1aaa9"
       ]
     },
     "ClBb-ord-G3-pp-N-T12d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G3-pp-N-T12d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G3-pp-N-T12d.wav",
         "a403e4a0c5b1700ff7fc6ab2dab62727"
       ]
     },
     "ClBb-ord-G#3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#3-pp-N-N.wav",
         "9f8903fa396e51c5e9800a8d101f50b2"
       ]
     },
     "ClBb-ord-A3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A3-pp-N-N.wav",
         "cb2912611941d6e43bbe73b32b053c98"
       ]
     },
     "ClBb-ord-A#3-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#3-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#3-pp-N-N.wav",
         "daad2830f6bde36f4a6fb2c76b81cef8"
       ]
     },
     "ClBb-ord-B3-pp-N-T12d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B3-pp-N-T12d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B3-pp-N-T12d.wav",
         "1dd1467a919225e197157924c9a176f6"
       ]
     },
     "ClBb-ord-C4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C4-pp-N-N.wav",
         "1aa675728758b50991d808ba3c0625be"
       ]
     },
     "ClBb-ord-C#4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#4-pp-N-N.wav",
         "d2b279e24f3e24bcb6117aa2d8da637f"
       ]
     },
     "ClBb-ord-D4-pp-N-T12d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D4-pp-N-T12d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D4-pp-N-T12d.wav",
         "1c4dac89d16401f2a546d8b5c7a69e29"
       ]
     },
     "ClBb-ord-D#4-pp-N-T12d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#4-pp-N-T12d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#4-pp-N-T12d.wav",
         "617cab72aedc29615e6463fed6edacac"
       ]
     },
     "ClBb-ord-E4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E4-pp-N-N.wav",
         "6f7d7f2fc555bf45cf3928f1a0373b12"
       ]
     },
     "ClBb-ord-F4-pp-N-T14d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F4-pp-N-T14d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F4-pp-N-T14d.wav",
         "7d671fb1c9252f97e42854070a6a4222"
       ]
     },
     "ClBb-ord-F#4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#4-pp-N-N.wav",
         "6722e9ac51de149ed2544c8d248b1b56"
       ]
     },
     "ClBb-ord-G4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G4-pp-N-N.wav",
         "a6393aa33c1af81a33c239481269cb07"
       ]
     },
     "ClBb-ord-G#4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#4-pp-N-N.wav",
         "c75730e8a25a22be40874e2987d0282d"
       ]
     },
     "ClBb-ord-A4-pp-N-T13d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A4-pp-N-T13d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A4-pp-N-T13d.wav",
         "1d7083e5bd4e2a5c9abf709b3119d723"
       ]
     },
     "ClBb-ord-A#4-pp-N-T15d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#4-pp-N-T15d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#4-pp-N-T15d.wav",
         "b909fd3f05addf9d9646e35638f21f2b"
       ]
     },
     "ClBb-ord-B4-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B4-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B4-pp-N-N.wav",
         "9bc27364928d9623031dcb8a92811961"
       ]
     },
     "ClBb-ord-C5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C5-pp-N-N.wav",
         "bdf59fa31e5d5c2d950d7e620e707b9d"
       ]
     },
     "ClBb-ord-C#5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#5-pp-N-N.wav",
         "08ccb98d6e1721ce5a4158982ed81485"
       ]
     },
     "ClBb-ord-D5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D5-pp-N-N.wav",
         "ea27c64d0c87c82df66e5d62393d7015"
       ]
     },
     "ClBb-ord-D#5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#5-pp-N-N.wav",
         "b2405b7f8666eb64049c6da92d903d98"
       ]
     },
     "ClBb-ord-E5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E5-pp-N-N.wav",
         "3aec26078e8699f854b7d982efe3d56d"
       ]
     },
     "ClBb-ord-F5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F5-pp-N-N.wav",
         "9e4c24c44b6a518aef92ccbd9579e2b8"
       ]
     },
     "ClBb-ord-F#5-pp-N-T11d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#5-pp-N-T11d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#5-pp-N-T11d.wav",
         "2a24df9be02bdcb332db6cdd1f836029"
       ]
     },
     "ClBb-ord-G5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G5-pp-N-N.wav",
         "eefa339166f98ae2ebe3923c645ece81"
       ]
     },
     "ClBb-ord-G#5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#5-pp-N-N.wav",
         "23abcf7193c7e5ba5c9dced74563460c"
       ]
     },
     "ClBb-ord-A5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A5-pp-N-N.wav",
         "d2a84a0000538730cb2243cff03857ac"
       ]
     },
     "ClBb-ord-A#5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#5-pp-N-N.wav",
         "910efd65c6a2d943bb84c7f3bbeadf29"
       ]
     },
     "ClBb-ord-B5-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B5-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B5-pp-N-N.wav",
         "ca6f035d604937deb4599dad35786202"
       ]
     },
     "ClBb-ord-C6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C6-pp-N-N.wav",
         "6c1797fa1e0c89fa7f7296b402a56778"
       ]
     },
     "ClBb-ord-C#6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#6-pp-N-N.wav",
         "034f4fa7c75de9b28b1c0c793aa4c165"
       ]
     },
     "ClBb-ord-D6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D6-pp-N-N.wav",
         "bf02748b9e98e653feeeb7dcedeb900a"
       ]
     },
     "ClBb-ord-D#6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#6-pp-N-N.wav",
         "6adba91184b7cc4451b7141951c3cd2d"
       ]
     },
     "ClBb-ord-E6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E6-pp-N-N.wav",
         "c69ca9756ea3f71e3b656020cc1dc6b9"
       ]
     },
     "ClBb-ord-F6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F6-pp-N-N.wav",
         "368147e6a1db66e3871a7bf5b1bbb967"
       ]
     },
     "ClBb-ord-F#6-pp-N-T16d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#6-pp-N-T16d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#6-pp-N-T16d.wav",
         "933c425fa82b80fa68f27e079f2e1999"
       ]
     },
     "ClBb-ord-G6-pp-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G6-pp-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G6-pp-N-N.wav",
         "8bd0902e1e9bbbddefba1871a92bec9c"
       ]
     },
     "ClBb-ord-D3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D3-mf-N-N.wav",
         "533bc4ce3abf61b78c5e0e80f4c77ed9"
       ]
     },
     "ClBb-ord-D#3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#3-mf-N-N.wav",
         "774d62c33634765506cc080d2e9395f7"
       ]
     },
     "ClBb-ord-E3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E3-mf-N-N.wav",
         "9b982bc029a8465ac94a7c8b7d2deb76"
       ]
     },
     "ClBb-ord-F3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F3-mf-N-N.wav",
         "e26217564573d21ecce41257368cfad7"
       ]
     },
     "ClBb-ord-F#3-mf-N-T15d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#3-mf-N-T15d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#3-mf-N-T15d.wav",
         "6876c504befdebd9b6a7dd5e000c9ebe"
       ]
     },
     "ClBb-ord-G3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G3-mf-N-N.wav",
         "361069cfc927bd3e576fda2a18d2c073"
       ]
     },
     "ClBb-ord-G#3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#3-mf-N-N.wav",
         "5456f428c1890d475f1d5f50c93e1a1e"
       ]
     },
     "ClBb-ord-A3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A3-mf-N-N.wav",
         "fd8149ed2dcbfd96d8220f7031780c34"
       ]
     },
     "ClBb-ord-A#3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#3-mf-N-N.wav",
         "14fa3123a12ff2afa026a79898a811f1"
       ]
     },
     "ClBb-ord-B3-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B3-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B3-mf-N-N.wav",
         "c9dfa2b35fb61deb9683e39166cbd5a8"
       ]
     },
     "ClBb-ord-C4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C4-mf-N-N.wav",
         "029f06e17b2d0c3257b2d4acf750b976"
       ]
     },
     "ClBb-ord-C#4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#4-mf-N-N.wav",
         "bf5261bd9b99cd263edfac69d1c8ef83"
       ]
     },
     "ClBb-ord-D4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D4-mf-N-N.wav",
         "48446f692b1b5c65617dd7d6ddb8e8ae"
       ]
     },
     "ClBb-ord-D#4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#4-mf-N-N.wav",
         "15976c6be251b162839bd40228be8a93"
       ]
     },
     "ClBb-ord-E4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E4-mf-N-N.wav",
         "2f8b2dda678cd0cee2c04ade6048e2e9"
       ]
     },
     "ClBb-ord-F4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F4-mf-N-N.wav",
         "db8af408df7ca97bcb1afecddfe6cbdf"
       ]
     },
     "ClBb-ord-F#4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#4-mf-N-N.wav",
         "7506fdbe6fa79dfd47beb730049d88f4"
       ]
     },
     "ClBb-ord-G4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G4-mf-N-N.wav",
         "cda98f9785e0a2ad05131db5c052ed24"
       ]
     },
     "ClBb-ord-G#4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#4-mf-N-N.wav",
         "189f08b3f4d7056541e6b1219e365fc5"
       ]
     },
     "ClBb-ord-A4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A4-mf-N-N.wav",
         "bd5ea8f12375a2b8b6b1a15160e7dc35"
       ]
     },
     "ClBb-ord-A#4-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#4-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#4-mf-N-N.wav",
         "3f52951fa3ff45cb50b0b50c90a0b192"
       ]
     },
     "ClBb-ord-B4-mf-N-T12u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B4-mf-N-T12u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B4-mf-N-T12u.wav",
         "d3c3f9881fb1cb116eec838974e83beb"
       ]
     },
     "ClBb-ord-C5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C5-mf-N-N.wav",
         "6eaabfb50943dce777e5e8b99a48232a"
       ]
     },
     "ClBb-ord-C#5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#5-mf-N-N.wav",
         "bbaa6cd8cb8e54da5c22edb3aafd6fc9"
       ]
     },
     "ClBb-ord-D5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D5-mf-N-N.wav",
         "753781238a15fe367e91697520f4fa0e"
       ]
     },
     "ClBb-ord-D#5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#5-mf-N-N.wav",
         "3a45f1ab777ead8cf0ff85f5ba2a6862"
       ]
     },
     "ClBb-ord-E5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E5-mf-N-N.wav",
         "4ef699880657db5d38bffeeb1c255faa"
       ]
     },
     "ClBb-ord-F5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F5-mf-N-N.wav",
         "71209e288f1cf726bbf25da6fc39a5ad"
       ]
     },
     "ClBb-ord-F#5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#5-mf-N-N.wav",
         "541714cf007167cc7ccadeb7a7553316"
       ]
     },
     "ClBb-ord-G5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G5-mf-N-N.wav",
         "0e05ccd091d552ed5beaebf0fa1835bb"
       ]
     },
     "ClBb-ord-G#5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#5-mf-N-N.wav",
         "14d9d57705f7ab846f2ca7069ecf63ea"
       ]
     },
     "ClBb-ord-A5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A5-mf-N-N.wav",
         "c830c23a05145475b17abfc6c1f0973e"
       ]
     },
     "ClBb-ord-A#5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#5-mf-N-N.wav",
         "892e57fc567c00f98746bfdbfc0d5d66"
       ]
     },
     "ClBb-ord-B5-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B5-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B5-mf-N-N.wav",
         "b13be8c329e3ef1407ba5bd39b9020f3"
       ]
     },
     "ClBb-ord-C6-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C6-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C6-mf-N-N.wav",
         "c985d9dc90630d55f1b81812e89810fe"
       ]
     },
     "ClBb-ord-C#6-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#6-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#6-mf-N-N.wav",
         "cb15f340d9b4229c931e892a62eedd01"
       ]
     },
     "ClBb-ord-D6-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D6-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D6-mf-N-N.wav",
         "7fb63a782f8eddc56c3c669df13d86ff"
       ]
     },
     "ClBb-ord-D#6-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#6-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#6-mf-N-N.wav",
         "6aedb99363ce1395f2999d514b398441"
       ]
     },
     "ClBb-ord-E6-mf-N-T19d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E6-mf-N-T19d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E6-mf-N-T19d.wav",
         "e918e7745b0699af790ee31ad8a98d74"
       ]
     },
     "ClBb-ord-F6-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F6-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F6-mf-N-N.wav",
         "00211b9394a475e2e3b5f3a56fb30a7c"
       ]
     },
     "ClBb-ord-F#6-mf-N-T10u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#6-mf-N-T10u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#6-mf-N-T10u.wav",
         "f8b0eb1994e542b79dbdfe36f622f93f"
       ]
     },
     "ClBb-ord-G6-mf-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G6-mf-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G6-mf-N-N.wav",
         "1ca034fc1072c4d7834535542076899e"
       ]
     },
     "ClBb-ord-D3-ff-N-T31u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D3-ff-N-T31u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D3-ff-N-T31u.wav",
         "cf91df8f0a3e454a869d6301f819bc8c"
       ]
     },
     "ClBb-ord-D#3-ff-N-T35u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#3-ff-N-T35u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#3-ff-N-T35u.wav",
         "6729cdc10c953038129d6d5b7cd9244a"
       ]
     },
     "ClBb-ord-E3-ff-N-T20u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E3-ff-N-T20u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E3-ff-N-T20u.wav",
         "3934bc7901916a8a81c139a000d933d7"
       ]
     },
     "ClBb-ord-F3-ff-N-T16u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F3-ff-N-T16u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F3-ff-N-T16u.wav",
         "77c717a24abc6a550a20eb26cf685227"
       ]
     },
     "ClBb-ord-F#3-ff-N-T21u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#3-ff-N-T21u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#3-ff-N-T21u.wav",
         "25d524410ab77879e7e75a6aae649e8c"
       ]
     },
     "ClBb-ord-G3-ff-N-T20u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G3-ff-N-T20u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G3-ff-N-T20u.wav",
         "09e78a6ec3047533e1b7f061fd940268"
       ]
     },
     "ClBb-ord-G#3-ff-N-T19u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#3-ff-N-T19u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#3-ff-N-T19u.wav",
         "32f0cc49724f7d91663bc8cadde97f37"
       ]
     },
     "ClBb-ord-A3-ff-N-T22u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A3-ff-N-T22u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A3-ff-N-T22u.wav",
         "37454bc23dd4f7080614b1073060859e"
       ]
     },
     "ClBb-ord-A#3-ff-N-T13u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#3-ff-N-T13u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#3-ff-N-T13u.wav",
         "5991213df70fd1d0e3d99564a9ec6d12"
       ]
     },
     "ClBb-ord-B3-ff-N-T16u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B3-ff-N-T16u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B3-ff-N-T16u.wav",
         "acafd30ec70372bc301af1ea9ced22c9"
       ]
     },
     "ClBb-ord-C4-ff-N-T33u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C4-ff-N-T33u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C4-ff-N-T33u.wav",
         "a8bc97c71361d83d8847799c6011f269"
       ]
     },
     "ClBb-ord-C#4-ff-N-T15u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#4-ff-N-T15u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#4-ff-N-T15u.wav",
         "e6f9e9f2b2dcf9088fa530329346e422"
       ]
     },
     "ClBb-ord-D4-ff-N-T19u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D4-ff-N-T19u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D4-ff-N-T19u.wav",
         "09e5b7216897dca6b8fd149e757b8c50"
       ]
     },
     "ClBb-ord-D#4-ff-N-T20u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#4-ff-N-T20u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#4-ff-N-T20u.wav",
         "ce319183ca72a37817557cf03ab242b8"
       ]
     },
     "ClBb-ord-E4-ff-N-T30u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E4-ff-N-T30u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E4-ff-N-T30u.wav",
         "db48a06527d24dc5773da9bd1534259d"
       ]
     },
     "ClBb-ord-F4-ff-N-T13u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F4-ff-N-T13u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F4-ff-N-T13u.wav",
         "f6a2f4efe7da282707d49848f8afc488"
       ]
     },
     "ClBb-ord-F#4-ff-N-T24u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#4-ff-N-T24u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#4-ff-N-T24u.wav",
         "5196464a0e278c56723e19fb460f57f6"
       ]
     },
     "ClBb-ord-G4-ff-N-T30u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G4-ff-N-T30u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G4-ff-N-T30u.wav",
         "bc82773ebd00287ec26885cb09b9c2cd"
       ]
     },
     "ClBb-ord-G#4-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#4-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#4-ff-N-N.wav",
         "b1b5f5f5ae4dfa28227940f7deb57b03"
       ]
     },
     "ClBb-ord-A4-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A4-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A4-ff-N-N.wav",
         "68a9f923d90b37b76875e436b0873329"
       ]
     },
     "ClBb-ord-A#4-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#4-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#4-ff-N-N.wav",
         "d793f87d045095380c27c3372df94fae"
       ]
     },
     "ClBb-ord-B4-ff-N-T21u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B4-ff-N-T21u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B4-ff-N-T21u.wav",
         "083abc9358993c58856091b0d43aab0c"
       ]
     },
     "ClBb-ord-C5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C5-ff-N-N.wav",
         "04647ef64c071c2000012fa1272165ce"
       ]
     },
     "ClBb-ord-C#5-ff-N-T13u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#5-ff-N-T13u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#5-ff-N-T13u.wav",
         "914ef46f9421f1e2a05b46c40f7a56aa"
       ]
     },
     "ClBb-ord-D5-ff-N-T14u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D5-ff-N-T14u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D5-ff-N-T14u.wav",
         "848110645afdb03c574d240883af9e82"
       ]
     },
     "ClBb-ord-D#5-ff-N-T11u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#5-ff-N-T11u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#5-ff-N-T11u.wav",
         "586330d4556d4f967e40eea276d60d82"
       ]
     },
     "ClBb-ord-E5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E5-ff-N-N.wav",
         "c067770bc2209999b3820588520552d2"
       ]
     },
     "ClBb-ord-F5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F5-ff-N-N.wav",
         "3a9ad5a7bc895712a5e6b56b3c9d062d"
       ]
     },
     "ClBb-ord-F#5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#5-ff-N-N.wav",
         "d7dfbecb5c1e971cf548452107db6a83"
       ]
     },
     "ClBb-ord-G5-ff-N-T12u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G5-ff-N-T12u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G5-ff-N-T12u.wav",
         "8308e17937127d1d9f3a5183e33c30fe"
       ]
     },
     "ClBb-ord-G#5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G#5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G#5-ff-N-N.wav",
         "5cd18b761fdf319f5d1dc36119d01bcf"
       ]
     },
     "ClBb-ord-A5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A5-ff-N-N.wav",
         "06ccb859f0dde50d55998b36af821368"
       ]
     },
     "ClBb-ord-A#5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-A#5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-A#5-ff-N-N.wav",
         "bd16b4a74d5473677090877d4c5a165a"
       ]
     },
     "ClBb-ord-B5-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-B5-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-B5-ff-N-N.wav",
         "e6c0d11dbf3e70dbd2ca814d19949c34"
       ]
     },
     "ClBb-ord-C6-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C6-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C6-ff-N-N.wav",
         "240f45d6cf74bc04c50bee54fa108875"
       ]
     },
     "ClBb-ord-C#6-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-C#6-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-C#6-ff-N-N.wav",
         "add4c2d1fb7fc47bbbffb66340db0a5f"
       ]
     },
     "ClBb-ord-D6-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D6-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D6-ff-N-N.wav",
         "255bee7ff527e642852c012196ecaaf9"
       ]
     },
     "ClBb-ord-D#6-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-D#6-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-D#6-ff-N-N.wav",
         "5b03aafc7b148986c40c51cb9ac095dc"
       ]
     },
     "ClBb-ord-E6-ff-N-T10d": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-E6-ff-N-T10d.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-E6-ff-N-T10d.wav",
         "48c3eb99c615eab267b565a638c5100e"
       ]
     },
     "ClBb-ord-F6-ff-N-T10u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F6-ff-N-T10u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F6-ff-N-T10u.wav",
         "602c1ebcd72ec45446e9ed2d763a2dee"
       ]
     },
     "ClBb-ord-F#6-ff-N-T15u": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-F#6-ff-N-T15u.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-F#6-ff-N-T15u.wav",
         "501a34dc5b45dc4dfeb69d98b5c6f2ee"
       ]
     },
     "ClBb-ord-G6-ff-N-N": {
       "audio": [
-        "Winds/Clarinet_Bb/ordinario/ClBb-ord-G6-ff-N-N.wav",
+        "audio/Winds/Clarinet_Bb/ordinario/ClBb-ord-G6-ff-N-N.wav",
         "1ebdccb59cb596e7ede8b7b6faa4a944"
       ]
     },
     "Fl-ord-B3-pp-N-T19u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B3-pp-N-T19u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B3-pp-N-T19u.wav",
         "a76aac9da07203376e7dc26e639fd2d6"
       ]
     },
     "Fl-ord-C4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C4-pp-N-N.wav",
         "01e788dbd7c19de69ed3395e968a066a"
       ]
     },
     "Fl-ord-C#4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#4-pp-N-N.wav",
         "c20f0dc4a7db3a35a04c12137b6d14b1"
       ]
     },
     "Fl-ord-D4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D4-pp-N-N.wav",
         "44aba9ec4a522c13dece953cc124372c"
       ]
     },
     "Fl-ord-D#4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#4-pp-N-N.wav",
         "4ce2b0deca328cf4fc747d5ac4bc4392"
       ]
     },
     "Fl-ord-E4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E4-pp-N-N.wav",
         "973dc4710c939805327214cd1693cad9"
       ]
     },
     "Fl-ord-F4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F4-pp-N-N.wav",
         "5640039c05c48cc8b9ccf013e177d4d2"
       ]
     },
     "Fl-ord-F#4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#4-pp-N-N.wav",
         "735033a79bc8f70b682686da278e4d6e"
       ]
     },
     "Fl-ord-G4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G4-pp-N-N.wav",
         "642b185fde66fbb76ba09aa462b8f2a1"
       ]
     },
     "Fl-ord-G#4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#4-pp-N-N.wav",
         "be73b7de87a4d90319e5377b0f660566"
       ]
     },
     "Fl-ord-A4-pp-N-T18u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A4-pp-N-T18u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A4-pp-N-T18u.wav",
         "e01eef7094019b6f957c5fd997875c4f"
       ]
     },
     "Fl-ord-A#4-pp-N-T11u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#4-pp-N-T11u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#4-pp-N-T11u.wav",
         "4e017c27f3a289cf9b609027f04ad3da"
       ]
     },
     "Fl-ord-B4-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B4-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B4-pp-N-N.wav",
         "47828af4240a5ec84db06ef60163bd2c"
       ]
     },
     "Fl-ord-C5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C5-pp-N-N.wav",
         "013a50084f50356e8f19d0a74fa3fd27"
       ]
     },
     "Fl-ord-C#5-pp-N-T10u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#5-pp-N-T10u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#5-pp-N-T10u.wav",
         "25fc9a0dc7da2eaf6bd0baf20f852170"
       ]
     },
     "Fl-ord-D5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D5-pp-N-N.wav",
         "0616ab25e9a7c55d65481afb8474a6bd"
       ]
     },
     "Fl-ord-D#5-pp-N-T10u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#5-pp-N-T10u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#5-pp-N-T10u.wav",
         "d7105b2fa205693cdb7f01f4627cec2e"
       ]
     },
     "Fl-ord-E5-pp-N-T13u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E5-pp-N-T13u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E5-pp-N-T13u.wav",
         "c7a865805b5fa917beb1de097fad2b87"
       ]
     },
     "Fl-ord-F5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F5-pp-N-N.wav",
         "ee189700ebe0fc385a988dffca30e6fb"
       ]
     },
     "Fl-ord-F#5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#5-pp-N-N.wav",
         "6e7808c3dbbcc1598c6bff0ba1b7217a"
       ]
     },
     "Fl-ord-G5-pp-N-T11u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G5-pp-N-T11u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G5-pp-N-T11u.wav",
         "26cf69d0aebae6b56c394adf1979517a"
       ]
     },
     "Fl-ord-G#5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#5-pp-N-N.wav",
         "72f1a497584fbc83c910c3037c5c542b"
       ]
     },
     "Fl-ord-A5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A5-pp-N-N.wav",
         "4e72076fc33da432a326ebbbf25fc54e"
       ]
     },
     "Fl-ord-A#5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#5-pp-N-N.wav",
         "530e508a5274455656c589baee48ae1e"
       ]
     },
     "Fl-ord-B5-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B5-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B5-pp-N-N.wav",
         "d7b440d5904a8b1487f79f1f17d5748c"
       ]
     },
     "Fl-ord-C6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C6-pp-N-N.wav",
         "e5190a673bcf85c00b6211a4b6847834"
       ]
     },
     "Fl-ord-C#6-pp-N-T12d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#6-pp-N-T12d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#6-pp-N-T12d.wav",
         "5adecf7e99b2da3f07a33d46e7b4059c"
       ]
     },
     "Fl-ord-D6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D6-pp-N-N.wav",
         "f7b81f7a175ec8ff10787b20ecb75a2b"
       ]
     },
     "Fl-ord-D#6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#6-pp-N-N.wav",
         "c8741847242080349b1364eef536977d"
       ]
     },
     "Fl-ord-E6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E6-pp-N-N.wav",
         "a56c60e39f24c6f63d0896bd22ede32b"
       ]
     },
     "Fl-ord-F6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F6-pp-N-N.wav",
         "d8c08ab4343a2e36f1c79722a267bb89"
       ]
     },
     "Fl-ord-F#6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#6-pp-N-N.wav",
         "b0836daf2fe1deda93cb7b811d23b562"
       ]
     },
     "Fl-ord-G6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G6-pp-N-N.wav",
         "622261403ad8c98bff84cd12661b32a3"
       ]
     },
     "Fl-ord-G#6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#6-pp-N-N.wav",
         "cb2adce20659d1aa9d6a7c2eae3f7b4f"
       ]
     },
     "Fl-ord-A6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A6-pp-N-N.wav",
         "39f4499eece80181627fa487fd59cecb"
       ]
     },
     "Fl-ord-A#6-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#6-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#6-pp-N-N.wav",
         "1d246986fb7730837b1a2f099ed3b2df"
       ]
     },
     "Fl-ord-B6-pp-N-T11u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B6-pp-N-T11u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B6-pp-N-T11u.wav",
         "5e4081bcf3f0322ec3a0b7de4a38b462"
       ]
     },
     "Fl-ord-C7-pp-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C7-pp-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C7-pp-N-N.wav",
         "bb6d47c85dadde0f94ee236bbf031d58"
       ]
     },
     "Fl-ord-C#7-p-N-T12u": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#7-p-N-T12u.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#7-p-N-T12u.wav",
         "a2a9a5bb5e80c693fac6439a908002cd"
       ]
     },
     "Fl-ord-D7-p-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D7-p-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D7-p-N-N.wav",
         "229621f288a59271ca3d10b57b87a736"
       ]
     },
     "Fl-ord-B3-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B3-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B3-mf-N-N.wav",
         "06c2ac6e5a1ece2fd56d42f6e92c3196"
       ]
     },
     "Fl-ord-C4-mf-N-T14d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C4-mf-N-T14d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C4-mf-N-T14d.wav",
         "404881c086097e3ade3766b2d32de886"
       ]
     },
     "Fl-ord-C#4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#4-mf-N-N.wav",
         "41bd928576f88a5fc4d56a2dcd776557"
       ]
     },
     "Fl-ord-D4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D4-mf-N-N.wav",
         "b28ebd16e17d39bae99958dff740d1bf"
       ]
     },
     "Fl-ord-D#4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#4-mf-N-N.wav",
         "521f9ddd77a77788d81cea39db9cf5a2"
       ]
     },
     "Fl-ord-E4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E4-mf-N-N.wav",
         "b1491d1a6465881fbe12b18123ed1b0f"
       ]
     },
     "Fl-ord-F4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F4-mf-N-N.wav",
         "49181a8f8efaa8febc062d3a01d7027b"
       ]
     },
     "Fl-ord-F#4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#4-mf-N-N.wav",
         "afa9f947e3effba57437f32fd95affe1"
       ]
     },
     "Fl-ord-G4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G4-mf-N-N.wav",
         "d6adefe56e55668077bedca7a8e940e7"
       ]
     },
     "Fl-ord-G#4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#4-mf-N-N.wav",
         "774b702a37754536fd326dc19e445a8e"
       ]
     },
     "Fl-ord-A4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A4-mf-N-N.wav",
         "3379ec8d79ff8e62f45c291d4e930f16"
       ]
     },
     "Fl-ord-A#4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#4-mf-N-N.wav",
         "8e92d04b1bec5b28ec9583e70ea0fa3b"
       ]
     },
     "Fl-ord-B4-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B4-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B4-mf-N-N.wav",
         "7321cb657eeb1a26b9e8d42a312c0f1d"
       ]
     },
     "Fl-ord-C5-mf-N-T17d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C5-mf-N-T17d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C5-mf-N-T17d.wav",
         "2b4bb219b5dcd651e03204da6d8e614c"
       ]
     },
     "Fl-ord-C#5-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#5-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#5-mf-N-N.wav",
         "92e9b10972dfbb0af5ae7dea781a3f52"
       ]
     },
     "Fl-ord-D5-mf-N-T11d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D5-mf-N-T11d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D5-mf-N-T11d.wav",
         "9b2819d8440e0d4a6fd6543bb3c87508"
       ]
     },
     "Fl-ord-D#5-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#5-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#5-mf-N-N.wav",
         "e96aa2094c1201abcc94d57b84245a5c"
       ]
     },
     "Fl-ord-E5-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E5-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E5-mf-N-N.wav",
         "4d05ec54bbea58a696b889426249d0de"
       ]
     },
     "Fl-ord-F5-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F5-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F5-mf-N-N.wav",
         "9e62d6128a44f7d06f67ba700f8ee48f"
       ]
     },
     "Fl-ord-F#5-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#5-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#5-mf-N-N.wav",
         "e2413ddd5ede6fe1680937a11b71f850"
       ]
     },
     "Fl-ord-G5-mf-N-T16d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G5-mf-N-T16d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G5-mf-N-T16d.wav",
         "33e7bb0277e1ab45d1c0da81dc2fc0ef"
       ]
     },
     "Fl-ord-G#5-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#5-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#5-mf-N-N.wav",
         "70ff7a071aacf9582e1214b7fddab804"
       ]
     },
     "Fl-ord-A5-mf-N-T11d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A5-mf-N-T11d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A5-mf-N-T11d.wav",
         "e29ef41840ff1cd359bd47d5b2bac32a"
       ]
     },
     "Fl-ord-A#5-mf-N-T18d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#5-mf-N-T18d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#5-mf-N-T18d.wav",
         "b7b8bda28b022b61666740b156f00060"
       ]
     },
     "Fl-ord-B5-mf-N-T17d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B5-mf-N-T17d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B5-mf-N-T17d.wav",
         "b15502db0cfccacc12a459b8cc17e4d0"
       ]
     },
     "Fl-ord-C6-mf-N-T25d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C6-mf-N-T25d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C6-mf-N-T25d.wav",
         "c6cd96fa482d5f7ba22d58f2cc14a39d"
       ]
     },
     "Fl-ord-C#6-mf-N-T15d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#6-mf-N-T15d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#6-mf-N-T15d.wav",
         "11d3645c0bbfea35180e87ad0314709e"
       ]
     },
     "Fl-ord-D6-mf-N-T11d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D6-mf-N-T11d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D6-mf-N-T11d.wav",
         "c10db467335b7a1207474b5ba0ecf5f4"
       ]
     },
     "Fl-ord-D#6-mf-N-T12d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#6-mf-N-T12d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#6-mf-N-T12d.wav",
         "c0a701168341ce9c5c0ab3ec88cb01e4"
       ]
     },
     "Fl-ord-E6-mf-N-T17d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E6-mf-N-T17d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E6-mf-N-T17d.wav",
         "0ccd109a606f0efc332fad53425088b1"
       ]
     },
     "Fl-ord-F6-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F6-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F6-mf-N-N.wav",
         "3d3044ea20699041cf85059a46d594c3"
       ]
     },
     "Fl-ord-F#6-mf-N-T10d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#6-mf-N-T10d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#6-mf-N-T10d.wav",
         "e03a48e5ec9154ee309a3e11ee801642"
       ]
     },
     "Fl-ord-G6-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G6-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G6-mf-N-N.wav",
         "611b1972e38e3848bc008986f3a0e09f"
       ]
     },
     "Fl-ord-G#6-mf-N-T14d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#6-mf-N-T14d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#6-mf-N-T14d.wav",
         "8efdf820f34f4f47424636215a9d8c4d"
       ]
     },
     "Fl-ord-A6-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A6-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A6-mf-N-N.wav",
         "028ae491b8558eec0403569d4c631417"
       ]
     },
     "Fl-ord-A#6-mf-N-T11d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#6-mf-N-T11d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#6-mf-N-T11d.wav",
         "6eed57a5bc62d0f6e37b22cee169449c"
       ]
     },
     "Fl-ord-B6-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B6-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B6-mf-N-N.wav",
         "2bfd051924b7330a5b3c5a570c140fb6"
       ]
     },
     "Fl-ord-C7-mf-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C7-mf-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C7-mf-N-N.wav",
         "37c20bdc8c56e1adcfe8d97819b1193b"
       ]
     },
     "Fl-ord-B3-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B3-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B3-ff-N-N.wav",
         "f554faa6c57870a1e863dde4ced64a59"
       ]
     },
     "Fl-ord-C4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C4-ff-N-N.wav",
         "97283dc3baf0458b9ec9ad9305ea879d"
       ]
     },
     "Fl-ord-C#4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#4-ff-N-N.wav",
         "87faa00b1308d12767181250a2c74d53"
       ]
     },
     "Fl-ord-D4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D4-ff-N-N.wav",
         "fab697d4bffa4fa40f705f35a293cc78"
       ]
     },
     "Fl-ord-D#4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#4-ff-N-N.wav",
         "65bb29d7d2ae21845dc86b09e54397e9"
       ]
     },
     "Fl-ord-E4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E4-ff-N-N.wav",
         "e7bda7c1a5cb1dd99ee60f6261894583"
       ]
     },
     "Fl-ord-F4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F4-ff-N-N.wav",
         "cdc4b536e56c0223a0c57f91a0dd59ee"
       ]
     },
     "Fl-ord-F#4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#4-ff-N-N.wav",
         "7aa05a51a6cfda3940a3a16c609bc18f"
       ]
     },
     "Fl-ord-G4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G4-ff-N-N.wav",
         "13be641c28b20d15d5b98c8dd0b6f4bf"
       ]
     },
     "Fl-ord-G#4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#4-ff-N-N.wav",
         "7153051bebfb6e88efc09c3387ebce2a"
       ]
     },
     "Fl-ord-A4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A4-ff-N-N.wav",
         "c636873a8445ad33db897d1db35ba569"
       ]
     },
     "Fl-ord-A#4-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#4-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#4-ff-N-N.wav",
         "e8c6d7f2a50a7e1e3c6b6fad93ace758"
       ]
     },
     "Fl-ord-B4-ff-N-T10d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B4-ff-N-T10d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B4-ff-N-T10d.wav",
         "a226429e6c347ff29bbb15bcb7ec384e"
       ]
     },
     "Fl-ord-C5-ff-N-T19d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C5-ff-N-T19d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C5-ff-N-T19d.wav",
         "96fdf47f9f2a905c2dd642df1094d10e"
       ]
     },
     "Fl-ord-C#5-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#5-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#5-ff-N-N.wav",
         "1b9c340067ea2a72ee43fdc0bb491224"
       ]
     },
     "Fl-ord-D5-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D5-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D5-ff-N-N.wav",
         "839a1ae0c5d93b58bd8cb46782ff03db"
       ]
     },
     "Fl-ord-D#5-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#5-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#5-ff-N-N.wav",
         "a540402d84a489c48b61c9176d66d7b3"
       ]
     },
     "Fl-ord-E5-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E5-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E5-ff-N-N.wav",
         "23dc75c0196ae4812761d2575d403a2b"
       ]
     },
     "Fl-ord-F5-ff-N-T13d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F5-ff-N-T13d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F5-ff-N-T13d.wav",
         "865e08bc5a0f105d2686c767a715a14c"
       ]
     },
     "Fl-ord-F#5-ff-N-T11d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#5-ff-N-T11d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#5-ff-N-T11d.wav",
         "d4c19c76c079dbf925aa784a9a7e831b"
       ]
     },
     "Fl-ord-G5-ff-N-T14d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G5-ff-N-T14d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G5-ff-N-T14d.wav",
         "bf8c942c4b4d868707eff9ac3e17bb19"
       ]
     },
     "Fl-ord-G#5-ff-N-T19d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#5-ff-N-T19d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#5-ff-N-T19d.wav",
         "832432aefbc34330c9b44e1b983a6744"
       ]
     },
     "Fl-ord-A5-ff-N-T22d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A5-ff-N-T22d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A5-ff-N-T22d.wav",
         "35e8304004a3cd41ea48c4f5fa6eeb58"
       ]
     },
     "Fl-ord-A#5-ff-N-T21d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#5-ff-N-T21d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#5-ff-N-T21d.wav",
         "4573af16b8f2f76b6c1e677904f18a67"
       ]
     },
     "Fl-ord-B5-ff-N-T20d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B5-ff-N-T20d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B5-ff-N-T20d.wav",
         "9023ae4538532173f00f5fd64f9d8edb"
       ]
     },
     "Fl-ord-C6-ff-N-T38d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C6-ff-N-T38d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C6-ff-N-T38d.wav",
         "4b494709f83db35f5734a0a55a173e09"
       ]
     },
     "Fl-ord-C#6-ff-N-T30d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#6-ff-N-T30d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#6-ff-N-T30d.wav",
         "bcbb8888c3854070f1c6b6d6e585ecd7"
       ]
     },
     "Fl-ord-D6-ff-N-T20d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D6-ff-N-T20d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D6-ff-N-T20d.wav",
         "fb32432e16494e227b95fbae99c8312d"
       ]
     },
     "Fl-ord-D#6-ff-N-T16d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D#6-ff-N-T16d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D#6-ff-N-T16d.wav",
         "e1b7dbe20047bd6bda456d99a1db586e"
       ]
     },
     "Fl-ord-E6-ff-N-T25d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-E6-ff-N-T25d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-E6-ff-N-T25d.wav",
         "02374d5a83ccffe0f84e368185e16844"
       ]
     },
     "Fl-ord-F6-ff-N-T15d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F6-ff-N-T15d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F6-ff-N-T15d.wav",
         "66450a156da4aacfb8fe764b52122efc"
       ]
     },
     "Fl-ord-F#6-ff-N-T19d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-F#6-ff-N-T19d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-F#6-ff-N-T19d.wav",
         "984b50ca1bd32cf649cf0d92950accf8"
       ]
     },
     "Fl-ord-G6-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G6-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G6-ff-N-N.wav",
         "9c7d54ffceca9bbe7d8a5a0855e3b7ca"
       ]
     },
     "Fl-ord-G#6-ff-N-T17d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-G#6-ff-N-T17d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-G#6-ff-N-T17d.wav",
         "7987537de201367d388591c83505b6f7"
       ]
     },
     "Fl-ord-A6-ff-N-T13d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A6-ff-N-T13d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A6-ff-N-T13d.wav",
         "8067c7b700cde7f81026ab4c0163d90c"
       ]
     },
     "Fl-ord-A#6-ff-N-T15d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-A#6-ff-N-T15d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-A#6-ff-N-T15d.wav",
         "c07025437fb9b6296d8b564bd5f3922a"
       ]
     },
     "Fl-ord-B6-ff-N-T21d": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-B6-ff-N-T21d.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-B6-ff-N-T21d.wav",
         "d32aace6d0e6fb0bc4c5e7a0024b20e8"
       ]
     },
     "Fl-ord-C7-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C7-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C7-ff-N-N.wav",
         "23e3c56f17d627885a5dbcf71c4ef049"
       ]
     },
     "Fl-ord-C#7-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-C#7-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-C#7-ff-N-N.wav",
         "c72342379b34c8c99eab3c4f7fbb2895"
       ]
     },
     "Fl-ord-D7-ff-N-N": {
       "audio": [
-        "Winds/Flute/ordinario/Fl-ord-D7-ff-N-N.wav",
+        "audio/Winds/Flute/ordinario/Fl-ord-D7-ff-N-N.wav",
         "fec3fc8e5f5d7154196d707abc0f5dba"
       ]
     },
     "Ob-ord-A#3-pp-N-T12d": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#3-pp-N-T12d.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#3-pp-N-T12d.wav",
         "b4f0d26d23af1d7a9cd7701eb6232943"
       ]
     },
     "Ob-ord-B3-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B3-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B3-pp-N-N.wav",
         "e6efdfec2233389ebc406ca1de2f73dc"
       ]
     },
     "Ob-ord-C4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C4-pp-N-N.wav",
         "664411460485af597431459b0be2fa7d"
       ]
     },
     "Ob-ord-C#4-pp-N-R100u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#4-pp-N-R100u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#4-pp-N-R100u.wav",
         "9b2b0bc61e308ecfc699e519dc9d9f03"
       ]
     },
     "Ob-ord-D4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D4-pp-N-N.wav",
         "bee779394adab8e8c2970e7e9c3c531f"
       ]
     },
     "Ob-ord-D#4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#4-pp-N-N.wav",
         "91cb7330e2ebfce01b2c542d77afdda8"
       ]
     },
     "Ob-ord-E4-pp-N-R100u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E4-pp-N-R100u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E4-pp-N-R100u.wav",
         "6cf7aa145b0f2a927456961d1f35ac6c"
       ]
     },
     "Ob-ord-F4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F4-pp-N-N.wav",
         "93a2cb35659bc0b82ceb1c9140c73845"
       ]
     },
     "Ob-ord-F#4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#4-pp-N-N.wav",
         "bb228e57d34d5bf33267ace96c7d6a55"
       ]
     },
     "Ob-ord-G4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G4-pp-N-N.wav",
         "bf9f4fbe1ad5618864e71b352dcbaad0"
       ]
     },
     "Ob-ord-G#4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#4-pp-N-N.wav",
         "a1b0a3930391a8492a0e5676d8942dac"
       ]
     },
     "Ob-ord-A4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A4-pp-N-N.wav",
         "f56d929fdcaa96aba35ebf02ab7f8f23"
       ]
     },
     "Ob-ord-A#4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#4-pp-N-N.wav",
         "14806c9421356592430874407d678d16"
       ]
     },
     "Ob-ord-B4-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B4-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B4-pp-N-N.wav",
         "1e1d61c4e85d018a2e4587d0cf5554f1"
       ]
     },
     "Ob-ord-C5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C5-pp-N-N.wav",
         "c878bf00ea17703760199302c594ae84"
       ]
     },
     "Ob-ord-C#5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#5-pp-N-N.wav",
         "1c96bf88b87a6ac30739931c4dbe97e9"
       ]
     },
     "Ob-ord-D5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D5-pp-N-N.wav",
         "9dc7ac7d397cc658592e092ba3f647cc"
       ]
     },
     "Ob-ord-D#5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#5-pp-N-N.wav",
         "158e0f3de3983df4e5881b02be386982"
       ]
     },
     "Ob-ord-E5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E5-pp-N-N.wav",
         "40df8fd8449c4fbf3b3561661f9bf566"
       ]
     },
     "Ob-ord-F5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F5-pp-N-N.wav",
         "a06ce6ce4b33f45798f1ebdf2b629e42"
       ]
     },
     "Ob-ord-F#5-pp-N-T12d": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#5-pp-N-T12d.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#5-pp-N-T12d.wav",
         "77545b4938a57b1339d2d327f5b5a2b8"
       ]
     },
     "Ob-ord-G5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G5-pp-N-N.wav",
         "bc0aa25ef4cb8a68d46e17ac665922bb"
       ]
     },
     "Ob-ord-G#5-pp-N-T11u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#5-pp-N-T11u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#5-pp-N-T11u.wav",
         "ad9690e36bc19b3f9f2de17d055bceff"
       ]
     },
     "Ob-ord-A5-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A5-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A5-pp-N-N.wav",
         "b02bc07ce12970f3c3c764ecdf74bf2a"
       ]
     },
     "Ob-ord-A#5-pp-N-T14u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#5-pp-N-T14u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#5-pp-N-T14u.wav",
         "01568f4f54d2d8c3d0f312e3fc76f3b1"
       ]
     },
     "Ob-ord-B5-pp-N-T20u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B5-pp-N-T20u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B5-pp-N-T20u.wav",
         "eab094ceee1009b83ed60e3a264506bc"
       ]
     },
     "Ob-ord-C6-pp-N-T13u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C6-pp-N-T13u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C6-pp-N-T13u.wav",
         "736847a2019c4777a5f64cddce85527e"
       ]
     },
     "Ob-ord-C#6-pp-N-T10u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#6-pp-N-T10u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#6-pp-N-T10u.wav",
         "3dfc64baa37529e8d8326420eeef1b72"
       ]
     },
     "Ob-ord-D6-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D6-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D6-pp-N-N.wav",
         "2dc5ffd576c4e9f0b0b5f5d458b0964b"
       ]
     },
     "Ob-ord-D#6-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#6-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#6-pp-N-N.wav",
         "bb410433498d8bbb73edd100d731f0e7"
       ]
     },
     "Ob-ord-E6-pp-N-T23u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E6-pp-N-T23u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E6-pp-N-T23u.wav",
         "41c664b2adc161f0d7165e27675d1fae"
       ]
     },
     "Ob-ord-F6-pp-N-T11u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F6-pp-N-T11u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F6-pp-N-T11u.wav",
         "817256590c658a52a0a1e9fac5501d94"
       ]
     },
     "Ob-ord-F#6-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#6-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#6-pp-N-N.wav",
         "6590c1e4ded23e5422d1a48d60569902"
       ]
     },
     "Ob-ord-G6-pp-N-T19u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G6-pp-N-T19u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G6-pp-N-T19u.wav",
         "2b7a79f24b7de5b1596d46a714d74c06"
       ]
     },
     "Ob-ord-G#6-pp-N-T12d": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#6-pp-N-T12d.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#6-pp-N-T12d.wav",
         "63338dff2c0cfcaf4afa5b30726f219f"
       ]
     },
     "Ob-ord-A6-pp-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A6-pp-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A6-pp-N-N.wav",
         "9a73881d1ed17a1f32bde40e95e9c148"
       ]
     },
     "Ob-ord-A#3-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#3-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#3-mf-N-N.wav",
         "bcc9d117919a646a35ac7e5071cbba51"
       ]
     },
     "Ob-ord-B3-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B3-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B3-mf-N-N.wav",
         "5dc82c61f8df20c59d89f67458a732de"
       ]
     },
     "Ob-ord-C4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C4-mf-N-N.wav",
         "0743de03da1f6a04d28d940812bc2136"
       ]
     },
     "Ob-ord-C#4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#4-mf-N-N.wav",
         "f01a126bbe5918bdd42f25b0d6113e7f"
       ]
     },
     "Ob-ord-D4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D4-mf-N-N.wav",
         "d513c7a2195cfbabbcc61a3be3985ffd"
       ]
     },
     "Ob-ord-D#4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#4-mf-N-N.wav",
         "07f4b8fab022cf18aedc1202d5fc47fa"
       ]
     },
     "Ob-ord-E4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E4-mf-N-N.wav",
         "9b61ec9bc32489378eb1897f88aeb748"
       ]
     },
     "Ob-ord-F4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F4-mf-N-N.wav",
         "a64f121d470a2da267ffbc841b6d66e6"
       ]
     },
     "Ob-ord-F#4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#4-mf-N-N.wav",
         "ee3352a8dcfb3002865cb7bb7b7555fc"
       ]
     },
     "Ob-ord-G4-mf-N-R100u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G4-mf-N-R100u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G4-mf-N-R100u.wav",
         "c221f4bbb2f53a6b1fc91d1a3825839a"
       ]
     },
     "Ob-ord-G#4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#4-mf-N-N.wav",
         "fbb5c729105f728ce16370eb30760f0d"
       ]
     },
     "Ob-ord-A4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A4-mf-N-N.wav",
         "fd8d00f69bd5b4c06fc45103d69d9737"
       ]
     },
     "Ob-ord-A#4-mf-N-R100u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#4-mf-N-R100u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#4-mf-N-R100u.wav",
         "171e7ffc3edcc83b764600354eedc703"
       ]
     },
     "Ob-ord-B4-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B4-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B4-mf-N-N.wav",
         "3cce5f27c3d034bab2535587e1b53042"
       ]
     },
     "Ob-ord-C5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C5-mf-N-N.wav",
         "68365da83cecaef8900a75c7aaf400e9"
       ]
     },
     "Ob-ord-C#5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#5-mf-N-N.wav",
         "27cdd5bcd6e038663ee349bbd087df8b"
       ]
     },
     "Ob-ord-D5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D5-mf-N-N.wav",
         "6d8f25a9488f7fc1332baa38e7cbbc23"
       ]
     },
     "Ob-ord-D#5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#5-mf-N-N.wav",
         "439f2ace5fd147827a6846a4313d6061"
       ]
     },
     "Ob-ord-E5-mf-N-T10u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E5-mf-N-T10u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E5-mf-N-T10u.wav",
         "e983c612e8cd32be37e46b0dbdc9c635"
       ]
     },
     "Ob-ord-F5-mf-N-T12u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F5-mf-N-T12u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F5-mf-N-T12u.wav",
         "18cbf2fb87169673a68860f2e2a373b9"
       ]
     },
     "Ob-ord-F#5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#5-mf-N-N.wav",
         "a8810796b8c2a81f261b075b329ed29f"
       ]
     },
     "Ob-ord-G5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G5-mf-N-N.wav",
         "46de88e4dea246449a0889d7dc8003c7"
       ]
     },
     "Ob-ord-G#5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#5-mf-N-N.wav",
         "5498ca0f94d81a4cdc3d635e89b4a45b"
       ]
     },
     "Ob-ord-A5-mf-N-T11u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A5-mf-N-T11u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A5-mf-N-T11u.wav",
         "e2ac9b6fbd335f5325588476d7973262"
       ]
     },
     "Ob-ord-A#5-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#5-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#5-mf-N-N.wav",
         "9fa20ac8ca57b06dbdba89e49fa42441"
       ]
     },
     "Ob-ord-B5-mf-N-T12u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B5-mf-N-T12u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B5-mf-N-T12u.wav",
         "9299c024a1ac7e4a65ee5c50311d9a4a"
       ]
     },
     "Ob-ord-C6-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C6-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C6-mf-N-N.wav",
         "236a5f69722e99fc73f7441077d38dab"
       ]
     },
     "Ob-ord-C#6-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#6-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#6-mf-N-N.wav",
         "12df2f978c7653e9c7fad95185d00d77"
       ]
     },
     "Ob-ord-D6-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D6-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D6-mf-N-N.wav",
         "da05fcf2e328457026ec2215c6df019f"
       ]
     },
     "Ob-ord-D#6-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#6-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#6-mf-N-N.wav",
         "d322311165527a1b8d9a9a7945c44b2b"
       ]
     },
     "Ob-ord-E6-mf-N-T22u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E6-mf-N-T22u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E6-mf-N-T22u.wav",
         "376f93d380b808c5b8ce65971eebdc82"
       ]
     },
     "Ob-ord-F6-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F6-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F6-mf-N-N.wav",
         "26a7124975f0f53aabf6f4cba64ed6bc"
       ]
     },
     "Ob-ord-F#6-mf-N-T12u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#6-mf-N-T12u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#6-mf-N-T12u.wav",
         "6bec9e0d59a5dfefcd8a181c1c430c48"
       ]
     },
     "Ob-ord-G6-mf-N-T15u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G6-mf-N-T15u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G6-mf-N-T15u.wav",
         "1c02a6c0c265cbf056a12a60401a4d51"
       ]
     },
     "Ob-ord-G#6-mf-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#6-mf-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#6-mf-N-N.wav",
         "325e268da99e91a91a6efdb3ba12d223"
       ]
     },
     "Ob-ord-A#3-ff-N-T10d": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#3-ff-N-T10d.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#3-ff-N-T10d.wav",
         "8a967c78afb1b35e945216cbc8e472ce"
       ]
     },
     "Ob-ord-B3-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B3-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B3-ff-N-N.wav",
         "d2d5090a49a8e4e0bc2378bb84474892"
       ]
     },
     "Ob-ord-C4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C4-ff-N-N.wav",
         "c97c8a7201b7345ebab4cbdb24793231"
       ]
     },
     "Ob-ord-C#4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#4-ff-N-N.wav",
         "9c1b12c5bc6cce5d2776a42328933861"
       ]
     },
     "Ob-ord-D4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D4-ff-N-N.wav",
         "52e53279e20ee3eb39a9316e261019c1"
       ]
     },
     "Ob-ord-D#4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#4-ff-N-N.wav",
         "2c9653aa4cce8f5bfe9c447558c2b359"
       ]
     },
     "Ob-ord-E4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E4-ff-N-N.wav",
         "4b1a494ee59b91726514a1f164f51fe4"
       ]
     },
     "Ob-ord-F4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F4-ff-N-N.wav",
         "504e87bab7a83af11f947371cfa2718d"
       ]
     },
     "Ob-ord-F#4-ff-N-T11d": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#4-ff-N-T11d.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#4-ff-N-T11d.wav",
         "fe7c3ba54d857bb8f210404ae4e96a3b"
       ]
     },
     "Ob-ord-G4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G4-ff-N-N.wav",
         "b1de1695fcaf7aa28ac28f93e8e8ae44"
       ]
     },
     "Ob-ord-G#4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#4-ff-N-N.wav",
         "05fcd5b3d3b005355578c962902f1bc9"
       ]
     },
     "Ob-ord-A4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A4-ff-N-N.wav",
         "661089df2898be1920e3bc79af0ea417"
       ]
     },
     "Ob-ord-A#4-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#4-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#4-ff-N-N.wav",
         "86b54fd8abf719c8056421bf931519c3"
       ]
     },
     "Ob-ord-B4-ff-N-T13d": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B4-ff-N-T13d.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B4-ff-N-T13d.wav",
         "3e9a92b928e86ddeb9ca24b1849963ba"
       ]
     },
     "Ob-ord-C5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C5-ff-N-N.wav",
         "cd82d4919116e0f1ee2eb3feaa3e7aef"
       ]
     },
     "Ob-ord-C#5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#5-ff-N-N.wav",
         "8dacf6dc35645c09447f5d133454096f"
       ]
     },
     "Ob-ord-D5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D5-ff-N-N.wav",
         "6fa15d2cacd77eb29baf7676a730df70"
       ]
     },
     "Ob-ord-D#5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#5-ff-N-N.wav",
         "080b554572891200f03444e178869b16"
       ]
     },
     "Ob-ord-E5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E5-ff-N-N.wav",
         "d99a39170bdf874f4683cfb3124e86e5"
       ]
     },
     "Ob-ord-F5-ff-N-T10u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F5-ff-N-T10u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F5-ff-N-T10u.wav",
         "c3e38c91a38fab1cfc7a0dab33bee791"
       ]
     },
     "Ob-ord-F#5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#5-ff-N-N.wav",
         "c47ec6886b2ed7c709716ee691f8dc88"
       ]
     },
     "Ob-ord-G5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G5-ff-N-N.wav",
         "45e092fea206cf13b5ae707c08899f4c"
       ]
     },
     "Ob-ord-G#5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#5-ff-N-N.wav",
         "151e484fdf113027643ddf276a10aca4"
       ]
     },
     "Ob-ord-A5-ff-N-T19u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A5-ff-N-T19u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A5-ff-N-T19u.wav",
         "12400fb74dee17bd5aaec295c7605860"
       ]
     },
     "Ob-ord-A#5-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A#5-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A#5-ff-N-N.wav",
         "895b03d2bf421261824e9c6560531ea3"
       ]
     },
     "Ob-ord-B5-ff-N-T11u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-B5-ff-N-T11u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-B5-ff-N-T11u.wav",
         "801711ddb9457dc211b5d35c835b0b36"
       ]
     },
     "Ob-ord-C6-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C6-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C6-ff-N-N.wav",
         "c471d618659fa63ac196b55ecf561d30"
       ]
     },
     "Ob-ord-C#6-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-C#6-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-C#6-ff-N-N.wav",
         "a41590e26f10965a2bb409eb59cfe48c"
       ]
     },
     "Ob-ord-D6-ff-N-R100u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D6-ff-N-R100u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D6-ff-N-R100u.wav",
         "0e14fbae3b7d5e34986e26d20069633d"
       ]
     },
     "Ob-ord-D#6-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-D#6-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-D#6-ff-N-N.wav",
         "64a1e62647464d33dcef41fb5ab283f0"
       ]
     },
     "Ob-ord-E6-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-E6-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-E6-ff-N-N.wav",
         "44b48c05a46d6e901075de9dfcbaf41c"
       ]
     },
     "Ob-ord-F6-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F6-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F6-ff-N-N.wav",
         "97d4b06ae326fe91441e48512d1b02f1"
       ]
     },
     "Ob-ord-F#6-ff-N-T12u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-F#6-ff-N-T12u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-F#6-ff-N-T12u.wav",
         "f3509c0bf8837dbdad1f14b5f9722509"
       ]
     },
     "Ob-ord-G6-ff-N-T16u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G6-ff-N-T16u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G6-ff-N-T16u.wav",
         "b2e62b4c85a4f5843040e441e1541bf6"
       ]
     },
     "Ob-ord-G#6-ff-N-N": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-G#6-ff-N-N.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-G#6-ff-N-N.wav",
         "a9403bd41984d128d2d054fad037b5f7"
       ]
     },
     "Ob-ord-A6-ff-N-T18u": {
       "audio": [
-        "Winds/Oboe/ordinario/Ob-ord-A6-ff-N-T18u.wav",
+        "audio/Winds/Oboe/ordinario/Ob-ord-A6-ff-N-T18u.wav",
         "f8bf49838fec1b1c977dadfb1ab7bef1"
       ]
     }

--- a/mirdata/datasets/tinysol.py
+++ b/mirdata/datasets/tinysol.py
@@ -168,9 +168,7 @@ class Track(core.Track):
                 "Resampled": None,
             }
 
-        self.audio_path = os.path.join(
-            self._data_home, "audio", self._track_paths["audio"][0]
-        )
+        self.audio_path = os.path.join(self._data_home, self._track_paths["audio"][0])
 
         self.family = self._track_metadata["Family"]
         self.instrument_abbr = self._track_metadata["Instrument (abbr.)"]

--- a/scripts/make_tinysol_index.py
+++ b/scripts/make_tinysol_index.py
@@ -6,7 +6,7 @@ import json
 import os
 
 
-TINYSOL_INDEX_PATH = '../mirdata/indexes/tinysol_index.json'
+TINYSOL_INDEX_PATH = '../mirdata/datasets/indexes/tinysol_index.json'
 
 
 def md5(file_path):
@@ -43,7 +43,7 @@ def make_tinysol_index(tinysol_data_path):
             audio_path = os.path.join(audio_dir, local_path)
             audio_checksum = md5(audio_path)
             key = os.path.splitext(os.path.split(local_path)[1])[0]
-            tinysol_index[key] = {"audio": (local_path, audio_checksum)}
+            tinysol_index[key] = {"audio": (os.path.join("audio",local_path), audio_checksum)}
 
     with open(TINYSOL_INDEX_PATH, 'w') as fhandle:
         json.dump(tinysol_index, fhandle, indent=2)


### PR DESCRIPTION
Modify `tinysol` index and module to be compatible with `Dataset` and in the same format as other datasets. Fixes #351 

- [x] Update `make_tinysol_index.py`
- [x] Update `tinysol_index.json` with new local path and update to new index structure using `update_index.py`
- [x] Update `tinysol.py` `audiopath`