### PR TITLE
Add manual trigger to all GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,11 @@ name: CI
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
+  workflow_dispatch:
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -3,10 +3,11 @@ name: Formatting
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
+  workflow_dispatch:
 
 jobs:
   black:

--- a/.github/workflows/lint-python.yml
+++ b/.github/workflows/lint-python.yml
@@ -3,10 +3,11 @@ name: Linting
 on:
   push:
     branches:
-    - master
+      - master
   pull_request:
     branches:
-    - master
+      - master
+  workflow_dispatch:
     
 jobs:
   lint_python:

--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,6 +6,7 @@ name: Upload Python Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   deploy:


### PR DESCRIPTION
All GitHub Actions workflows now support manual triggering through the `workflow_dispatch` event, which adds a "Run Workflow" button to each workflow for more convenience.