### PR TITLE
580 mirdata multiple fixes

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ autodoc_mock_imports = [
     "scipy",
     "smart_open",
     "openpyxl",
+    "pandas",
 ]
 
 # # -- General configuration ---------------------------------------------------

--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -1288,7 +1288,9 @@ def convert_pitch_units(pitches, pitch_unit, target_pitch_unit):
             return pitches_midi
 
         if target_pitch_unit == "note_name":
-            return librosa.hz_to_note(pitches_hz)
+            # cast to np.array for compatibility with legacy python3.6 and
+            # librosa 0.9.2. It is redundant for librosa 0.10
+            return np.array(librosa.hz_to_note(pitches_hz))
 
         raise NotImplementedError
 

--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -823,7 +823,6 @@ class NoteData(Annotation):
             self.confidence = self.confidence[unq_idx]
 
     def __add__(self, other):
-
         if other is None:
             return self
 
@@ -1006,7 +1005,6 @@ class NoteData(Annotation):
         frequency_list: List[List[float]] = [[] for _ in times]
         confidence_list: List[List[float]] = [[] for _ in times]
         if self.confidence is not None:
-
             for t0, t1, pch, conf in zip(
                 intervals[:, 0], intervals[:, 1], self.pitches, self.confidence
             ):

--- a/mirdata/datasets/billboard.py
+++ b/mirdata/datasets/billboard.py
@@ -330,7 +330,6 @@ def load_named_sections(fpath: str):
 
 
 def _load_sections(fpath: str, section_type: str):
-
     timed_sections = _parse_timed_sections(fpath)
     assert timed_sections is not None
 

--- a/mirdata/datasets/dagstuhl_choirset.py
+++ b/mirdata/datasets/dagstuhl_choirset.py
@@ -118,7 +118,6 @@ class Track(core.Track):
     """
 
     def __init__(self, track_id, data_home, dataset_name, index, metadata):
-
         super().__init__(
             track_id=track_id,
             data_home=data_home,
@@ -265,7 +264,6 @@ class MultiTrack(core.MultiTrack):
     def __init__(
         self, mtrack_id, data_home, dataset_name, index, track_class, metadata
     ):
-
         super().__init__(
             mtrack_id=mtrack_id,
             data_home=data_home,

--- a/mirdata/datasets/egfxset.py
+++ b/mirdata/datasets/egfxset.py
@@ -205,7 +205,7 @@ class Track(core.Track):
         setting (list): the setting of the effect recorded or "None" when the recording is a clean effect sound
 
     Cached Properties:
-        note_name (list): a list with the note name annotation of the audio file (e.g. "Ab5", "C6", etc.)
+        note_name (ndarray): a list with the note name annotation of the audio file (e.g. "Ab5", "C6", etc.)
         midinote (NoteData): the midinote annotation of the audio file
     """
 

--- a/mirdata/datasets/egfxset.py
+++ b/mirdata/datasets/egfxset.py
@@ -337,7 +337,6 @@ class Dataset(core.Dataset):
             indexname.append(name["Effect "].split(" ")[0])
 
         for track in tracknames:
-
             if track[:3] == "RAT":
                 trackiden = track[:3].lower()
 

--- a/mirdata/datasets/filosax.py
+++ b/mirdata/datasets/filosax.py
@@ -281,7 +281,6 @@ class Track(core.Track):
     """
 
     def __init__(self, track_id, data_home, dataset_name, index, metadata):
-
         super().__init__(
             track_id,
             data_home,

--- a/mirdata/datasets/orchset.py
+++ b/mirdata/datasets/orchset.py
@@ -266,7 +266,6 @@ class Dataset(core.Dataset):
 
     @core.cached_property
     def _metadata(self):
-
         predominant_inst_path = os.path.join(
             self.data_home, "Orchset - Predominant Melodic Instruments.csv"
         )

--- a/mirdata/datasets/rwc_classical.py
+++ b/mirdata/datasets/rwc_classical.py
@@ -387,7 +387,6 @@ class Dataset(core.Dataset):
 
     @core.cached_property
     def _metadata(self):
-
         metadata_path = os.path.join(self.data_home, "metadata-master", "rwc-c.csv")
 
         try:

--- a/mirdata/datasets/rwc_jazz.py
+++ b/mirdata/datasets/rwc_jazz.py
@@ -240,7 +240,6 @@ class Dataset(core.Dataset):
 
     @core.cached_property
     def _metadata(self):
-
         metadata_path = os.path.join(self.data_home, "metadata-master", "rwc-j.csv")
 
         try:

--- a/mirdata/datasets/rwc_popular.py
+++ b/mirdata/datasets/rwc_popular.py
@@ -322,7 +322,6 @@ class Dataset(core.Dataset):
 
     @core.cached_property
     def _metadata(self):
-
         metadata_path = os.path.join(self.data_home, "metadata-master", "rwc-p.csv")
 
         try:

--- a/mirdata/datasets/salami.py
+++ b/mirdata/datasets/salami.py
@@ -282,7 +282,6 @@ class Dataset(core.Dataset):
 
     @core.cached_property
     def _metadata(self):
-
         metadata_path = os.path.join(
             self.data_home,
             os.path.join(

--- a/mirdata/datasets/saraga_hindustani.py
+++ b/mirdata/datasets/saraga_hindustani.py
@@ -306,7 +306,6 @@ def load_tempo(fhandle):
 
     reader = csv.reader(fhandle, delimiter=",")
     for line in reader:
-
         if "NaN" in line or " NaN" in line or "NaN " in line:
             return None
 

--- a/mirdata/datasets/slakh.py
+++ b/mirdata/datasets/slakh.py
@@ -121,7 +121,6 @@ class Track(core.Track):
     """
 
     def __init__(self, track_id, data_home, dataset_name, index, metadata):
-
         super().__init__(
             track_id,
             data_home,

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -146,7 +146,6 @@ def downloader(
 
             if remotes[k].unpack_directories:
                 for src_dir in remotes[k].unpack_directories:
-
                     # path to destination directory
                     destination_dir = (
                         os.path.join(save_dir, remotes[k].destination_dir)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
         keywords="mir dataset loader audio",
         license="BSD-3-Clause",
         install_requires=[
-            "black == 23.1.0",
+            "black == 22.8.0",  # last version for python3.6
             "tqdm",
             "librosa >= 0.9.2",
             "numpy>=1.16",

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         install_requires=[
             "black == 23.1.0",
             "tqdm",
-            "librosa >= 0.8.0",
+            "librosa >= 0.9.2",
             "numpy>=1.16",
             "jams",
             "requests",

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ if __name__ == "__main__":
         keywords="mir dataset loader audio",
         license="BSD-3-Clause",
         install_requires=[
+            "black == 23.1.0",
             "tqdm",
             "librosa >= 0.8.0",
             "numpy>=1.16",

--- a/tests/datasets/test_acousticbrainz_genre.py
+++ b/tests/datasets/test_acousticbrainz_genre.py
@@ -60,7 +60,6 @@ def test_to_jams():
 
 
 def test_filter_index():
-
     data_home = os.path.normpath("tests/resources/mir_datasets/acousticbrainz_genre")
     dataset = acousticbrainz_genre.Dataset(data_home, version="test")
     index = dataset.load_all_train()
@@ -84,7 +83,6 @@ def test_filter_index():
 
 
 def test_download(httpserver):
-
     data_home = os.path.normpath(
         "tests/resources/mir_datasets/acousticbrainz_genre_download"
     )

--- a/tests/datasets/test_beatles.py
+++ b/tests/datasets/test_beatles.py
@@ -61,7 +61,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = os.path.normpath("tests/resources/mir_datasets/beatles")
     dataset = beatles.Dataset(data_home)
     track = dataset.track("0111")

--- a/tests/datasets/test_billboard.py
+++ b/tests/datasets/test_billboard.py
@@ -5,7 +5,6 @@ from mirdata import annotations
 
 
 def test_track():
-
     default_trackid = "3"
     data_home = "tests/resources/mir_datasets/billboard"
     dataset = billboard.Dataset(data_home)
@@ -71,7 +70,6 @@ def test_track():
 
 
 def test_to_jams():
-
     default_trackid = "3"
     data_home = "tests/resources/mir_datasets/billboard"
     dataset = billboard.Dataset(data_home)

--- a/tests/datasets/test_dagstuhl_choirset.py
+++ b/tests/datasets/test_dagstuhl_choirset.py
@@ -166,7 +166,6 @@ def test_load_f0():
 
 
 def test_load_score():
-
     score_path = "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_scorerepresentation/DCS_LI_QuartetB_Take04_Stereo_STM_B.csv"
     score = dagstuhl_choirset.load_score(score_path)
     assert isinstance(score, annotations.NoteData)
@@ -194,7 +193,6 @@ def test_load_score():
 
 
 def test_load_beat():
-
     beat_path = "tests/resources/mir_datasets/dagstuhl_choirset/annotations_csv_beat/DCS_LI_QuartetB_Take04_Stereo_STM.csv"
     beat = dagstuhl_choirset.load_beat(beat_path)
     assert isinstance(beat, annotations.BeatData)

--- a/tests/datasets/test_dali.py
+++ b/tests/datasets/test_dali.py
@@ -17,7 +17,6 @@ import numpy as np
 
 
 def test_track():
-
     default_trackid = "4b196e6c99574dd49ad00d56e132712b"
     data_home = os.path.normpath("tests/resources/mir_datasets/dali")
     dataset = dali.Dataset(data_home)

--- a/tests/datasets/test_egfxset.py
+++ b/tests/datasets/test_egfxset.py
@@ -95,7 +95,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = os.path.normpath("tests/resources/mir_datasets/egfxset")
     dataset = egfxset.Dataset(data_home, version="test")
 

--- a/tests/datasets/test_egfxset.py
+++ b/tests/datasets/test_egfxset.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 from mirdata import annotations
 from mirdata.datasets import egfxset
 from tests.test_utils import run_track_tests
@@ -35,7 +36,7 @@ def test_track():
 
     expected_property_types = {
         "audio": tuple,
-        "note_name": list,
+        "note_name": np.ndarray,
         "midinote": annotations.NoteData,
     }
 
@@ -74,7 +75,7 @@ def test_track():
 
     expected_property_types = {
         "audio": tuple,
-        "note_name": list,
+        "note_name": np.ndarray,
         "midinote": annotations.NoteData,
     }
 

--- a/tests/datasets/test_ikala.py
+++ b/tests/datasets/test_ikala.py
@@ -77,7 +77,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/ikala"
     default_trackid = "10161_chorus"
     dataset = ikala.Dataset(data_home)

--- a/tests/datasets/test_medley_solos_db.py
+++ b/tests/datasets/test_medley_solos_db.py
@@ -31,7 +31,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/medley_solos_db"
     dataset = medley_solos_db.Dataset(data_home)
     track = dataset.track("d07b1fc0-567d-52c2-fef4-239f31c9d40e")

--- a/tests/datasets/test_medleydb_melody.py
+++ b/tests/datasets/test_medleydb_melody.py
@@ -53,7 +53,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/medleydb_melody"
     dataset = medleydb_melody.Dataset(data_home)
     track = dataset.track("MusicDelta_Beethoven")

--- a/tests/datasets/test_medleydb_pitch.py
+++ b/tests/datasets/test_medleydb_pitch.py
@@ -46,7 +46,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/medleydb_pitch"
     dataset = medleydb_pitch.Dataset(data_home)
     track = dataset.track("AClassicEducation_NightOwl_STEM_08")

--- a/tests/datasets/test_mtg_jamendo_autotagging_moodtheme.py
+++ b/tests/datasets/test_mtg_jamendo_autotagging_moodtheme.py
@@ -70,7 +70,6 @@ def test_to_jams():
 
 
 def test_get_track_splits():
-
     dataset = mtg_jamendo_autotagging_moodtheme.Dataset(
         "tests/resources/mir_datasets/mtg_jamendo_autotagging_moodtheme"
     )

--- a/tests/datasets/test_orchset.py
+++ b/tests/datasets/test_orchset.py
@@ -58,7 +58,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/orchset"
     dataset = orchset.Dataset(data_home)
     track = dataset.track("Beethoven-S3-I-ex1")

--- a/tests/datasets/test_rwc_classical.py
+++ b/tests/datasets/test_rwc_classical.py
@@ -51,7 +51,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/rwc_classical"
     dataset = rwc_classical.Dataset(data_home)
     track = dataset.track("RM-C003")

--- a/tests/datasets/test_rwc_jazz.py
+++ b/tests/datasets/test_rwc_jazz.py
@@ -5,7 +5,6 @@ from tests.test_utils import run_track_tests
 
 
 def test_track():
-
     default_trackid = "RM-J004"
     data_home = os.path.normpath("tests/resources/mir_datasets/rwc_jazz")
     dataset = rwc_jazz.Dataset(data_home)
@@ -50,7 +49,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/rwc_jazz"
     dataset = rwc_jazz.Dataset(data_home)
     track = dataset.track("RM-J004")

--- a/tests/datasets/test_rwc_popular.py
+++ b/tests/datasets/test_rwc_popular.py
@@ -7,7 +7,6 @@ from tests.test_utils import run_track_tests
 
 
 def test_track():
-
     default_trackid = "RM-P001"
     data_home = os.path.normpath("tests/resources/mir_datasets/rwc_popular")
     dataset = rwc_popular.Dataset(data_home)
@@ -64,7 +63,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/rwc_popular"
     dataset = rwc_popular.Dataset(data_home)
     track = dataset.track("RM-P001")

--- a/tests/datasets/test_salami.py
+++ b/tests/datasets/test_salami.py
@@ -6,7 +6,6 @@ from tests.test_utils import run_track_tests
 
 
 def test_track():
-
     default_trackid = "2"
     data_home = os.path.normpath("tests/resources/mir_datasets/salami")
     dataset = salami.Dataset(data_home)
@@ -122,7 +121,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/salami"
     dataset = salami.Dataset(data_home)
     track = dataset.track("2")

--- a/tests/datasets/test_saraga_hindustani.py
+++ b/tests/datasets/test_saraga_hindustani.py
@@ -6,7 +6,6 @@ from tests.test_utils import run_track_tests
 
 
 def test_track():
-
     default_trackid = "50_Irani_Bhairavi_Thumri"
     data_home = os.path.normpath("tests/resources/mir_datasets/saraga_hindustani")
     dataset = saraga_hindustani.Dataset(data_home)

--- a/tests/datasets/test_slakh.py
+++ b/tests/datasets/test_slakh.py
@@ -157,7 +157,6 @@ def test_load_tracks():
 
 
 def test_to_jams():
-
     default_trackid = "Track00001-S00"
     data_home = "tests/resources/mir_datasets/slakh"
     dataset = slakh.Dataset(data_home, version="test")
@@ -269,7 +268,6 @@ def test_multitrack():
 
 
 def test_multitrack_to_jams():
-
     default_mtrackid = "Track00001"
     data_home = "tests/resources/mir_datasets/slakh"
     dataset = slakh.Dataset(data_home, version="test")

--- a/tests/datasets/test_vocadito.py
+++ b/tests/datasets/test_vocadito.py
@@ -75,7 +75,6 @@ def test_track():
 
 
 def test_to_jams():
-
     data_home = "tests/resources/mir_datasets/vocadito"
     default_trackid = "1"
     dataset = vocadito.Dataset(data_home)

--- a/tests/resources/tmp_download_test/remote.wav
+++ b/tests/resources/tmp_download_test/remote.wav
@@ -1,0 +1,1 @@
+This is a test file. It is validated using checksum. Do not change the contents of this file.

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1074,7 +1074,6 @@ def test_validate_intervals():
 
 
 def test_validate_unit():
-
     annotations.validate_unit("a", {"a": "asdf", "b": "asdfd"})
     annotations.validate_unit(None, {"a": "asdf", "b": "asdfd"}, allow_none=True)
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -229,7 +229,6 @@ def test_load_and_trackids():
         trackid_len = len(track_ids)
         # if the dataset has tracks, test the loaders
         if dataset._track_class is not None:
-
             try:
                 choice_track = dataset.choice_track()
             except:
@@ -255,9 +254,7 @@ def test_load_and_trackids():
 
 
 def test_track():
-
     for dataset_name in DATASETS:
-
         dataset = mirdata.initialize(
             dataset_name,
             os.path.normpath(os.path.join(TEST_DATA_HOME, dataset_name)),
@@ -431,7 +428,6 @@ def test_multitracks():
     data_home_dir = "tests/resources/mir_datasets"
 
     for dataset_name in DATASETS:
-
         dataset = mirdata.initialize(
             dataset_name, os.path.join(TEST_DATA_HOME, dataset_name), version="test"
         )

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,10 @@
 envlist = py36,py37,py38,check-formatting,mypy
 
 [testenv]
-passenv = CIRCLECI CIRCLE_* CI_PULL_REQUEST
+passenv =
+  CIRCLECI
+  CIRCLE_*
+  CI_PULL_REQUEST
 extras =
   tests
   dali


### PR DESCRIPTION
Addressing #580

- [Fix tox for formatting test](https://github.com/mir-dataset-loaders/mirdata/commit/309ec47758501ff6db942469ab341ae128826815)
- [Pin black version to 23.1.0](https://github.com/mir-dataset-loaders/mirdata/commit/a39914fc4d7fa7cfeacdfa280bca4ee7bc73ea89) --> rollback, will do when terminating python3.6 support
- [Upgrade librosa version and ensure python3.6 compatibility](https://github.com/mir-dataset-loaders/mirdata/commit/80b239a5081dafd1abb14a7e6d48364504704e99)
- [Black formatting with new 23.1.0 version](https://github.com/mir-dataset-loaders/mirdata/commit/64a33076551c177e776ae0da981359294b1832e6)
- [Fixing egfxset expected return value](https://github.com/mir-dataset-loaders/mirdata/commit/c71de62093e6546bd41ceb79ac9707e76bc524a3)
- [Mock pandas import at sphinx autodoc](https://github.com/mir-dataset-loaders/mirdata/commit/30b0db3c2f04f22a3c786fe776fe48e7ef987487)
- [Fix black version for python3.6](https://github.com/mir-dataset-loaders/mirdata/pull/581/commits/6c5a1c8e0afe4ae5b1e2be27740bbf8babda3fbf)