### PR TITLE
Fixes #673 - Failing Tests for PHENICX-Anechoic Dataset Loader

### DIFF
--- a/mirdata/datasets/phenicx_anechoic.py
+++ b/mirdata/datasets/phenicx_anechoic.py
@@ -358,7 +358,7 @@ def load_score(fhandle: TextIO) -> annotations.NoteData:
     """
 
     #### read start, end times
-    intervals = np.loadtxt(fhandle, delimiter=",", usecols=[0, 1], dtype=np.float_)
+    intervals = np.loadtxt(fhandle, delimiter=",", usecols=[0, 1], dtype=np.float64)
 
     #### read notes as string
     fhandle.seek(0)


### PR DESCRIPTION
Replaces deprecated usage of `np.float_` with `np.float64` to ensure compatibility with NumPy 2.0+