### PR TITLE
Fixes #668 - Refactor tags handling and update tests for Jamendo

### DIFF
--- a/tests/datasets/test_mtg_jamendo_autotagging_moodtheme.py
+++ b/tests/datasets/test_mtg_jamendo_autotagging_moodtheme.py
@@ -31,7 +31,7 @@ def test_track():
         "artist_id": str,
         "album_id": str,
         "duration": float,
-        "tags": str,
+        "tags": list,
     }
 
     run_track_tests(track, expected_attributes, expected_property_types)
@@ -53,7 +53,7 @@ def test_track_properties_and_attributes():
     assert track.artist_id == "artist_000087"
     assert track.album_id == "album_000149"
     assert track.duration == 212.7
-    assert track.tags == "mood/theme---background"
+    assert track.tags == ["background"]
 
 
 def test_get_track_splits():


### PR DESCRIPTION
Fixes #668 

- Refactor the tags method to return a list of tags such as `['dramatic', 'epic', 'inspiring', 'powerful', 'upbeat', 'uplifting']` instead of a string such as `"mood/theme---dramatic"`
- Modify metadata loading to accommodate multiple tags. Previously the tags method only returned the first tag out of many.
- Update the tests to reflect the change in the expected tags data type from string to list.