### PR TITLE
Billboard audio is not available on request

### DIFF
--- a/docs/source/table.rst
+++ b/docs/source/table.rst
@@ -38,7 +38,7 @@
           :target: https://creativecommons.org/licenses/by-sa/4.0
 
    * - Billboard (McGill)
-     - - audio: 🔑
+     - - audio: ❌
        - annotations: ✅
      - - :ref:`chords`
        - :ref:`sections`


### PR DESCRIPTION
A one-liner indicating that, unfortunately, the Billboard audio is not available on request. I reached out to Ashley Burgoyne (the dataset's creator) who informed me that the audio could not be shared. CC @Spijkervet who originally added the dataset to this library, on the off chance that there is some other path for obtaining the audio.