### PR TITLE
[WIP] Adding annotations.Tags and reformatting to_jams

### DIFF
--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -76,6 +76,29 @@ class Annotation(object):
         return repr_str
 
 
+class Tags(Annotation):
+    """Tags class
+    Attributes:
+        labels (list): list of string tags
+        confidence (np.ndarray or None): array of confidence values, float in [0, 1]
+        labels_unit (str): labels unit, one of LABELS_UNITS
+        time (float): time of the tag (default is 0.0)
+        duration (float): duration of the tag (default is None)
+    """
+
+    def __init__(self, labels, labels_unit, confidence=None) -> None:
+
+        validate_array_like(labels, list, str)
+        validate_array_like(confidence, np.ndarray, float, none_allowed=True)
+        validate_confidence(confidence)
+        validate_lengths_equal([labels, confidence])
+        validate_unit(labels_unit, LABEL_UNITS)
+
+        self.labels = labels
+        self.confidence = confidence
+        self.labels_unit = labels_unit
+
+
 class BeatData(Annotation):
     """BeatData class
 

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -554,17 +554,25 @@ def lyrics_to_jams(lyric_data, description=None):
 
 
 def tag_to_jams(tag_data, namespace="tag_open", description=None):
-    """Convert lyric annotations into jams format.
+    """Convert tag annotations into jams format.
 
     Args:
-        lyric_data (annotations.LyricData): lyric annotation object
+        tags (annotations.Tags): tags annotation object
         namespace (str): the jams-compatible tag namespace
-        description (str): annotation descriptoin
+        description (str): annotation description (default is None)
 
     Returns:
         jams.Annotation: jams annotation object.
 
     """
+    ann = jams.Annotation(namespace=namespace)
+    ann.annotation_metadata = jams.AnnotationMetadata(data_source="mirdata")
+    for t, c in zip(tag_data.labels, tag_data.confidence):
+        ann.append(time=0.0, duration=duration, value=t, confidence=c)
+    if description is not None:
+        ann.sandbox = jams.Sandbox(name=description)
+    return ann
+
     jannot_tag = jams.Annotation(namespace=namespace)
     jannot_tag.annotation_metadata = jams.AnnotationMetadata(data_source="mirdata")
     if tag_data is not None:


### PR DESCRIPTION
This PR fixes #540 and #541. ccing @bmcfee

While looking at the `to_jams` functions I realized that they are unnecessarily complicated to accommodate `Salami` multi-annotator schema. I'm going to simplify the `to_jams` converters so they don't expect the list of tuples anymore (which will simplify `jams_utils` a lot) and will address the multi-annotator of Salami using #515 and mirroring [this PR from Soundata](here).

@rabitt check if I'm not duplicating work or stepping on your #545.