### PR TITLE
remove # -\*- coding: utf-8 -\*-\n  header

### DIFF
--- a/docs/source/contributing_examples/example.py
+++ b/docs/source/contributing_examples/example.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Example Dataset Loader
 
 .. admonition:: Dataset Info

--- a/docs/source/contributing_examples/make_example_index.py
+++ b/docs/source/contributing_examples/make_example_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import argparse
 import glob
 import json

--- a/docs/source/contributing_examples/test_example.py
+++ b/docs/source/contributing_examples/test_example.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata import annotations

--- a/mirdata/__init__.py
+++ b/mirdata/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import importlib
 import os
 import pkgutil

--- a/mirdata/core.py
+++ b/mirdata/core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Core mirdata classes
 """
 import json

--- a/mirdata/datasets/acousticbrainz_genre.py
+++ b/mirdata/datasets/acousticbrainz_genre.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Acoustic Brainz Genre dataset
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/beatles.py
+++ b/mirdata/datasets/beatles.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Beatles Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/beatport_key.py
+++ b/mirdata/datasets/beatport_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """beatport_key Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/cante100.py
+++ b/mirdata/datasets/cante100.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 cante100 Loader
 

--- a/mirdata/datasets/dali.py
+++ b/mirdata/datasets/dali.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """DALI Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/giantsteps_key.py
+++ b/mirdata/datasets/giantsteps_key.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """giantsteps_key Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/giantsteps_tempo.py
+++ b/mirdata/datasets/giantsteps_tempo.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """giantsteps_tempo Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/groove_midi.py
+++ b/mirdata/datasets/groove_midi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Groove MIDI Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/gtzan_genre.py
+++ b/mirdata/datasets/gtzan_genre.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """GTZAN-Genre Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """GuitarSet Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/ikala.py
+++ b/mirdata/datasets/ikala.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """iKala Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/irmas.py
+++ b/mirdata/datasets/irmas.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 IRMAS Loader
 

--- a/mirdata/datasets/maestro.py
+++ b/mirdata/datasets/maestro.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """MAESTRO Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/medley_solos_db.py
+++ b/mirdata/datasets/medley_solos_db.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Medley-solos-DB Dataset Loader.
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/medleydb_melody.py
+++ b/mirdata/datasets/medleydb_melody.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """MedleyDB melody Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/medleydb_pitch.py
+++ b/mirdata/datasets/medleydb_pitch.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """MedleyDB pitch Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/mridangam_stroke.py
+++ b/mirdata/datasets/mridangam_stroke.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Mridangam Stroke Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/orchset.py
+++ b/mirdata/datasets/orchset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """ORCHSET Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/rwc_classical.py
+++ b/mirdata/datasets/rwc_classical.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """RWC Classical Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/rwc_jazz.py
+++ b/mirdata/datasets/rwc_jazz.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """RWC Jazz Dataset Loader.
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/rwc_popular.py
+++ b/mirdata/datasets/rwc_popular.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """RWC Popular Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/salami.py
+++ b/mirdata/datasets/salami.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """SALAMI Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/saraga_carnatic.py
+++ b/mirdata/datasets/saraga_carnatic.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Saraga Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/saraga_hindustani.py
+++ b/mirdata/datasets/saraga_hindustani.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Saraga Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/tinysol.py
+++ b/mirdata/datasets/tinysol.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """TinySOL Dataset Loader.
 
 .. admonition:: Dataset Info

--- a/mirdata/datasets/tonality_classicaldb.py
+++ b/mirdata/datasets/tonality_classicaldb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Tonality classicalDB Dataset Loader
 
 .. admonition:: Dataset Info

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utilities for downloading from the web.
 """
 

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utilities for converting mirdata Annotation objects to jams format.
 """
 import os

--- a/mirdata/validate.py
+++ b/mirdata/validate.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Utility functions for mirdata"""
 
 import hashlib

--- a/mirdata/version.py
+++ b/mirdata/version.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 """Version info"""
 
 short_version = "0.3"

--- a/scripts/legacy/make_gtzan_genre_index.py
+++ b/scripts/legacy/make_gtzan_genre_index.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-
-
 import os
 import sys
 import json

--- a/scripts/legacy/make_ikala_index.py
+++ b/scripts/legacy/make_ikala_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import argparse
 import glob
 import json

--- a/scripts/legacy/make_rwc_classical_index.py
+++ b/scripts/legacy/make_rwc_classical_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import argparse
 import hashlib
 import json

--- a/scripts/legacy/make_rwc_jazz_index.py
+++ b/scripts/legacy/make_rwc_jazz_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import argparse
 import hashlib
 import json

--- a/scripts/legacy/make_rwc_popular_index.py
+++ b/scripts/legacy/make_rwc_popular_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import argparse
 import hashlib
 import json

--- a/scripts/legacy/update_index.py
+++ b/scripts/legacy/update_index.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # This script modifies indexes from mirdata <= 0.3.0b0 to support versions, and to check integrity of
 # tracks, multitracks, metadata and tables. The structure of indexes will now be:
 #

--- a/scripts/print_track_docstring.py
+++ b/scripts/print_track_docstring.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import argparse
 import importlib
 import itertools

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import pytest
 import os
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import sys
 import pytest
 import numpy as np

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import beatles

--- a/tests/test_beatport_key.py
+++ b/tests/test_beatport_key.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import beatport_key

--- a/tests/test_cante100.py
+++ b/tests/test_cante100.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import numpy as np
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 import numpy as np
 

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 import shutil
 import sys

--- a/tests/test_full_dataset.py
+++ b/tests/test_full_dataset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This test takes a long time, but it makes sure that the datset can be locally downloaded,
 validated successfully, and loaded.

--- a/tests/test_giantsteps_key.py
+++ b/tests/test_giantsteps_key.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import giantsteps_key

--- a/tests/test_giantsteps_tempo.py
+++ b/tests/test_giantsteps_tempo.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import giantsteps_tempo

--- a/tests/test_groove_midi.py
+++ b/tests/test_groove_midi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import pretty_midi
 import shutil

--- a/tests/test_gtzan_genre.py
+++ b/tests/test_gtzan_genre.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from tests.test_utils import run_track_tests

--- a/tests/test_guitarset.py
+++ b/tests/test_guitarset.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import jams
 

--- a/tests/test_ikala.py
+++ b/tests/test_ikala.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import ikala

--- a/tests/test_initialize.py
+++ b/tests/test_initialize.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import pytest
 
 from mirdata import core

--- a/tests/test_irmas.py
+++ b/tests/test_irmas.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from tests.test_utils import run_track_tests

--- a/tests/test_jams_utils.py
+++ b/tests/test_jams_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pytest
 import jams

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import importlib
 import inspect
 from inspect import signature

--- a/tests/test_maestro.py
+++ b/tests/test_maestro.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import shutil
 import pretty_midi

--- a/tests/test_medley_solos_db.py
+++ b/tests/test_medley_solos_db.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from mirdata.datasets import medley_solos_db
 from tests.test_utils import run_track_tests
 

--- a/tests/test_medleydb_melody.py
+++ b/tests/test_medleydb_melody.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import medleydb_melody

--- a/tests/test_medleydb_pitch.py
+++ b/tests/test_medleydb_pitch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import medleydb_pitch

--- a/tests/test_mridangam_stroke.py
+++ b/tests/test_mridangam_stroke.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import os
 
 from tests.test_utils import run_track_tests

--- a/tests/test_orchset.py
+++ b/tests/test_orchset.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os, shutil
 import numpy as np
 

--- a/tests/test_rwc_classical.py
+++ b/tests/test_rwc_classical.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import rwc_classical

--- a/tests/test_rwc_jazz.py
+++ b/tests/test_rwc_jazz.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from mirdata.datasets import rwc_jazz
 from mirdata import annotations
 from tests.test_utils import run_track_tests

--- a/tests/test_rwc_popular.py
+++ b/tests/test_rwc_popular.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import rwc_popular

--- a/tests/test_salami.py
+++ b/tests/test_salami.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 from mirdata.datasets import salami
 from mirdata import annotations

--- a/tests/test_saraga_carnatic.py
+++ b/tests/test_saraga_carnatic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 from mirdata import annotations
 from mirdata.datasets import saraga_carnatic

--- a/tests/test_saraga_hindustani.py
+++ b/tests/test_saraga_hindustani.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 from mirdata import annotations
 from mirdata.datasets import saraga_hindustani

--- a/tests/test_tinysol.py
+++ b/tests/test_tinysol.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import numpy as np
 
 from mirdata.datasets import tinysol

--- a/tests/test_tonality_classicaldb.py
+++ b/tests/test_tonality_classicaldb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import sys
 
 import librosa

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 import itertools
 import os
 import sys


### PR DESCRIPTION
It is a legacy from Python2 support. However, currently, python2 is not supported by mirdata