### PR TITLE
pin music 21 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,6 @@ if __name__ == "__main__":
                 "sphinx_rtd_theme",
             ],
             "dali": ["dali-dataset==1.1"],
-            "haydn_op20": ["music21"],
+            "haydn_op20": ["music21==6.7.1"],
         },
     )


### PR DESCRIPTION
The latest builds are all failing because music21 updated in an incompatible way and we hand't pinned the version. This pins it!