### PR TITLE
Cleanup Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
-    "attrs>=23.1.0",
     "chardet>=5.0.0",
     "Deprecated>=1.2.14",
     "h5py>=3.7.0",
@@ -32,7 +31,6 @@ dependencies = [
     "pretty_midi>=0.2.10",
     "pyyaml>=6.0",
     "openpyxl>=3.0.10",
-    "requests>=2.31.0",
     "scipy>=1.7.3",
     "tqdm>=4.66.1",
     "smart_open[all]>=5.0.0",

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -4,7 +4,9 @@ import io
 import os
 import sys
 import pytest
-import requests
+import urllib.request
+import urllib.error
+
 
 import mirdata
 from mirdata import core
@@ -184,16 +186,13 @@ def test_download(mocker):
 
                 url = dataset.remotes[key].url
                 try:
-                    request = requests.head(url)
-                    assert request.ok, "Link {} for {} does not return OK".format(
-                        url, dataset_name
-                    )
-                except requests.exceptions.ConnectionError:
-                    assert False, "Link {} for {} is unreachable".format(
-                        url, dataset_name
-                    )
-                except:
-                    assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
+                    req = urllib.request.Request(url, method="HEAD")
+                    with urllib.request.urlopen(req, timeout=10) as response:
+                        assert response.status == 200, f"Link {url} for {dataset_name} does not return OK"
+                except urllib.error.URLError:
+                    assert False, f"Link {url} for {dataset_name} is unreachable"
+                except Exception:
+                    assert False, f"{dataset_name}: {sys.exc_info()[0]}"
         else:
             try:
                 dataset.download()


### PR DESCRIPTION
Remove unused dependencies
- attrs

Replace with standard library
- requests with urllib for HTTP head requests in a test

Next step is to remove openpyxl and test whether it passes or fails any workflows.