### PR TITLE
Updating documentation displaying dataset versions and partial downloads

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath("./source/_ext"))
 sys.path.insert(0, os.path.abspath("../"))
 
 # -- Project information -----------------------------------------------------
@@ -62,6 +63,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_togglebutton",
     "sphinx.ext.extlinks",
+    "docstring_mod",
 ]
 
 # To shorten links of licenses and add to table

--- a/docs/source/_ext/docstring_mod.py
+++ b/docs/source/_ext/docstring_mod.py
@@ -1,38 +1,40 @@
+def add_versions(module, lines):
+    if hasattr(module, 'INDEXES'):
+        indexes = module.INDEXES
+        lines.append('**Versions:** ' + ' '.join([f'``{v}``' for v in indexes.keys()]))
+        lines.append('')
+
+
+def add_partial_downloads(module, dataset_class, lines):
+    remotes = getattr(dataset_class, 'REMOTES', None) or getattr(module, 'REMOTES', {})
+    if isinstance(remotes, dict):
+        lines.append('')
+        lines.append('**Partial Downloads:**')
+        lines.append(' '.join([f'``{v}``' for v in remotes.keys()]))
+        lines.append('')
+
+
 def process_docstring(app, what, name, obj, options, lines):
-    """Process the docstring for classes that inherit from Dataset."""
     try:
         from mirdata.core import Dataset
+
         if what == 'class' and isinstance(obj, type) and issubclass(obj, Dataset) and obj is not Dataset:
-            # Find the module that contains this class
-            module_name = obj.__module__
-            module = __import__(module_name, fromlist=['INDEXES', 'REMOTES'])
-            
-            # If the module has INDEXES, add version info
-            if hasattr(module, 'INDEXES'):
-                indexes = module.INDEXES
-                
-                # Add version info
-                lines.append('')
-                lines.append('Available Versions')
-                lines.append('-----------------')
-                
-                for version in indexes.keys():
-                    lines.append(f" - **{version}**")
-            
-            # If the module has REMOTES, add remote files info
-            if hasattr(module, 'REMOTES'):
-                remotes = module.REMOTES
-                
-                # Add remote files info
-                lines.append('')
-                lines.append('Remote Files')
-                lines.append('------------')
-                
-                for remote_name, remote_info in remotes.items():
-                    lines.append(f" - **{remote_name}**: {remote_info.url}")
+            module = __import__(obj.__module__, fromlist=['INDEXES'])
+            add_versions(module, lines)
+
+        if what == 'method' and name.endswith('.download'):
+            class_path = name.rsplit('.', 1)[0]
+            parts = class_path.split('.')
+            module_path = '.'.join(parts[:-1])
+            class_name = parts[-1]
+            module = __import__(module_path, fromlist=[class_name])
+            dataset_class = getattr(module, class_name)
+            if hasattr(dataset_class, 'REMOTES') or hasattr(module, 'REMOTES'):
+                add_partial_downloads(module, dataset_class, lines)
+
     except (ImportError, AttributeError, TypeError) as e:
         print(f"Warning: Error processing docstring for {name}: {e}")
-        pass
+
 
 def setup(app):
     app.connect('autodoc-process-docstring', process_docstring)

--- a/docs/source/_ext/docstring_mod.py
+++ b/docs/source/_ext/docstring_mod.py
@@ -1,0 +1,39 @@
+def process_docstring(app, what, name, obj, options, lines):
+    """Process the docstring for classes that inherit from Dataset."""
+    try:
+        from mirdata.core import Dataset
+        if what == 'class' and isinstance(obj, type) and issubclass(obj, Dataset) and obj is not Dataset:
+            # Find the module that contains this class
+            module_name = obj.__module__
+            module = __import__(module_name, fromlist=['INDEXES', 'REMOTES'])
+            
+            # If the module has INDEXES, add version info
+            if hasattr(module, 'INDEXES'):
+                indexes = module.INDEXES
+                
+                # Add version info
+                lines.append('')
+                lines.append('Available Versions')
+                lines.append('-----------------')
+                
+                for version in indexes.keys():
+                    lines.append(f" - **{version}**")
+            
+            # If the module has REMOTES, add remote files info
+            if hasattr(module, 'REMOTES'):
+                remotes = module.REMOTES
+                
+                # Add remote files info
+                lines.append('')
+                lines.append('Remote Files')
+                lines.append('------------')
+                
+                for remote_name, remote_info in remotes.items():
+                    lines.append(f" - **{remote_name}**: {remote_info.url}")
+    except (ImportError, AttributeError, TypeError) as e:
+        print(f"Warning: Error processing docstring for {name}: {e}")
+        pass
+
+def setup(app):
+    app.connect('autodoc-process-docstring', process_docstring)
+    return {'version': '0.1', 'parallel_read_safe': True}

--- a/docs/source/_ext/docstring_mod.py
+++ b/docs/source/_ext/docstring_mod.py
@@ -1,8 +1,10 @@
 def add_versions(module, lines):
-    if hasattr(module, 'INDEXES'):
-        indexes = module.INDEXES
-        lines.append('**Versions:** ' + ' '.join([f'``{v}``' for v in indexes.keys()]))
+    try:
+        lines.append('**Available Versions:** ' + ' '.join([f'``{v}``' for v in module.INDEXES.keys() if v not in ["default", "sample", "test"]]))
+        lines.append('Default version: ``{}``'.format(module.INDEXES["default"]))
         lines.append('')
+    except Exception as e:
+        lines.append(f"Error fetching versions: {e}")
 
 
 def add_partial_downloads(module, dataset_class, lines):

--- a/mirdata/datasets/irmas.py
+++ b/mirdata/datasets/irmas.py
@@ -109,6 +109,7 @@ BIBTEX = """
   version      = {1.0},
   doi          = {10.5281/zenodo.1290750},
   url          = {https://doi.org/10.5281/zenodo.1290750}
+}
 """
 
 INDEXES = {


### PR DESCRIPTION
This PR improves the documentation by explicitly listing available versions for each dataset as well as possible partial downloads.

Solution: Created a Sphinx extension that automatically modifies docstrings to include this missing information.

Fixes #525 #594