### PR TITLE
Update array validation check to avoid VisibleDeprecationWarning

### DIFF
--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -1420,7 +1420,7 @@ def validate_array_like(array_like, expected_type, expected_dtype, none_allowed=
             f"Array should have dtype {expected_dtype} but has {array_like.dtype}"
         )
 
-    if np.asarray(array_like).size == 0:
+    if np.asarray(array_like, dtype=object).size == 0:
         raise ValueError("Object should not be empty, use None instead")
 
 


### PR DESCRIPTION
As of now, numpy throws a VisibleDeprecationWarning when creating an array from ragged nested sequences. I ran into this warning executing `mirdata.annotations.MultiF0Data.to_matrix()`.

> mirdata\annotations.py:1423: VisibleDeprecationWarning: Creating an ndarray from ragged nested sequences (which is a list-or-tuple of lists-or-tuples-or ndarrays with different lengths or shapes) is deprecated. If you meant to do this, you must specify 'dtype=object' when creating the ndarray.
> if np.asarray(array_like).size == 0:

This can be easily suppressed with the proposed update.