### PR TITLE
Fixing possible typo in orchset.py md5 checksum

### DIFF
--- a/mirdata/datasets/orchset.py
+++ b/mirdata/datasets/orchset.py
@@ -40,7 +40,7 @@ INDEXES = {
     "1.0": core.Index(
         filename="orchset_index_1.0.json",
         url="https://zenodo.org/records/14024357/files/orchset_index_1.0.json?download=1",
-        checksum="c2b1b0(441d14be73b16c915d57005857",
+        checksum="c2b1b0441d14be73b16c915d57005857",
     ),
     "sample": core.Index(filename="orchset_index_1.0_sample.json"),
 }


### PR DESCRIPTION
Re: #655 -- removed parenthesis (typo?) from md5 checksum for orchest_index_1.0.json.