### PR TITLE
track docstring in dataset is incorrectly formatted

### DIFF
--- a/mirdata/core.py
+++ b/mirdata/core.py
@@ -90,8 +90,7 @@ class Dataset(object):
         bibtex (str or None): dataset citation/s in bibtex format
         remotes (dict or None): data to be downloaded
         readme (str): information about the dataset
-        track (function): a function which inputs a track_id (str) and
-            returns (mirdata.core.Track or None)
+        track (function): a function mapping a track_id to a mirdata.core.Track
 
     """
 


### PR DESCRIPTION
Right now the Dataset object docstring has a formatting mistake, related to the multiline comment and the docstring_inherit decorator not handling it properly - the second line is treated as a new variable ("returns")
![image](https://user-images.githubusercontent.com/8169843/104620182-b5158b00-565c-11eb-8e99-b60c04438bbd.png)

This PR doesn't fix it, but puts a bandaid on the problem by making all the arguments have one-line descriptions.