### PR TITLE
Update links to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # mirdata
-common loaders for Music Information Retrieval (MIR) datasets. Find the API documentation [here](https://mirdata.readthedocs.io/en/latest/).
+common loaders for Music Information Retrieval (MIR) datasets. Find the API documentation [here](https://mirdata.readthedocs.io/).
 
 [![CircleCI](https://circleci.com/gh/mir-dataset-loaders/mirdata.svg?style=svg)](https://circleci.com/gh/mir-dataset-loaders/mirdata)
 [![codecov](https://codecov.io/gh/mir-dataset-loaders/mirdata/branch/master/graph/badge.svg)](https://codecov.io/gh/mir-dataset-loaders/mirdata)
@@ -33,7 +33,7 @@ orchset.validate()  # validate that all the expected files are there
 example_track = orchset.choice_track()  # choose a random example track
 print(example_track)  # see the available data
 ```
-See the [documentation](https://mirdata.readthedocs.io/en/latest/) for more examples and the API reference.
+See the [documentation](https://mirdata.readthedocs.io/) for more examples and the API reference.
 
 
 ### Currently supported datasets
@@ -41,7 +41,7 @@ See the [documentation](https://mirdata.readthedocs.io/en/latest/) for more exam
 
 Supported datasets include [AcousticBrainz](https://zenodo.org/record/2553414#.X8jTgulKhhE), [DALI](https://github.com/gabolsgabs/DALI), [Guitarset](http://github.com/marl/guitarset/), [MAESTRO](https://magenta.tensorflow.org/datasets/maestro), [TinySOL](https://www.orch-idea.org/), among many others.
 
-For the **complete list** of supported datasets, see the [documentation](https://mirdata.readthedocs.io/en/latest/source/quick_reference.html)
+For the **complete list** of supported datasets, see the [documentation](https://mirdata.readthedocs.io/en/stable/source/quick_reference.html)
 
 
 ### Citing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,7 +59,6 @@ extlinks = {
     "cante": ("https://zenodo.org/record/1324183#.X_nq7-n7RUI%s", "Custom"),
     "ikala": ("http://mac.citi.sinica.edu.tw/ikala/%s", "Custom"),
     "rwc": ("https://staff.aist.go.jp/m.goto/RWC-MDB/%s", "Custom"),
-
 }
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,14 @@ mirdata
  * loading annotation files to a common format, consistent with ``mir_eval``
  * parsing track level metadata for detailed evaluations.
 
+
+.. code-block::
+
+    pip install mirdata
+
+
 For more details on how to use the library see the :ref:`tutorial`.
+
 
 Citing mirdata
 --------------

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -303,6 +303,7 @@ However, to contribute to the library using remote indexes you have to add in ``
 ``download_utils.RemoteFileMetadata`` dictionary with the remote index information.
 
 .. code-block:: python
+
     DATA = utils.LargeData("acousticbrainz_genre_index.json", remote_index=REMOTE_INDEX)
 
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -38,14 +38,10 @@ Whenever possible, the data downloaded using :code:`.download()` is the same dat
 
 Does mirdata provide data loaders for pytorch/Tensorflow?
 ---------------------------------------------------------
-For now, no. Music datasets are very widely varied in their annotation types and supported tasks. To make a data loader, there would need to be "standard" ways to encode the desired inputs/outputs - unofortunately this is not universal for most datasets and usages. Still, this library provides the necessary first step for building data loaders and it is easy to build data loaders on top of this. For a simple example, see our examples_ page.
-
-.. _examples: https://mirdata.readthedocs.io/en/latest/source/example.html#
-
-
-Why didn’t you release a version of this library in MATLAB/C/Java/R?
---------------------------------------------------------------------
-The creators of this library are Python users, so we made a libray in python. We'd be very happy to provide guidance to anyone who wants to create a version of this library in another programming languages.
+For now, no. Music datasets are very widely varied in their annotation types and supported tasks. 
+To make a data loader, there would need to be "standard" ways to encode the desired inputs/outputs - unfortunately this is not universal for most datasets and usages. 
+Still, this library provides the necessary first step for building data loaders and it is easy to build data loaders on top of this. 
+For a tutorial, see our :ref:`tutorial`.
 
 
 A download link is broken for a loader's :code:`.download()` function. What do I do?
@@ -67,7 +63,6 @@ No. All datasets have "mistakes", and we do not want to create another version o
 
 Does mirdata support data which lives off-disk?
 -----------------------------------------------
-Yes. While the simple useage of mirdata assumes that data lives on-disk, it can be used for off-disk data as well. See the "local vs remote" example in the examples_ page for details.
-
-.. _examples: https://mirdata.readthedocs.io/en/latest/source/example.html#
+Yes. While the simple useage of mirdata assumes that data lives on-disk, it can be used for off-disk data as well. 
+See :ref:`Remote Data Example` for details.
 

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -4,9 +4,7 @@ FAQ
 
 How do I add a new loader?
 --------------------------
-Take a look at our instructions_!
-
-.. _instructions: https://github.com/mir-dataset-loaders/mirdata/blob/master/CONTRIBUTING.md
+Take a look at our :ref:`contributing` docs!
 
 
 How do I get access to a dataset if the download function says it’s not available?
@@ -41,7 +39,7 @@ Does mirdata provide data loaders for pytorch/Tensorflow?
 For now, no. Music datasets are very widely varied in their annotation types and supported tasks. 
 To make a data loader, there would need to be "standard" ways to encode the desired inputs/outputs - unfortunately this is not universal for most datasets and usages. 
 Still, this library provides the necessary first step for building data loaders and it is easy to build data loaders on top of this. 
-For a tutorial, see our :ref:`tutorial`.
+For more information, see :ref:`Using mirdata with tensorflow`.
 
 
 A download link is broken for a loader's :code:`.download()` function. What do I do?

--- a/docs/source/mirdata.rst
+++ b/docs/source/mirdata.rst
@@ -8,6 +8,7 @@ Initializing
 
 .. autofunction:: mirdata.list_datasets
 
+.. _Datasets API:
 
 Dataset Loaders
 ---------------

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -4,6 +4,11 @@
 Overview
 ########
 
+.. code-block::
+
+    pip install mirdata
+
+
 ``mirdata`` is a library which aims to standardize how audio datasets are accessed in Python, 
 removing the need for writing custom loaders in every project, and improving reproducibility.
 Working with datasets usually requires an often cumbersome step of downloading data and writing 

--- a/docs/source/quick_reference.rst
+++ b/docs/source/quick_reference.rst
@@ -178,4 +178,3 @@ a track.
 
 
 .. _article: https://link.springer.com/article/10.1007/s10844-013-0250-y
-.. _here: https://mirdata.readthedocs.io/en/latest/source/mirdata.html#datasets

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -204,6 +204,8 @@ Alternatively, we don't need to load the whole dataset to get a single track.
     example_melody = example_track.melody  # Get the melody from first track
 
 
+.. _Remote Data Example: 
+
 Accessing data remotely
 ^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -255,7 +257,7 @@ Annotation classes
 ``mirdata`` defines annotation-specific data classes. These data classes are meant to standarize the format for
 all loaders, and are compatibly with `JAMS <https://jams.readthedocs.io/en/stable/>`_ and `mir_eval <https://craffel.github.io/mir_eval/>`_.
 
-The list and descriptions of available annotation classes can be found `at this link <https://mirdata.readthedocs.io/en/latest/source/mirdata.html#module-mirdata.annotations>`_.
+The list and descriptions of available annotation classes can be found in :ref:`annotations`.
 
 .. note:: These classes may be extended in the case that a loader requires it.
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -368,9 +368,10 @@ This is the result of the example above.
 
 You can see that ``very_bad_melody_extractor`` performs very badly!
 
+.. _Using mirdata with tensorflow:
 
-Using mirdata with tf.data.Dataset
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using mirdata with tensorflow
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 The following is a simple example of a generator that can be used to create a tensorflow Dataset.
 

--- a/mirdata/core.py
+++ b/mirdata/core.py
@@ -11,7 +11,7 @@ from mirdata import download_utils
 from mirdata import validate
 
 MAX_STR_LEN = 100
-DOCS_URL = "https://mirdata.readthedocs.io/en/latest/source/mirdata.html"
+DOCS_URL = "https://mirdata.readthedocs.io/en/stable/source/mirdata.html"
 DISCLAIMER = """
 ******************************************************************************************
 DISCLAIMER: mirdata is a software package with its own license which is independent from

--- a/scripts/legacy/update_index.py
+++ b/scripts/legacy/update_index.py
@@ -132,7 +132,7 @@ def get_dataset_version(module):
         "ikala": None,  # http://mac.citi.sinica.edu.tw/ikala/
         "irmas": "1.0",  # https://zenodo.org/record/1290750/
         "maestro": "2.0.0",  # https://magenta.tensorflow.org/datasets/maestro
-        "medley_solos_db": None,  # https://mirdata.readthedocs.io/en/latest/source/mirdata.html
+        "medley_solos_db": "1.2",  # https://zenodo.org/record/1344103
         "medleydb_melody": "5.0",  # https://zenodo.org/record/2628782#.X6BKOJNKi3J
         "medleydb_pitch": "2.0",  # https://zenodo.org/record/2620624#.XKZc7hNKh24
         "mridangam_stroke": "1.5",  # https://zenodo.org/record/1265188#.X6BKhpNKi3J


### PR DESCRIPTION
We included links to the "latest" version of the docs which points to master. This changes it to point to stable, and removes links when they weren't needed (e.g. internal docs references).

+ adds version information to medley-solos-db, which was missing