### PR TITLE
Fix setup extras_requirements installation. Add missing comma.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
         ],
         extras_require={
             "tests": [
-                "decorator>=5.1.1"
+                "decorator>=5.1.1",
                 "pytest>=4.4.0",
                 "pytest-cov>=2.6.1",
                 "pytest-pep8>=1.0.0",


### PR DESCRIPTION
Fixes #601 
Add missing comma to `setup.py` to be able to `pip install .`