### PR TITLE
Add support for `*args` and `**kwargs` in `io.coerce_to_*` decorators

### DIFF
--- a/mirdata/datasets/cipi.py
+++ b/mirdata/datasets/cipi.py
@@ -147,7 +147,7 @@ class Track(core.Track):
         )
 
     @property
-    def difficulty_annotation(self) -> int:
+    def difficulty_annotation(self) -> Optional[int]:
         return (
             self._track_metadata["henle"] if "henle" in self._track_metadata else None
         )

--- a/mirdata/datasets/dali.py
+++ b/mirdata/datasets/dali.py
@@ -261,12 +261,11 @@ def load_annotations_granularity(annotations_path: TextIO, granularity: str):
         NoteData for granularity='notes' or LyricData otherwise
 
     """
-    try:
-        with gzip.open(annotations_path.name, "rb") as f:
-            output = pickle.load(f)
-    except Exception as e:
-        with gzip.open(annotations_path.name, "r") as f:
-            output = pickle.load(f)
+    # We no longer need the try/except block here
+    # If the file does not exist, we'll get an error in the decorator instead
+    with gzip.open(annotations_path.name, "rb") as f:
+        output = pickle.load(f)
+
     text = []
     notes = []
     begs = []

--- a/mirdata/datasets/dali.py
+++ b/mirdata/datasets/dali.py
@@ -19,7 +19,7 @@ import gzip
 import logging
 import os
 import pickle
-from typing import BinaryIO, Optional, Tuple
+from typing import BinaryIO, Optional, TextIO, Tuple
 
 from deprecated.sphinx import deprecated
 import librosa
@@ -249,11 +249,12 @@ def load_audio(fhandle: BinaryIO) -> Optional[Tuple[np.ndarray, float]]:
     return librosa.load(fhandle, sr=None, mono=True)
 
 
-def load_annotations_granularity(annotations_path, granularity):
+@io.coerce_to_string_io
+def load_annotations_granularity(annotations_path: TextIO, granularity: str):
     """Load annotations at the specified level of granularity
 
     Args:
-        annotations_path (str): path to a DALI annotation file
+        annotations_path (str or file-like): path to a DALI annotation file
         granularity (str): one of 'notes', 'words', 'lines', 'paragraphs'
 
     Returns:
@@ -261,10 +262,10 @@ def load_annotations_granularity(annotations_path, granularity):
 
     """
     try:
-        with gzip.open(annotations_path, "rb") as f:
+        with gzip.open(annotations_path.name, "rb") as f:
             output = pickle.load(f)
     except Exception as e:
-        with gzip.open(annotations_path, "r") as f:
+        with gzip.open(annotations_path.name, "r") as f:
             output = pickle.load(f)
     text = []
     notes = []
@@ -276,12 +277,11 @@ def load_annotations_granularity(annotations_path, granularity):
         ends.append(round(annot["time"][1], 3))
         text.append(annot["text"])
     if granularity == "notes":
-        annotation = annotations.NoteData(
+        return annotations.NoteData(
             np.array([begs, ends]).T, "s", np.array(notes), "hz"
         )
     else:
-        annotation = annotations.LyricData(np.array([begs, ends]).T, "s", text, "words")
-    return annotation
+        return annotations.LyricData(np.array([begs, ends]).T, "s", text, "words")
 
 
 def load_annotations_class(annotations_path):

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -378,10 +378,9 @@ def load_chords(jams_path: TextIO, leadsheet_version):
         ChordData: Chord data
 
     """
-    try:
-        jam = jams.load(jams_path)
-    except FileNotFoundError:
-        raise FileNotFoundError("jams_path {} does not exist".format(jams_path.name))
+    # We no longer need the try/except block here
+    # If the file does not exist, we'll get an error in the decorator instead
+    jam = jams.load(jams_path)
 
     if leadsheet_version:
         anno = jam.search(namespace="chord")[0]
@@ -452,10 +451,9 @@ def load_pitch_contour(jams_path: TextIO, string_num):
         F0Data: Pitch contour data for the given string
 
     """
-    try:
-        jam = jams.load(jams_path)
-    except FileNotFoundError:
-        raise FileNotFoundError("jams_path {} does not exist".format(jams_path.name))
+    # With the decorator, we no longer need the try/except block here
+    # If the file does not exist, we'll get an error in the decorator instead
+    jam = jams.load(jams_path)
 
     anno_arr = jam.search(namespace="pitch_contour")
     anno = anno_arr.search(data_source=str(string_num))[0]
@@ -488,10 +486,9 @@ def load_notes(jams_path: TextIO, string_num):
         NoteData: Note data for the given string
 
     """
-    try:
-        jam = jams.load(jams_path)
-    except FileNotFoundError:
-        raise FileNotFoundError("jams_path {} does not exist".format(jams_path.name))
+    # With the decorator, we no longer need the try/except block here
+    # If the file does not exist, we'll get an error in the decorator instead
+    jam = jams.load(jams_path)
 
     anno_arr = jam.search(namespace="note_midi")
     anno = anno_arr.search(data_source=str(string_num))[0]

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -364,12 +364,12 @@ def load_beats(fhandle: TextIO) -> annotations.BeatData:
     return annotations.BeatData(times, "s", np.array(positions), "bar_index")
 
 
-# no decorator because of https://github.com/mir-dataset-loaders/mirdata/issues/503
-def load_chords(jams_path, leadsheet_version):
+@io.coerce_to_string_io
+def load_chords(jams_path: TextIO, leadsheet_version):
     """Load a guitarset chord annotation.
 
     Args:
-        jams_path (str): path to the jams annotation file
+        jams_path (str or file-like): path to the jams annotation file
         leadsheet_version (Bool):
             Whether or not to load the leadsheet version of the chord annotation
             If False, load the infered version.
@@ -379,10 +379,9 @@ def load_chords(jams_path, leadsheet_version):
 
     """
     try:
-        with open(jams_path, "r") as fhandle:
-            jam = jams.load(fhandle)
+        jam = jams.load(jams_path)
     except FileNotFoundError:
-        raise FileNotFoundError("jams_path {} does not exist".format(jams_path))
+        raise FileNotFoundError("jams_path {} does not exist".format(jams_path.name))
 
     if leadsheet_version:
         anno = jam.search(namespace="chord")[0]
@@ -440,12 +439,12 @@ def _fill_pitch_contour(times, freqs, voicing, max_time, contour_hop, duration=N
     return filled_times, filled_freqs, filled_voicing
 
 
-# no decorator because of https://github.com/mir-dataset-loaders/mirdata/issues/503
-def load_pitch_contour(jams_path, string_num):
+@io.coerce_to_string_io
+def load_pitch_contour(jams_path: TextIO, string_num):
     """Load a guitarset pitch contour annotation for a given string
 
     Args:
-        jams_path (str): path to the jams annotation file
+        jams_path (str or file-like): path to the jams annotation file
         string_num (int), in range(6): Which string to load.
             0 is the Low E string, 5 is the high e string.
 
@@ -454,10 +453,9 @@ def load_pitch_contour(jams_path, string_num):
 
     """
     try:
-        with open(jams_path, "r") as fhandle:
-            jam = jams.load(fhandle)
+        jam = jams.load(jams_path)
     except FileNotFoundError:
-        raise FileNotFoundError("jams_path {} does not exist".format(jams_path))
+        raise FileNotFoundError("jams_path {} does not exist".format(jams_path.name))
 
     anno_arr = jam.search(namespace="pitch_contour")
     anno = anno_arr.search(data_source=str(string_num))[0]
@@ -477,12 +475,12 @@ def load_pitch_contour(jams_path, string_num):
     )
 
 
-# no decorator because of https://github.com/mir-dataset-loaders/mirdata/issues/503
-def load_notes(jams_path, string_num):
+@io.coerce_to_string_io
+def load_notes(jams_path: TextIO, string_num):
     """Load a guitarset note annotation for a given string
 
     Args:
-        jams_path (str): path to the jams annotation file
+        jams_path (str or file-like): path to the jams annotation file
         string_num (int), in range(6): Which string to load.
             0 is the Low E string, 5 is the high e string.
 
@@ -491,10 +489,9 @@ def load_notes(jams_path, string_num):
 
     """
     try:
-        with open(jams_path) as fhandle:
-            jam = jams.load(fhandle)
+        jam = jams.load(jams_path)
     except FileNotFoundError:
-        raise FileNotFoundError("jams_path {} does not exist".format(jams_path))
+        raise FileNotFoundError("jams_path {} does not exist".format(jams_path.name))
 
     anno_arr = jam.search(namespace="note_midi")
     anno = anno_arr.search(data_source=str(string_num))[0]

--- a/mirdata/datasets/tonas.py
+++ b/mirdata/datasets/tonas.py
@@ -217,12 +217,12 @@ def load_audio(fhandle: str) -> Tuple[np.ndarray, float]:
     return librosa.load(fhandle, sr=44100, mono=True)
 
 
-# no decorator because of https://github.com/mir-dataset-loaders/mirdata/issues/503
-def load_f0(fpath: str, corrected: bool) -> Optional[annotations.F0Data]:
+@io.coerce_to_string_io
+def load_f0(fpath: TextIO, corrected: bool) -> Optional[annotations.F0Data]:
     """Load TONAS f0 annotations
 
     Args:
-        fpath (str): path pointing to f0 annotation file
+        fpath (str or file-like): path pointing to f0 annotation file
         corrected (bool): if True, loads manually corrected frequency values
             otherwise, loads automatically extracted frequency values
 
@@ -234,13 +234,12 @@ def load_f0(fpath: str, corrected: bool) -> Optional[annotations.F0Data]:
     freqs = []
     freqs_corr = []
     energies = []
-    with open(fpath, "r") as fhandle:
-        reader = np.genfromtxt(fhandle)
-        for line in reader:
-            times.append(float(line[0]))
-            freqs.append(float(line[2]))
-            freqs_corr.append(float(line[3]))
-            energies.append(float(line[1]))
+    reader = np.genfromtxt(fpath)
+    for line in reader:
+        times.append(float(line[0]))
+        freqs.append(float(line[2]))
+        freqs_corr.append(float(line[3]))
+        energies.append(float(line[1]))
 
     freq_array = np.array(freqs_corr if corrected else freqs, dtype="float")
     energy_array = np.array(energies, dtype="float")

--- a/mirdata/io.py
+++ b/mirdata/io.py
@@ -1,6 +1,6 @@
 import functools
 import io
-from typing import BinaryIO, Callable, List, Optional, TextIO, TypeVar, Union
+from typing import Any, BinaryIO, Callable, List, Optional, TextIO, Union
 
 import numpy as np
 import pretty_midi
@@ -8,21 +8,21 @@ from smart_open import open
 
 from mirdata import annotations
 
-T = TypeVar("T")  # Can be anything
 
-
-def coerce_to_string_io(
-    func: Callable[[TextIO], T]
-) -> Callable[[Optional[Union[str, TextIO]]], Optional[T]]:
+def coerce_to_string_io(func: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(func)
-    def wrapper(file_path_or_obj: Optional[Union[str, TextIO]]) -> Optional[T]:
+    def wrapper(
+        file_path_or_obj: Optional[Union[str, TextIO]],
+        *args: Optional[Any],
+        **kwargs: Optional[Any],
+    ) -> Optional[Any]:
         if not file_path_or_obj:
             return None
         if isinstance(file_path_or_obj, str):
             with open(file_path_or_obj, encoding="utf-8") as f:
-                return func(f)
+                return func(f, *args, **kwargs)
         elif isinstance(file_path_or_obj, io.StringIO):
-            return func(file_path_or_obj)
+            return func(file_path_or_obj, *args, **kwargs)
         else:
             raise ValueError(
                 "Invalid argument passed to {}, argument has the type {}",
@@ -33,18 +33,20 @@ def coerce_to_string_io(
     return wrapper
 
 
-def coerce_to_bytes_io(
-    func: Callable[[BinaryIO], T]
-) -> Callable[[Optional[Union[str, BinaryIO]]], Optional[T]]:
+def coerce_to_bytes_io(func: Callable[..., Any]) -> Callable[..., Any]:
     @functools.wraps(func)
-    def wrapper(file_path_or_obj: Optional[Union[str, BinaryIO]]) -> Optional[T]:
+    def wrapper(
+        file_path_or_obj: Optional[Union[str, BinaryIO]],
+        *args: Optional[Any],
+        **kwargs: Optional[Any],
+    ) -> Optional[Any]:
         if not file_path_or_obj:
             return None
         if isinstance(file_path_or_obj, str):
             with open(file_path_or_obj, "rb") as f:
-                return func(f)
+                return func(f, *args, **kwargs)
         elif isinstance(file_path_or_obj, io.BytesIO):
-            return func(file_path_or_obj)
+            return func(file_path_or_obj, *args, **kwargs)
         else:
             raise ValueError(
                 "Invalid argument passed to {}, argument has the type {}",


### PR DESCRIPTION
As discussed with @genisplaja in https://github.com/mir-dataset-loaders/mirdata/pull/652#pullrequestreview-2735847747, this PR makes an initial attempt to allow for the use of optional `args` and `kwargs` in the two decorator functions inside `io`.

The changes to the decorators themselves are very minor. I also changed a few functions in several loaders that weren't previously using the decorators. These are the same as defined in `test_loaders.EXCEPTIONS`, i.e.:

```
EXCEPTIONS = {
    "dali": {"load_annotations_granularity": {"granularity": "notes"}},
    "guitarset": {
        "load_pitch_contour": {"string_num": 1},
        "load_notes": {"string_num": 1},
        "load_chords": {"leadsheet_version": False},
    },
    "tonas": {"load_f0": {"corrected": True}},
    "compmusic_carnatic_varnam": {
        "load_notation": {
            "taala_path": "a/fake/path",
            "structure_path": "a/fake/path",
        },
    },
}
```

A few other things to note:
- I had to simplify the typehints for both `coerce_to*` functions in order to get `mypy` passing successfully. Someone with more familiarity with this package might have a better idea for how to keep the original type hints in place as much as possible.
- Weirdly, I also had to make a number of changes to functionality in `compmusic_carnatic_varnam.load_notation` for the same `mypy` reasons. Probably the most substantial is replacing calls to `np.arange` with the builtin `range` argument. I don't think this should lead to any functional changes (and tbh I have no idea why `mypy` started throwing additional errors when adding the decorator), but would appreciate someone with more familiarity taking a look.
- There are no changes to any of the tests, all seem to pass successfully on my local machine with the decorator changes made.
- There's also a bonus fix to `cipy.difficulty_annotation` that was throwing up (unrelated) `mypy` errors for me.