### PR TITLE
Fix Documentation - Separate the subsections in the Tutorial

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -4,6 +4,7 @@
 Tutorial
 ########
 
+
 Installation
 ^^^^^^^^^^^^
 


### PR DESCRIPTION
This pull request makes a small documentation update to the `docs/source/tutorial.rst` file. 
Previously, all the subsections were under the "Installation" subsection rather than their own separate subsections.
It has now been fixed to have separate subsections as expected.

<img width="300" height="438" alt="image" src="https://github.com/user-attachments/assets/2e388db4-3d6e-4956-bd55-d2e903b2496b" />
