### PR TITLE
tests currently fail for extractall_unicode after a package update

### DIFF
--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -320,8 +320,11 @@ def extractall_unicode(zfile, out_dir):
             "cp437"
         ).decode(errors="ignore") != filename:
             filename_bytes = filename.encode("cp437")
-            guessed_encoding = chardet.detect(filename_bytes)["encoding"] or "utf8"
-            filename = filename_bytes.decode(guessed_encoding, "replace")
+            if filename_bytes.decode('utf-8', "replace")!=filename_bytes.decode(errors="ignore"):
+                guessed_encoding = chardet.detect(filename_bytes)["encoding"] or "utf8"
+                filename = filename_bytes.decode(guessed_encoding, "replace")
+            else:
+                filename = filename_bytes.decode("utf-8", "replace")
 
         disk_file_name = os.path.join(out_dir, filename)
 


### PR DESCRIPTION
after a package update of charted or zipfile, the main branch got broken. 
we need to deal with zip archives created under windows and unicode filenames differently. thus I have added another if branch to deal with these cases separately. 