### PR TITLE
Dataset.readme

### DIFF
--- a/mirdata/core.py
+++ b/mirdata/core.py
@@ -11,7 +11,7 @@ from mirdata import download_utils
 from mirdata import validate
 
 MAX_STR_LEN = 100
-
+DOCS_URL = "https://mirdata.readthedocs.io/en/latest/source/mirdata.html"
 
 ##### decorators ######
 
@@ -78,6 +78,7 @@ class Dataset(object):
         data_home (str): path where mirdata will look for the dataset
         name (str): the identifier of the dataset
         bibtex (str): dataset citation/s in bibtex format
+        readme (str): a link to information about the dataset
         remotes (dict): data to be downloaded
         download_info (str): download instructions or caveats
         track (core.Track): an uninstantiated Track object
@@ -114,6 +115,7 @@ class Dataset(object):
         self.bibtex = bibtex
         self.remotes = remotes
         self._download_info = download_info
+        self.readme = "{}/#module-mirdata.datasets.{}".format(DOCS_URL, self.name)
 
         # this is a hack to be able to have dataset-specific docstrings
         self.track = lambda track_id: self._track(track_id)

--- a/mirdata/core.py
+++ b/mirdata/core.py
@@ -115,7 +115,7 @@ class Dataset(object):
         self.bibtex = bibtex
         self.remotes = remotes
         self._download_info = download_info
-        self.readme = "{}/#module-mirdata.datasets.{}".format(DOCS_URL, self.name)
+        self.readme = "{}#module-mirdata.datasets.{}".format(DOCS_URL, self.name)
 
         # this is a hack to be able to have dataset-specific docstrings
         self.track = lambda track_id: self._track(track_id)


### PR DESCRIPTION
reintroduces `Dataset.readme`, but instead of printing text, prints a link to the relevant docs.

This along with #407 (removes hidden `dataset_info` from Dataset docstring), closes #410