### PR TITLE
Add to_mir_eval for NoteData, MultiF0Data, and F0Data

### DIFF
--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -624,11 +624,11 @@ class MultiF0Data(Annotation):
 
         Returns:
             * times (np.ndarray): array of uniformly spaced time stamps in seconds
-            * frequency_list (list): list of lists of frequency values in Hz
+            * frequency_list (list): list of np.array of frequency values in Hz
         """
         times = convert_time_units(self.times, self.time_unit, "s")
         frequency_list = [
-            convert_pitch_units(flist, self.frequency_unit, "hz")
+            convert_pitch_units(np.array(flist), self.frequency_unit, "hz")
             for flist in self.frequency_list
         ]
         return times, frequency_list

--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -412,6 +412,19 @@ class F0Data(Annotation):
         matrix[index[:, 0], index[:, 1]] = voicing
         return matrix
 
+    def to_mir_eval(self):
+        """Convert units and format to what is expected by mir_eval.melody.evaluate
+
+        Returns:
+            * times (np.ndarray) - uniformly spaced times in seconds
+            * frequencies (np.ndarray) - frequency values in hz
+            * voicing (np.ndarray) - voicings, as likelihood values
+        """
+        times = convert_time_units(self.times, self.time_unit, "s")
+        frequencies = convert_pitch_units(self.frequencies, self.frequency_unit, "hz")
+        voicing = convert_amplitude_units(self.voicing, self.voicing_unit, "likelihood")
+        return times, frequencies, voicing
+
 
 class MultiF0Data(Annotation):
     """MultiF0Data class
@@ -605,6 +618,20 @@ class MultiF0Data(Annotation):
         matrix = np.zeros((len(time_scale), len(frequency_scale)))
         matrix[index[:, 0], index[:, 1]] = voicing
         return matrix
+
+    def to_mir_eval(self):
+        """Convert annotation into the format expected by mir_eval.multipitch.evaluate
+
+        Returns:
+            * times (np.ndarray): array of uniformly spaced time stamps in seconds
+            * frequency_list (list): list of lists of frequency values in Hz
+        """
+        times = convert_time_units(self.times, self.time_unit, "s")
+        frequency_list = [
+            convert_pitch_units(flist, self.frequency_unit, "hz")
+            for flist in self.frequency_list
+        ]
+        return times, frequency_list
 
 
 class NoteData(Annotation):
@@ -820,6 +847,26 @@ class NoteData(Annotation):
             None if self.confidence is None else confidence_list,
             self.confidence_unit,
         )
+
+    def to_mir_eval(self):
+        """Convert data to the format expected by mir_eval.transcription.evaluate and
+        mir_eval.transcription_velocity.evaluate
+
+        Returns:
+            * intervals (np.ndarray) - (n x 2) array of intervals of start time, end time in seconds
+            * pitches (np.ndarray) - array of pitch values in hz
+            * velocity (optional, np.ndarray) - array of velocity values between 0 and 127
+        """
+        intervals = convert_time_units(self.intervals, self.interval_unit, "s")
+        pitches = convert_pitch_units(self.pitches, self.pitch_unit, "hz")
+        velocity = (
+            None
+            if self.confidence is None
+            else convert_amplitude_units(
+                self.confidence, self.confidence_unit, "velocity"
+            )
+        )
+        return intervals, pitches, velocity
 
 
 class KeyData(Annotation):

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -231,7 +231,7 @@ class Track(core.Track):
     @core.cached_property
     def multif0(self) -> annotations.MultiF0Data:
         contours: List[annotations.F0Data] = list(self.pitch_contours.values())
-        max_times = np.argmax(
+        max_times: int = np.argmax(
             [
                 0 if contour_data is None else len(contour_data.times)
                 for contour_data in contours

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -53,7 +53,7 @@
 """
 import logging
 import os
-from typing import BinaryIO, Optional, TextIO, Tuple
+from typing import BinaryIO, Optional, TextIO, Tuple, Dict
 
 import jams
 import librosa
@@ -154,6 +154,7 @@ class Track(core.Track):
             - 'G': F0Data(...)
             - 'B': F0Data(...)
             - 'e': F0Data(...)
+        multif0 (MultiF0Data): all pitch contour data as one multif0 annotation
         notes (dict):
             Notes per string
             - 'E': NoteData(...)
@@ -162,6 +163,7 @@ class Track(core.Track):
             - 'G': NoteData(...)
             - 'B': NoteData(...)
             - 'e': NoteData(...)
+        notes_all (NoteData): all note data as one note annotation
 
     """
 
@@ -219,7 +221,7 @@ class Track(core.Track):
         return load_key_mode(self.jams_path)
 
     @core.cached_property
-    def pitch_contours(self):
+    def pitch_contours(self) -> Dict[annotations.F0Data]:
         contours = {}
         # iterate over 6 strings
         for i in range(6):
@@ -227,12 +229,33 @@ class Track(core.Track):
         return contours
 
     @core.cached_property
-    def notes(self):
+    def multif0(self) -> annotations.MultiF0Data:
+        contours = self.pitch_contours.values()
+        max_times = np.argmax([len(contour_data.times) for contour_data in contours])
+        times = contours[max_times].times
+        frequency_list = [[] for _ in times]
+        for contour in contours:
+            for i, f in enumerate(contour.frequencies):
+                if f > 0:
+                    frequency_list[i].append(f)
+        return annotations.MultiF0Data(times, "s", frequency_list, "hz")
+
+    @core.cached_property
+    def notes(self) -> Dict[annotations.NoteData]:
         notes = {}
         # iterate over 6 strings
         for i in range(6):
             notes[_GUITAR_STRINGS[i]] = load_notes(self.jams_path, i)
         return notes
+
+    @core.cached_property
+    def notes_all(self) -> annotations.NoteData:
+        intervals = []
+        pitches = []
+        for note_data in self.notes.values():
+            intervals.extend(note_data.intervals)
+            pitches.extend(note_data.pitches)
+        return annotations.NoteData(intervals, "s", pitches, "midi")
 
     @property
     def audio_mic(self) -> Optional[Tuple[np.ndarray, float]]:

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -230,7 +230,7 @@ class Track(core.Track):
 
     @core.cached_property
     def multif0(self) -> annotations.MultiF0Data:
-        contours = list(self.pitch_contours.values())
+        contours: List[annotations.F0Data] = list(self.pitch_contours.values())
         max_times = np.argmax(
             [
                 0 if contour_data is None else len(contour_data.times)

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -53,7 +53,7 @@
 """
 import logging
 import os
-from typing import BinaryIO, Optional, TextIO, Tuple, Dict
+from typing import BinaryIO, Optional, TextIO, Tuple, Dict, List
 
 import jams
 import librosa
@@ -238,7 +238,7 @@ class Track(core.Track):
             ],
         )
         times = contours[max_times].times
-        frequency_list = [[] for _ in times]
+        frequency_list: List[list] = [[] for _ in times]
         for contour in contours:
             if contour is None:
                 continue

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -231,13 +231,13 @@ class Track(core.Track):
     @core.cached_property
     def multif0(self) -> annotations.MultiF0Data:
         contours: List[annotations.F0Data] = list(self.pitch_contours.values())
-        max_times: int = np.argmax(
+        max_times = np.argmax(
             [
                 0 if contour_data is None else len(contour_data.times)
                 for contour_data in contours
             ],
-        )
-        times = contours[max_times].times
+        )  # type: ignore
+        times = contours[max_times].times  # type: ignore
         frequency_list: List[list] = [[] for _ in times]
         for contour in contours:
             if contour is None:

--- a/tests/datasets/test_guitarset.py
+++ b/tests/datasets/test_guitarset.py
@@ -37,7 +37,9 @@ def test_track():
         "inferred_chords": annotations.ChordData,
         "key_mode": annotations.KeyData,
         "pitch_contours": dict,
+        "multif0": annotations.MultiF0Data,
         "notes": dict,
+        "notes_all": annotations.NoteData
         "audio_mic": tuple,
         "audio_mix": tuple,
         "audio_hex": tuple,

--- a/tests/datasets/test_guitarset.py
+++ b/tests/datasets/test_guitarset.py
@@ -39,7 +39,7 @@ def test_track():
         "pitch_contours": dict,
         "multif0": annotations.MultiF0Data,
         "notes": dict,
-        "notes_all": annotations.NoteData
+        "notes_all": annotations.NoteData,
         "audio_mic": tuple,
         "audio_mix": tuple,
         "audio_hex": tuple,
@@ -53,6 +53,39 @@ def test_track():
 
     assert isinstance(track.pitch_contours["e"], annotations.F0Data)
     assert isinstance(track.notes["e"], annotations.NoteData)
+
+
+def test_notes_and_all_notes():
+    dataset = guitarset.Dataset(TEST_DATA_HOME)
+    track = dataset.track("03_BN3-119-G_solo")
+    notes_all = track.notes_all
+    for note in track.notes.values():
+        if note is None:
+            continue
+        for interval, pitch in zip(note.intervals, note.pitches):
+            assert interval in notes_all.intervals
+            assert pitch in notes_all.pitches
+        assert note.interval_unit == notes_all.interval_unit
+        assert note.pitch_unit == notes_all.pitch_unit
+        assert note.confidence_unit == notes_all.confidence_unit
+
+
+def test_contours_and_multif0():
+    dataset = guitarset.Dataset(TEST_DATA_HOME)
+    track = dataset.track("03_BN3-119-G_solo")
+    multif0 = track.multif0
+    for contour in track.pitch_contours.values():
+        if contour is None:
+            continue
+        assert np.allclose(contour.times[:100], multif0.times[:100])
+        for i, f in enumerate(contour.frequencies):
+            if f > 0:
+                assert f in multif0.frequency_list[i]
+            else:
+                assert f not in multif0.frequency_list[i]
+
+        assert contour.time_unit == multif0.time_unit
+        assert contour.frequency_unit == multif0.frequency_unit
 
 
 def test_fill_pitch_contour():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,5 +1,6 @@
 import sys
 import pytest
+import mir_eval
 import numpy as np
 
 import mirdata
@@ -286,6 +287,12 @@ def test_note_data():
     assert np.allclose(intervals_me, intervals)
     assert np.allclose(pitches_me, notes)
     assert np.allclose(velocity_me, np.array([0, 127.0, 127.0]))
+    scores = mir_eval.transcription.evaluate(
+        intervals_me, pitches_me, intervals_me, pitches_me
+    )
+    scores = mir_eval.transcription_velocity.evaluate(
+        intervals_me, pitches_me, velocity_me, intervals_me, pitches_me, velocity_me
+    )
 
     note_data = annotations.NoteData(
         intervals, "ms", np.array([60.0, 70.0, 100.0]), "midi"
@@ -296,6 +303,9 @@ def test_note_data():
     )
     assert np.allclose(pitches_me, np.array([261.6255653, 466.16376152, 2637.0204553]))
     assert velocity_me is None
+    scores = mir_eval.transcription.evaluate(
+        intervals_me, pitches_me, intervals_me, pitches_me
+    )
 
 
 def test_chord_data():
@@ -441,6 +451,9 @@ def test_f0_data():
     assert np.allclose(times_me, times)
     assert np.allclose(frequencies, frequency_me)
     assert np.allclose(voicing, voicing_me)
+    scores = mir_eval.melody.evaluate(
+        times_me, frequency_me, times_me, frequency_me, voicing_me, voicing_me
+    )
 
 
 def test_multif0_data():
@@ -524,7 +537,11 @@ def test_multif0_data():
 
     times_me, frequencies_me = f0_data.to_mir_eval()
     assert np.allclose(times_me, times)
-    assert frequencies_me == frequencies
+    for flist, farr in zip(frequencies, frequencies_me):
+        assert np.allclose(flist, farr)
+    scores = mir_eval.multipitch.evaluate(
+        times_me, frequencies_me, times_me, frequencies_me
+    )
 
 
 def test_key_data():

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -278,6 +278,25 @@ def test_note_data():
     with pytest.raises(ValueError):
         mf0_data = note_data.to_multif0(0.5, "s", max_time=2.5)
 
+    # test to mireval
+    note_data = annotations.NoteData(
+        intervals, "s", notes, "hz", np.array([0.0, 1.0, 1.0]), "binary"
+    )
+    intervals_me, pitches_me, velocity_me = note_data.to_mir_eval()
+    assert np.allclose(intervals_me, intervals)
+    assert np.allclose(pitches_me, notes)
+    assert np.allclose(velocity_me, np.array([0, 127.0, 127.0]))
+
+    note_data = annotations.NoteData(
+        intervals, "ms", np.array([60.0, 70.0, 100.0]), "midi"
+    )
+    intervals_me, pitches_me, velocity_me = note_data.to_mir_eval()
+    assert np.allclose(
+        intervals_me, np.array([[0.001, 0.002], [0.0015, 0.003], [0.002, 0.003]])
+    )
+    assert np.allclose(pitches_me, np.array([261.6255653, 466.16376152, 2637.0204553]))
+    assert velocity_me is None
+
 
 def test_chord_data():
     intervals = np.array([[1.0, 2.0], [1.5, 3.0], [2.0, 3.0]])
@@ -417,6 +436,12 @@ def test_f0_data():
     )
     assert np.allclose(matrix, expected_matrix)
 
+    # test to mir_eval
+    times_me, frequency_me, voicing_me = f0_data.to_mir_eval()
+    assert np.allclose(times_me, times)
+    assert np.allclose(frequencies, frequency_me)
+    assert np.allclose(voicing, voicing_me)
+
 
 def test_multif0_data():
     times = np.array([1.0, 2.0])
@@ -496,6 +521,10 @@ def test_multif0_data():
         ]
     )
     assert np.allclose(matrix, matrix_expected)
+
+    times_me, frequencies_me = f0_data.to_mir_eval()
+    assert np.allclose(times_me, times)
+    assert frequencies_me == frequencies
 
 
 def test_key_data():


### PR DESCRIPTION
Part of #502  -
* adds `to_mir_eval` methods to NoteData, MultiF0Data, and F0Data

Adds two new cached properties to Guitarset:
* `Track.notes_all` (a combination of `Track.notes` across all strings)
* `Track.multif0` (a combination of `Track.pitch_contours` across all strings)