### PR TITLE
Fix indexes download

### DIFF
--- a/mirdata/annotations.py
+++ b/mirdata/annotations.py
@@ -1,5 +1,4 @@
-"""mirdata annotation data types
-"""
+"""mirdata annotation data types"""
 
 import logging
 import re

--- a/mirdata/core.py
+++ b/mirdata/core.py
@@ -1,5 +1,4 @@
-"""Core mirdata classes
-"""
+"""Core mirdata classes"""
 
 import json
 import os

--- a/mirdata/datasets/acousticbrainz_genre.py
+++ b/mirdata/datasets/acousticbrainz_genre.py
@@ -16,10 +16,10 @@
 
     We provide four datasets containing genre and subgenre annotations extracted from four different online metadata sources:
 
-    - AllMusic and Discogs are based on editorial metadata databases maintained by music experts and enthusiasts. These sources 
-      contain explicit genre/subgenre annotations of music releases (albums) following a predefined genre namespace and taxonomy. 
+    - AllMusic and Discogs are based on editorial metadata databases maintained by music experts and enthusiasts. These sources
+      contain explicit genre/subgenre annotations of music releases (albums) following a predefined genre namespace and taxonomy.
       We propagated release-level annotations to recordings (tracks) in AcousticBrainz to build the datasets.
-    - Lastfm and Tagtraum are based on collaborative music tagging platforms with large amounts of genre labels provided by their 
+    - Lastfm and Tagtraum are based on collaborative music tagging platforms with large amounts of genre labels provided by their
       users for music recordings (tracks). We have automatically inferred a genre/subgenre taxonomy and annotations from these labels.
 
     For details on format and contents, please refer to the data webpage.
@@ -34,7 +34,7 @@
         The AcousticBrainz Genre Dataset: Multi-Source, Multi-Level, Multi-Label, and Large-Scale.
         20th International Society for Music Information Retrieval Conference (ISMIR 2019).
 
-    This work is partially supported by the European Union’s Horizon 2020 research and innovation programme under 
+    This work is partially supported by the European Union’s Horizon 2020 research and innovation programme under
     grant agreement No 688382 AudioCommons.
 
 """

--- a/mirdata/datasets/ballroom.py
+++ b/mirdata/datasets/ballroom.py
@@ -24,11 +24,11 @@
     **Acknowledgments and References:**
 
     This dataset was created with the collaboration of experts in ballroom dance music. We extend our gratitude to those who contributed their knowledge and expertise to this project. For detailed information on the dataset and its creation, please refer to the associated research papers and documentation.
-    
+
     [1] Gouyon F., A. Klapuri, S. Dixon, M. Alonso, G. Tzanetakis, C. Uhle, and P. Cano. An experimental comparison of audio tempo induction algorithms. Transactions on Audio, Speech and Language Processing 14(5), pp.1832-1844, 2006.
 
     [2] Böck, S., and M. Schedl. Enhanced beat tracking with context-aware neural networks. In Proceedings of the International Conference on Digital Audio Effects (DAFX), 2010.
-    
+
     [3] Dixon, S., F. Gouyon & G. Widmer. Towards Characterisation of Music via Rhythmic Patterns. In Proceedings of the 5th International Society for Music Information Retrieval Conference (ISMIR). 2004.
 """
 

--- a/mirdata/datasets/candombe.py
+++ b/mirdata/datasets/candombe.py
@@ -3,14 +3,14 @@
 .. admonition:: Dataset Info
     :class: dropdown
 
-    This is a dataset of Candombe recordings with annotated beats and downbeats, totaling over 2 hours of audio. 
-    It comprises 35 complete performances by renowned players, in groups of three to five drums. 
+    This is a dataset of Candombe recordings with annotated beats and downbeats, totaling over 2 hours of audio.
+    It comprises 35 complete performances by renowned players, in groups of three to five drums.
     Recording sessions were conducted in studio, in the context of musicological research over the past two decades.
     A total of 26 tambor players took part, belonging to different generations and representing all the important traditional Candombe styles.
-    The audio files are stereo with a sampling rate of 44.1 kHz and 16-bit precision. 
+    The audio files are stereo with a sampling rate of 44.1 kHz and 16-bit precision.
     The location of beats and downbeats was annotated by an expert, adding to more than 4700 downbeats.
 
-    The audio is provided as .flac files and the annotations as .csv files. 
+    The audio is provided as .flac files and the annotations as .csv files.
     The values in the first column of the csv file are the time instants of the beats.
     The numbers on the second column indicate both the bar number and the beat number within the bar.
     For instance, 1.1, 1.2, 1.3 and 1.4 are the four beats of the first bar. Hence, each label ending with .1 indicates a downbeat.

--- a/mirdata/datasets/cipi.py
+++ b/mirdata/datasets/cipi.py
@@ -5,17 +5,17 @@
 
     The "Can I Play It?" (CIPI) dataset is a specialized collection of 652 classical piano scores, provided in a
     machine-readable MusicXML format and accompanied by integer-based difficulty levels ranging from 1 to 9, as
-    verified by expert pianists. Then, it provides embeddings for fingering and expresiveness of the piece. Each 
+    verified by expert pianists. Then, it provides embeddings for fingering and expresiveness of the piece. Each
     recording has multiple scores corresponding to it. This dataset focuses exclusively on classical piano music,
     offering a rich resource for music researchers, educators, and students. Developed by the Music Technology Group
-    in Barcelona, by P. Ramoneda et al. 
+    in Barcelona, by P. Ramoneda et al.
 
     The CIPI dataset facilitates various applications such as the study of musical complexity, the selection of
     appropriately leveled pieces for students, and general research in music education. The dataset, alongside
     embeddings of multiple dimensions of difficulty, has been made publicly available to encourage ongoing innovation
     and collaboration within the music education and research communities.
 
-    The dataset has been published alongside a paper in Expert Systems with Applications Journal. 
+    The dataset has been published alongside a paper in Expert Systems with Applications Journal.
 
     The dataset is shared under a Creative Commons Attribution Non Commercial Share Alike 4.0 International License, but
     need to be requested. Please do request the dataset here: https://zenodo.org/records/8037327. The dataset can only

--- a/mirdata/datasets/compmusic_carnatic_rhythm.py
+++ b/mirdata/datasets/compmusic_carnatic_rhythm.py
@@ -11,7 +11,7 @@
 
     The dataset contains the following data:
 
-    **AUDIO:** The pieces are chosen from the CompMusic Carnatic music collection. The pieces were chosen in four popular taalas of 
+    **AUDIO:** The pieces are chosen from the CompMusic Carnatic music collection. The pieces were chosen in four popular taalas of
     Carnatic music, which encompasses a majority of Carnatic music. The pieces were chosen include a mix of vocal and instrumental recordings,
     new and old recordings, and to span a wide variety of forms. All pieces have a percussion accompaniment, predominantly Mridangam. The
     excerpts are full length pieces or a part of the full length pieces. There are also several different pieces by the same artist (or release
@@ -27,9 +27,9 @@
     **METADATA:** For each excerpt, the taala of the piece, edupu (offset of the start of the piece, relative to the sama, measured in aksharas)
     of the composition, and the kalai (the cycle length scaling factor) are recorded. Each excerpt can be uniquely identified and located with the
     MBID of the recording, and the relative start and end times of the excerpt within the whole recording. A separate 5 digit taala based unique ID
-    is also provided for each excerpt as a double check. The artist, release, the lead instrument, and the raaga of the piece are additional 
+    is also provided for each excerpt as a double check. The artist, release, the lead instrument, and the raaga of the piece are additional
     editorial metadata obtained from the release. A flag indicates if the excerpt is a full piece or only a part of a full piece. There are optional
-    comments on audio quality and annotation specifics. 
+    comments on audio quality and annotation specifics.
 
     Possible uses of the dataset: Possible tasks where the dataset can be used include taala, sama and beat tracking, tempo estimation and tracking,
     taala recognition, rhythm based segmentation of musical audio, structural segmentation, audio to score/lyrics alignment, and rhythmic pattern

--- a/mirdata/datasets/compmusic_carnatic_varnam.py
+++ b/mirdata/datasets/compmusic_carnatic_varnam.py
@@ -28,7 +28,7 @@
     **Sections**
     The notation is given a single time per section, however, to align the svaras with the tala annotations, structure
     information is given. The structure is given in yaml format, specifying the order of the sections, and how many svaras
-    are sung per each tala tick. Broadly, there are just two only cases, 2 svaras per tick, and 4 svaras per tick. 
+    are sung per each tala tick. Broadly, there are just two only cases, 2 svaras per tick, and 4 svaras per tick.
     The structure information has been added in the 1.1 version of the dataset.
 
     **Possible uses of the dataset**

--- a/mirdata/datasets/compmusic_hindustani_rhythm.py
+++ b/mirdata/datasets/compmusic_hindustani_rhythm.py
@@ -3,8 +3,8 @@
 .. admonition:: Dataset Info
     :class: dropdown
 
-    CompMusic Hindustani Rhythm Dataset is a rhythm annotated test corpus for automatic rhythm analysis tasks in Hindustani Music. 
-    The collection consists of audio excerpts from the CompMusic Hindustani research corpus, manually annotated time aligned markers 
+    CompMusic Hindustani Rhythm Dataset is a rhythm annotated test corpus for automatic rhythm analysis tasks in Hindustani Music.
+    The collection consists of audio excerpts from the CompMusic Hindustani research corpus, manually annotated time aligned markers
     indicating the progression through the taal cycle, and the associated taal related metadata. A brief description of the dataset
     is provided below.
 
@@ -19,9 +19,9 @@
     The pieces are stereo, 160 kbps, mp3 files sampled at 44.1 kHz. The audio is also available as wav files for experiments.
 
     **SAM, VIBHAAG AND THE MAATRAS:** The primary annotations are audio synchronized time-stamps indicating the different metrical positions in the taal cycle.
-    The sam and matras of the cycle are annotated. The annotations were created using Sonic Visualizer by tapping to music and manually correcting the taps. 
+    The sam and matras of the cycle are annotated. The annotations were created using Sonic Visualizer by tapping to music and manually correcting the taps.
     Each annotation has a time-stamp and an associated numeric label that indicates the position of the beat marker in the taala cycle. The annotations and the
-    associated metadata have been verified for correctness and completeness by a professional Hindustani musician and musicologist. The long thick lines show 
+    associated metadata have been verified for correctness and completeness by a professional Hindustani musician and musicologist. The long thick lines show
     vibhaag boundaries. The numerals indicate the matra number in cycle. In each case, the sam (the start of the cycle, analogous to the downbeat) are indicated
     using the numeral 1.
 

--- a/mirdata/datasets/compmusic_indian_tonic.py
+++ b/mirdata/datasets/compmusic_indian_tonic.py
@@ -5,17 +5,17 @@
 
     This loader includes a combination of six different datasets for the task of Indian Art Music tonic identification.
 
-    These datasets comprise audio excerpts and manually done annotations of the tonic pitch of the lead artist for each audio excerpt. 
-    Each excerpt is accompanied by its associated editorial metadata. These datasets can be used to develop and evaluate computational 
-    approaches for automatic tonic identification in Indian art music. These datasets have been used in several articles mentioned below. 
-    A majority of These datasets come from the CompMusic corpora of Indian art music, for which each recording is associated with a MBID. 
+    These datasets comprise audio excerpts and manually done annotations of the tonic pitch of the lead artist for each audio excerpt.
+    Each excerpt is accompanied by its associated editorial metadata. These datasets can be used to develop and evaluate computational
+    approaches for automatic tonic identification in Indian art music. These datasets have been used in several articles mentioned below.
+    A majority of These datasets come from the CompMusic corpora of Indian art music, for which each recording is associated with a MBID.
     Through the MBID other information can be obtained using the Dunya API.
 
 
-    These six datasets are used for for the task of tonic identification for Indian Art Music, and can be used for a comparative evaluation. 
-    To the best of our knowledge these are the largest datasets available for tonic identification for Indian art  music. These datases vary 
-    in terms of the audio quality, recording period (decade), the number of recordings for Carnatic, Hindustani, male and female singers and 
-    instrumental and vocal excerpts. 
+    These six datasets are used for for the task of tonic identification for Indian Art Music, and can be used for a comparative evaluation.
+    To the best of our knowledge these are the largest datasets available for tonic identification for Indian art  music. These datases vary
+    in terms of the audio quality, recording period (decade), the number of recordings for Carnatic, Hindustani, male and female singers and
+    instrumental and vocal excerpts.
 
     All the datasets (annotations) are version controlled. The audio files corresponding to these datsets are made available on request
     for only research purposes. See DOWNLOAD_INFO of this loader.
@@ -25,7 +25,7 @@
     .. code-block::
 
         'ID': {
-            'artist': <name of the lead artist if available>, 
+            'artist': <name of the lead artist if available>,
             'filepath': <relative path to the audio file>,
             'gender': <gender of the lead singer if available>,
             'mbid': <musicbrainz id when available>,
@@ -41,10 +41,10 @@
     these features may be easily computed following the instructions in the related paper. See BIBTEX.
 
     There are a total of 2161 audio excerpts, and while the CM collection includes aproximately 50% Carnatic and 50% Hindustani recordings, IITM and
-    IISc collections are 100% Carnatic music. The excerpts vary a lot in duration. See [this webpage](https://compmusic.upf.edu/iam-tonic-dataset) 
+    IISc collections are 100% Carnatic music. The excerpts vary a lot in duration. See [this webpage](https://compmusic.upf.edu/iam-tonic-dataset)
     for a detailed overview of the datasets.
 
-    If you have any questions or comments about the dataset, please feel free to email: [sankalp (dot) gulati (at) gmail (dot) com], or 
+    If you have any questions or comments about the dataset, please feel free to email: [sankalp (dot) gulati (at) gmail (dot) com], or
     [sankalp (dot) gulati (at) upf (dot) edu].
 
 """

--- a/mirdata/datasets/compmusic_raga.py
+++ b/mirdata/datasets/compmusic_raga.py
@@ -3,26 +3,26 @@
 .. admonition:: Dataset Info
     :class: dropdown
 
-    Rāga datasets from CompMusicomprise two sizable datasets, one for each music tradition, 
-    Carnatic and Hindustani. These datasets comprise full length audio recordings and their 
-    associated rāga labels. These two datasets can be used to develop and evaluate approaches 
+    Rāga datasets from CompMusicomprise two sizable datasets, one for each music tradition,
+    Carnatic and Hindustani. These datasets comprise full length audio recordings and their
+    associated rāga labels. These two datasets can be used to develop and evaluate approaches
     for performing automatic rāga recognition in Indian art music.
 
     These datasets are derived from the CompMusic corpora of Indian Art Music. Therefore, the
     dataset has been compiled at the Music Technology Group, by a group of researchers working
     on the computational analysis of Carnatic and Hindustani music within the framework of the
-    ERC-funded CompMusic project. 
-    
-    Each recording is associated with a MBID. With the MBID other information can be obtained 
-    using the Dunya API or pycompmusic. 
+    ERC-funded CompMusic project.
 
-    The Carnatic subset comprises 124 hours of audio recordings and editorial metadata that 
-    includes carefully curated and verified rāga labels. It contains 480 recordings belonging 
+    Each recording is associated with a MBID. With the MBID other information can be obtained
+    using the Dunya API or pycompmusic.
+
+    The Carnatic subset comprises 124 hours of audio recordings and editorial metadata that
+    includes carefully curated and verified rāga labels. It contains 480 recordings belonging
     to 40 rāgas with 12 recordings per rāga.
 
-    The Hindustani subset comprises 116 hours of audio recordings and editorial metadata that 
-    includes carefully curated and verified rāga labels. It contains 300 recordings belonging 
-    to 30 rāgas with 10 recordings per rāga. 
+    The Hindustani subset comprises 116 hours of audio recordings and editorial metadata that
+    includes carefully curated and verified rāga labels. It contains 300 recordings belonging
+    to 30 rāgas with 10 recordings per rāga.
 
     The dataset also includes features per each file:
     * Tonic: float indicating the recording tonic
@@ -32,9 +32,9 @@
     * Nyas segments: KNN-extracted segments of Nyas (start and end times provided)
     * Tani segments: KNN-extracted segments of Tanis (start and end times provided)
 
-    The dataset includes both txt files and json files that contain information about each audio 
-    recording in terms of its mbid, the path of the audio/feature files and the associated rāga 
-    identifier. Each rāga is assigned a unique identifier by Dunya, which is similar to the mbid 
+    The dataset includes both txt files and json files that contain information about each audio
+    recording in terms of its mbid, the path of the audio/feature files and the associated rāga
+    identifier. Each rāga is assigned a unique identifier by Dunya, which is similar to the mbid
     in terms of purpose. A mapping of the rāga id to its transliterated name is also provided.
 
     For more information about the dataset please refer to: https://compmusic.upf.edu/node/328

--- a/mirdata/datasets/cuidado.py
+++ b/mirdata/datasets/cuidado.py
@@ -11,7 +11,7 @@
 
     **Beat and Bar Annotations:**
 
-    The beat annotations are structured as `.beats` files, where each line represents a beat with its timestamp and beat ID. 
+    The beat annotations are structured as `.beats` files, where each line represents a beat with its timestamp and beat ID.
 
     **Annotation Methodology:**
 
@@ -24,11 +24,11 @@
     **Acknowledgments and References:**
 
     This dataset was created with the collaboration of experts in cuidado dance music. We extend our gratitude to those who contributed their knowledge and expertise to this project. For detailed information on the dataset and its creation, please refer to the associated research papers and documentation (https://zenodo.org/records/1416940).
-    
+
     [1] Gouyon F., A. Klapuri, S. Dixon, M. Alonso, G. Tzanetakis, C. Uhle, and P. Cano. An experimental comparison of audio tempo induction algorithms. Transactions on Audio, Speech and Language Processing 14(5), pp.1832-1844, 2006.
 
     [2] Böck, S., and M. Schedl. Enhanced beat tracking with context-aware neural networks. In Proceedings of the International Conference on Digital Audio Effects (DAFX), 2010.
-    
+
     [3] Dixon, S., F. Gouyon & G. Widmer. Towards Characterisation of Music via Rhythmic Patterns. In Proceedings of the 5th International Society for Music Information Retrieval Conference (ISMIR). 2004.
 """
 

--- a/mirdata/datasets/da_tacos.py
+++ b/mirdata/datasets/da_tacos.py
@@ -4,19 +4,19 @@
 .. admonition:: Dataset Info
     :class: dropdown
 
-    Da-TACOS: a dataset for cover song identification and understanding. It contains two subsets, 
-    namely the benchmark subset (for benchmarking cover song identification systems) and the cover 
-    analysis subset (for analyzing the links among cover songs), with pre-extracted features and 
-    metadata for 15,000 and 10,000 songs, respectively. The annotations included in the metadata 
-    are obtained with the API of SecondHandSongs.com. All audio files we use to extract features 
-    are encoded in MP3 format and their sample rate is 44.1 kHz. Da-TACOS does not contain any 
-    audio files. For the results of our analyses on modifiable musical characteristics using the 
-    cover analysis subset and our initial benchmarking of 7 state-of-the-art cover song identification 
+    Da-TACOS: a dataset for cover song identification and understanding. It contains two subsets,
+    namely the benchmark subset (for benchmarking cover song identification systems) and the cover
+    analysis subset (for analyzing the links among cover songs), with pre-extracted features and
+    metadata for 15,000 and 10,000 songs, respectively. The annotations included in the metadata
+    are obtained with the API of SecondHandSongs.com. All audio files we use to extract features
+    are encoded in MP3 format and their sample rate is 44.1 kHz. Da-TACOS does not contain any
+    audio files. For the results of our analyses on modifiable musical characteristics using the
+    cover analysis subset and our initial benchmarking of 7 state-of-the-art cover song identification
     algorithms on the benchmark subset, you can look at our publication.
 
-    For organizing the data, we use the structure of SecondHandSongs where each song is called a 
-    ‘performance’, and each clique (cover group) is called a ‘work’. Based on this, the file names 
-    of the songs are their unique performance IDs (PID, e.g. P_22), and their labels with respect 
+    For organizing the data, we use the structure of SecondHandSongs where each song is called a
+    ‘performance’, and each clique (cover group) is called a ‘work’. Based on this, the file names
+    of the songs are their unique performance IDs (PID, e.g. P_22), and their labels with respect
     to their cliques are their work IDs (WID, e.g. W_14).
 
     Metadata for each song includes:

--- a/mirdata/datasets/egfxset.py
+++ b/mirdata/datasets/egfxset.py
@@ -23,31 +23,31 @@
     Categories, Models and Effects:
 
         Distortion:
-            Boss BD-2: 
+            Boss BD-2:
                        Blues Driver
-            Ibanez Minitube Screamer: 
+            Ibanez Minitube Screamer:
                        Tube Screamer
-            ProCo RAT2: 
+            ProCo RAT2:
                        Distortion
 
         Modulation:
-            Boss CE-3: 
+            Boss CE-3:
                        Chorus
-            MXR Phase 45: 
+            MXR Phase 45:
                        Phaser
-            Mooer E-Lady: 
+            Mooer E-Lady:
                        Flanger
 
         Delays:
             Line6 DL-4:
-                        Digital Delay, 
-                        Tape Echo, 
+                        Digital Delay,
+                        Tape Echo,
                         Sweep Echo
 
         Reverb:
             Orange CR-60 Combo Amplifier:
-                                        Plate Reverb, 
-                                        Hall Reverb, 
+                                        Plate Reverb,
+                                        Hall Reverb,
                                         Spring Reverb
 
 
@@ -65,7 +65,7 @@
              - Effect type
 
              - Hardware modes
-    
+
              - Knob names
 
              - Knob types
@@ -361,7 +361,7 @@ class Dataset(core.Dataset):
                     ],
                     "Note Name": annotations.convert_pitch_units(
                         pitches=np.array(
-                            [(cuerdas[noteCord[0]] + int(float(noteCord[1])))],
+                            [cuerdas[noteCord[0]] + int(float(noteCord[1]))],
                             dtype=float,
                         ),
                         pitch_unit="midi",
@@ -371,7 +371,7 @@ class Dataset(core.Dataset):
                         intervals=np.array([[0, 5]], dtype=float),
                         interval_unit="s",
                         pitches=np.array(
-                            [(cuerdas[noteCord[0]] + int(float(noteCord[1])))],
+                            [cuerdas[noteCord[0]] + int(float(noteCord[1]))],
                             dtype=float,
                         ),
                         pitch_unit="midi",
@@ -392,7 +392,7 @@ class Dataset(core.Dataset):
                     ],
                     "Note Name": annotations.convert_pitch_units(
                         pitches=np.array(
-                            [(cuerdas[noteCord[0]] + int(float(noteCord[1])))],
+                            [cuerdas[noteCord[0]] + int(float(noteCord[1]))],
                             dtype=float,
                         ),
                         pitch_unit="midi",
@@ -402,7 +402,7 @@ class Dataset(core.Dataset):
                         intervals=np.array([[0, 5]], dtype=float),
                         interval_unit="s",
                         pitches=np.array(
-                            [(cuerdas[noteCord[0]] + int(float(noteCord[1])))],
+                            [cuerdas[noteCord[0]] + int(float(noteCord[1]))],
                             dtype=float,
                         ),
                         pitch_unit="midi",

--- a/mirdata/datasets/filosax.py
+++ b/mirdata/datasets/filosax.py
@@ -5,7 +5,7 @@
 
     The Filosax dataset was conceived, curated and compiled by Dave Foster (a PhD student on the AIM programme at QMUL) and his supervisor Simon Dixon (C4DM @ QMUL).
     The dataset is a collection of 48 multitrack jazz recordings, where each piece has 8 corresponding audio files:
-    
+
     1) The original Aebersold backing track (stereo)
     2) Bass_Drums, a mono file of a mix of bass and drums
     3) Piano_Drums, a mono file of a mix of piano and drums
@@ -14,22 +14,22 @@
     6) Participant 3 Sax, a mono file of solo saxophone
     7) Participant 4 Sax, a mono file of solo saxophone
     8) Participant 5 Sax, a mono file of solo saxophone
-    
+
     Each piece is ~6mins long, so each of the 8 stems contains ~5hours of audio
-    
+
     For each piece, there is a corresponding .jams file containing piece-level annotations:
-    
+
     1) Beat annotation for the start of each bar and any mid-bar chord change
     2) Chord annotation for each bar, and mid-bar chord change
     3) Section annotation for when the solo changes between the 3 categories:
         a) head (melody)
         b) written solo (interpretation of transcribed solo)
         c) improvised solo
-        
+
     For each Sax recording (5 per piece), there is a corresponding .json file containing note annotations (see Note object).
-    
+
     The Participant folders also contain MIDI files of the transcriptions (frame level and score level) as well as a PDF and MusicXML of the typeset solo.
-    
+
     The dataset comes in 2 flavours: full (all 48 tracks and 5 sax players) and lite (5 tracks and 2 sax players).
     Both flavours can be used with or without the backing tracks (which need to be purchased online).
     Hence, when opening the dataset, use one of 4 versions: 'full', 'full_sax', 'lite', 'lite_sax'.

--- a/mirdata/datasets/four_way_tabla.py
+++ b/mirdata/datasets/four_way_tabla.py
@@ -16,7 +16,7 @@
     * Bit-depth: 16 bit
     * Audio format: .wav
 
-    Dataset usage: This dataset may be used for the data-driven research of tabla stroke transcription and 
+    Dataset usage: This dataset may be used for the data-driven research of tabla stroke transcription and
     identification. In this dataset, four important tabla characteristic strokes are considered.
 
     Dataset structure: The dataset is split in two subsets, containing training and testing samples. Within each

--- a/mirdata/datasets/hainsworth.py
+++ b/mirdata/datasets/hainsworth.py
@@ -21,10 +21,10 @@
 
     For more detailed information about the dataset and its creation, please refer to Stephen Hainsworth's PhD thesis and the associated research papers and documentation.
 
-    [1] Hainsworth, Stephen. (PhD Thesis) 
+    [1] Hainsworth, Stephen. (PhD Thesis)
 
     [2] Böck, Sebastian, et al. "Enhanced beat tracking with context-aware neural networks." In Proceedings of the International Conference on Digital Audio Effects (DAFX), 2010.
-    
+
 """
 
 import os

--- a/mirdata/datasets/idmt_smt_audio_effects.py
+++ b/mirdata/datasets/idmt_smt_audio_effects.py
@@ -12,7 +12,7 @@
     20592 monophonic guitar notes
     13860 polyphonic guitar sounds
     Overall, 11 different audio effects are incorporated:
-    feedback delay, slapback delay, reverb, chorus, flanger, phaser, tremolo, vibrato, 
+    feedback delay, slapback delay, reverb, chorus, flanger, phaser, tremolo, vibrato,
     distortion, overdrive, no effect (unprocessed notes/sounds)
 
     2 different electric guitars and 2 different electric bass guitars, each with two different pick-up settings and
@@ -25,8 +25,8 @@
     To organize the database, lists in XML format are used, which record all relevant information and are provided with
     the database as well as a summary of the used effect plugins and parameter settings.
 
-    In addition, most of this information is also encoded in the first part of the file name of the audio files using 
-    a simple alpha-numeric encoding scheme. The second part of the file name contains unique identification numbers. 
+    In addition, most of this information is also encoded in the first part of the file name of the audio files using
+    a simple alpha-numeric encoding scheme. The second part of the file name contains unique identification numbers.
     This provides an option for fast and flexible structuring of the data for various purposes.
 
     DOI

--- a/mirdata/datasets/irmas.py
+++ b/mirdata/datasets/irmas.py
@@ -109,6 +109,7 @@ BIBTEX = """
   version      = {1.0},
   doi          = {10.5281/zenodo.1290750},
   url          = {https://doi.org/10.5281/zenodo.1290750}
+}
 """
 
 INDEXES = {

--- a/mirdata/datasets/saraga_carnatic.py
+++ b/mirdata/datasets/saraga_carnatic.py
@@ -10,9 +10,9 @@
 
     - Section and tempo annotations stored as start and end timestamps together with the name of the section and
       tempo during the section (in a separate file)
-    - Sama annotations referring to rhythmic cycle boundaries stored as timestamps. 
+    - Sama annotations referring to rhythmic cycle boundaries stored as timestamps.
     - Phrase annotations stored as timestamps and transcription of the phrases using solfège symbols
-      ({S, r, R, g, G, m, M, P, d, D, n, N}). 
+      ({S, r, R, g, G, m, M, P, d, D, n, N}).
     - Audio features automatically extracted and stored: pitch and tonic.
     - The annotations are stored in text files, named as the audio filename but with the respective extension at the
       end, for instance: "Bhuvini Dasudane.tempo-manual.txt".

--- a/mirdata/datasets/saraga_hindustani.py
+++ b/mirdata/datasets/saraga_hindustani.py
@@ -9,7 +9,7 @@
     The dataset contains the following manual annotations referring to audio files:
 
     - Section and tempo annotations stored as start and end timestamps together with the name of the section and
-      tempo during the section (in a separate file) 
+      tempo during the section (in a separate file)
     - Sama annotations referring to rhythmic cycle boundaries stored
       as timestamps
     - Phrase annotations stored as timestamps and transcription of the phrases using solfège symbols

--- a/mirdata/datasets/simac.py
+++ b/mirdata/datasets/simac.py
@@ -11,7 +11,7 @@
 
     **Musical Facets and Descriptors:**
 
-    - **Rhythm:** SIMAC investigates various aspects of automatic rhythm description, such as tempo induction, beat tracking, and rhythmic pattern characterization. 
+    - **Rhythm:** SIMAC investigates various aspects of automatic rhythm description, such as tempo induction, beat tracking, and rhythmic pattern characterization.
 
     **Acknowledgments and References:**
 

--- a/mirdata/datasets/slakh.py
+++ b/mirdata/datasets/slakh.py
@@ -3,15 +3,15 @@
 .. admonition:: Dataset Info
     :class: dropdown
 
-    The Synthesized Lakh (Slakh) Dataset is a dataset of multi-track audio and aligned 
-    MIDI for music source separation and multi-instrument automatic transcription. 
-    Individual MIDI tracks are synthesized from the Lakh MIDI Dataset v0.1 using 
-    professional-grade sample-based virtual instruments, and the resulting audio is 
-    mixed together to make musical mixtures. 
-    
-    The original release of Slakh, called Slakh2100, 
-    contains 2100 automatically mixed tracks and accompanying, aligned MIDI files, 
-    synthesized from 187 instrument patches categorized into 34 classes, totaling 
+    The Synthesized Lakh (Slakh) Dataset is a dataset of multi-track audio and aligned
+    MIDI for music source separation and multi-instrument automatic transcription.
+    Individual MIDI tracks are synthesized from the Lakh MIDI Dataset v0.1 using
+    professional-grade sample-based virtual instruments, and the resulting audio is
+    mixed together to make musical mixtures.
+
+    The original release of Slakh, called Slakh2100,
+    contains 2100 automatically mixed tracks and accompanying, aligned MIDI files,
+    synthesized from 187 instrument patches categorized into 34 classes, totaling
     145 hours of mixture data.
 
     This loader supports two versions of Slakh:
@@ -19,7 +19,7 @@
     - baby-slakh: a mini version with 16k wav audio and only the first 20 tracks
 
     This dataset was created at Mitsubishi Electric Research Labl (MERL) and
-    Interactive Audio Lab at Northwestern University by Ethan Manilow, 
+    Interactive Audio Lab at Northwestern University by Ethan Manilow,
     Gordon Wichern, Prem Seetharaman, and Jonathan Le Roux.
 
     For more information see http://www.slakh.com/

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -1,5 +1,4 @@
-"""Utilities for downloading from the web.
-"""
+"""Utilities for downloading from the web."""
 
 import chardet
 import glob

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -102,6 +102,8 @@ def downloader(
     partial_download = partial_download if partial_download else index.partial_download
 
     if remotes is not None:
+        # BUG: when partial_download is not None, the index is not downloaded
+        # that is because objs_to_download is set to the partial_download which does not contain index
         if partial_download is not None:
             # check the keys in partial_download are in the download dict
             if not isinstance(partial_download, list) or any(
@@ -113,6 +115,8 @@ def downloader(
                     )
                 )
             objs_to_download = partial_download
+            # BUG-FIX: add index to the list of objects to download
+            objs_to_download.append("index")
         else:
             objs_to_download = list(remotes.keys())
 

--- a/mirdata/io.py
+++ b/mirdata/io.py
@@ -12,7 +12,7 @@ T = TypeVar("T")  # Can be anything
 
 
 def coerce_to_string_io(
-    func: Callable[[TextIO], T]
+    func: Callable[[TextIO], T],
 ) -> Callable[[Optional[Union[str, TextIO]]], Optional[T]]:
     @functools.wraps(func)
     def wrapper(file_path_or_obj: Optional[Union[str, TextIO]]) -> Optional[T]:
@@ -34,7 +34,7 @@ def coerce_to_string_io(
 
 
 def coerce_to_bytes_io(
-    func: Callable[[BinaryIO], T]
+    func: Callable[[BinaryIO], T],
 ) -> Callable[[Optional[Union[str, BinaryIO]]], Optional[T]]:
     @functools.wraps(func)
     def wrapper(file_path_or_obj: Optional[Union[str, BinaryIO]]) -> Optional[T]:

--- a/mirdata/jams_utils.py
+++ b/mirdata/jams_utils.py
@@ -1,5 +1,4 @@
-"""Utilities for converting mirdata Annotation classes to jams format.
-"""
+"""Utilities for converting mirdata Annotation classes to jams format."""
 
 import logging
 import os

--- a/tests/datasets/test_candombe.py
+++ b/tests/datasets/test_candombe.py
@@ -1,5 +1,4 @@
-"""Tests for Candombe dataset
-"""
+"""Tests for Candombe dataset"""
 
 import numpy as np
 from mirdata import annotations


### PR DESCRIPTION
This PR fixes #659, a bug where the index json file is not downloaded.


### Bug Description:
- When `partial_download` is not `None`, `objs_to_download` is set to `partial_download`, which does not contain `index`.
- This causes the index to be missing from the objects to be downloaded and therefore it is not downloaded.
- I believe this bug is affecting all the cases in which  `partial_download` is specified.

### Fix:
- Explicitly append `"index"` to `objs_to_download` when `partial_download` is not `None`.


`mirdata/download_utils.py`:
```python
if remotes is not None:
    # BUG: when partial_download is not None, the index is not downloaded
    # that is because objs_to_download is set to the partial_download which does not contain index
    if partial_download is not None:
        # check the keys in partial_download are in the download dict
        if not isinstance(partial_download, list) or any(
            [k not in remotes for k in partial_download]
        ):
            raise ValueError(
                "partial_download must be a list which is a subset of {}, but got {}".format(
                    list(remotes.keys()), partial_download
                )
            )
        objs_to_download = partial_download
        # BUG-FIX: add index to the list of objects to download
        objs_to_download.append("index")
    else:
        objs_to_download = list(remotes.keys())
```

### Code Change
```diff
        objs_to_download = partial_download
        # BUG-FIX: add index to the list of objects to download
+       objs_to_download.append("index")
    else:
        objs_to_download = list(remotes.keys())
```


