### PR TITLE
Black update formatting, Adding dependencies for visual

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -9,7 +9,7 @@ dependencies:
   - Deprecated>=1.2.14
   - h5py>=3.7.0
   - librosa>=0.10.1
-  - numpy>=1.21.6,<=2.3
+  - numpy>=1.21.6
   - openpyxl>=3.0.10
   - pandas>=1.3.5
   - pyyaml>=6.0
@@ -39,4 +39,3 @@ dependencies:
     - smart_open[all]>=6.4.0
     - testcontainers>=3.7.1
     - mir_eval>=0.7
-    - opencv-python>=4.13.0.90

--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -9,7 +9,7 @@ dependencies:
   - Deprecated>=1.2.14
   - h5py>=3.7.0
   - librosa>=0.10.1
-  - numpy>=1.21.6,<2.0
+  - numpy>=1.21.6,<=2.3
   - openpyxl>=3.0.10
   - pandas>=1.3.5
   - pyyaml>=6.0
@@ -39,3 +39,4 @@ dependencies:
     - smart_open[all]>=6.4.0
     - testcontainers>=3.7.1
     - mir_eval>=0.7
+    - opencv-python>=4.13.0.90

--- a/mirdata/__init__.py
+++ b/mirdata/__init__.py
@@ -4,7 +4,6 @@ import pkgutil
 
 from .version import version as __version__
 
-
 DATASETS = [
     d.name
     for d in pkgutil.iter_modules(

--- a/mirdata/datasets/acousticbrainz_genre.py
+++ b/mirdata/datasets/acousticbrainz_genre.py
@@ -46,7 +46,6 @@ from deprecated.sphinx import deprecated
 
 from mirdata import download_utils, core, io
 
-
 NAME = "acousticbrainz_genre"
 
 BIBTEX = """

--- a/mirdata/datasets/baf.py
+++ b/mirdata/datasets/baf.py
@@ -122,7 +122,6 @@ import pandas as pd
 from mirdata import annotations
 from mirdata import core
 
-
 BIBTEX = """@inproceedings{cortes2022BAF,
   author       = {Guillem Cortès and
                   Alex Ciurana and

--- a/mirdata/datasets/ballroom.py
+++ b/mirdata/datasets/ballroom.py
@@ -41,7 +41,6 @@ from typing import BinaryIO, Optional, TextIO, Tuple
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @ARTICLE{1678001,
     author={Gouyon, F. and Klapuri, A. and Dixon, S. and Alonso, M. and Tzanetakis, G. and Uhle, C. and Cano, P.},

--- a/mirdata/datasets/beatles.py
+++ b/mirdata/datasets/beatles.py
@@ -23,7 +23,6 @@ from mirdata import core
 from mirdata import annotations
 from mirdata import io
 
-
 BIBTEX = """@inproceedings{mauch2009beatles,
     title={OMRAS2 metadata project 2009},
     author={Mauch, Matthias and Cannam, Chris and Davies, Matthew and Dixon, Simon and Harte,

--- a/mirdata/datasets/brid.py
+++ b/mirdata/datasets/brid.py
@@ -43,7 +43,6 @@ from typing import BinaryIO, Optional, TextIO, Tuple
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @inproceedings{Maia2018AND,
   title={A Novel Dataset of Brazilian Rhythmic Instruments and Some Experiments in Computational Rhythm Analysis},

--- a/mirdata/datasets/cante100.py
+++ b/mirdata/datasets/cante100.py
@@ -61,7 +61,6 @@ from mirdata import core
 from mirdata import annotations
 from mirdata import io
 
-
 BIBTEX = """@dataset{nadine_kroher_2018_1322542,
   author       = {Nadine Kroher and
                   José Miguel Díaz-Báñez and

--- a/mirdata/datasets/compmusic_carnatic_rhythm.py
+++ b/mirdata/datasets/compmusic_carnatic_rhythm.py
@@ -55,7 +55,6 @@ import numpy as np
 from mirdata import annotations, core, io
 from smart_open import open
 
-
 try:
     from openpyxl import load_workbook as get_xlxs
 except ImportError:

--- a/mirdata/datasets/compmusic_hindustani_rhythm.py
+++ b/mirdata/datasets/compmusic_hindustani_rhythm.py
@@ -53,7 +53,6 @@ import numpy as np
 from mirdata import annotations, core, io
 from smart_open import open
 
-
 try:
     from openpyxl import load_workbook as get_xlxs
 except ImportError:

--- a/mirdata/datasets/compmusic_jingju_acappella.py
+++ b/mirdata/datasets/compmusic_jingju_acappella.py
@@ -58,7 +58,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @dataset{rong_gong_2018_1323561,
   author       = {Rong Gong and

--- a/mirdata/datasets/compmusic_otmm_makam.py
+++ b/mirdata/datasets/compmusic_otmm_makam.py
@@ -46,7 +46,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @software{sertan_senturk_2016_58413,
   author       = {Sertan Şentürk and

--- a/mirdata/datasets/compmusic_raga.py
+++ b/mirdata/datasets/compmusic_raga.py
@@ -51,7 +51,6 @@ import numpy as np
 from mirdata import annotations, core, download_utils, io
 from smart_open import open
 
-
 BIBTEX = """
 @article{gulati_2016,
   author       = {Gulati, Sankalp and Serrà, Joan and Kaustuv Kani, Ganguli 

--- a/mirdata/datasets/cuidado.py
+++ b/mirdata/datasets/cuidado.py
@@ -39,7 +39,6 @@ from typing import Optional, TextIO, Tuple, List
 
 from mirdata import annotations, core, io
 
-
 BIBTEX = """
 @article{1678001,
     author={Gouyon, F. and Klapuri, A. and Dixon, S. and Alonso, M. and Tzanetakis, G. and Uhle, C. and Cano, P.},

--- a/mirdata/datasets/da_tacos.py
+++ b/mirdata/datasets/da_tacos.py
@@ -95,6 +95,7 @@
         }
 
 """
+
 import json
 import os
 from typing import Optional, BinaryIO

--- a/mirdata/datasets/freesound_one_shot_percussive_sounds.py
+++ b/mirdata/datasets/freesound_one_shot_percussive_sounds.py
@@ -50,7 +50,6 @@ from smart_open import open
 
 from mirdata import download_utils, core, io
 
-
 BIBTEX = """
 @inproceedings{ramires2020, 
     author = "Antonio Ramires and Pritish Chandna and Xavier Favory and Emilia Gómez and Xavier Serra",

--- a/mirdata/datasets/giantsteps_key.py
+++ b/mirdata/datasets/giantsteps_key.py
@@ -41,7 +41,6 @@ import numpy as np
 
 from mirdata import core, download_utils, io
 
-
 BIBTEX = """@inproceedings{knees2015two,
   title={Two data sets for tempo estimation and key detection in electronic dance music annotated from user corrections},
   author={Knees, Peter and Faraldo P{\'e}rez, {\'A}ngel and Boyer, Herrera and Vogl, Richard and B{\"o}ck, Sebastian and H{\"o}rschl{\"a}ger, Florian and Le Goff, Mickael and others},

--- a/mirdata/datasets/giantsteps_tempo.py
+++ b/mirdata/datasets/giantsteps_tempo.py
@@ -75,7 +75,6 @@ import numpy as np
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """@inproceedings{knees2015two,
   title={Two data sets for tempo estimation and key detection in electronic dance music annotated from user corrections},
   author={Knees, Peter and Faraldo P{\'e}rez, {\'A}ngel and Boyer, Herrera and Vogl, Richard and B{\"o}ck, Sebastian and H{\"o}rschl{\"a}ger, Florian and Le Goff, Mickael and others},

--- a/mirdata/datasets/good_sounds.py
+++ b/mirdata/datasets/good_sounds.py
@@ -27,6 +27,7 @@
 
 
 """
+
 import json
 import os
 from typing import Optional, Tuple, BinaryIO

--- a/mirdata/datasets/groove_midi.py
+++ b/mirdata/datasets/groove_midi.py
@@ -61,7 +61,6 @@ from mirdata import core
 from mirdata import download_utils
 from mirdata import io
 
-
 BIBTEX = """@inproceedings{groove2019,
     Author = {Jon Gillick and Adam Roberts and Jesse Engel and Douglas Eck
               and David Bamman},

--- a/mirdata/datasets/gtzan_genre.py
+++ b/mirdata/datasets/gtzan_genre.py
@@ -24,7 +24,6 @@ import numpy as np
 
 from mirdata import download_utils, core, io, annotations
 
-
 BIBTEX = """@article{tzanetakis2002gtzan,
   title={GTZAN genre collection},
   author={Tzanetakis, George and Cook, P},

--- a/mirdata/datasets/guitarset.py
+++ b/mirdata/datasets/guitarset.py
@@ -63,7 +63,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """@inproceedings{xi2018guitarset,
 title={GuitarSet: A Dataset for Guitar Transcription},
 author={Xi, Qingyang and Bittner, Rachel M and Ye, Xuzhou and Pauwels, Johan and Bello, Juan P},

--- a/mirdata/datasets/hainsworth.py
+++ b/mirdata/datasets/hainsworth.py
@@ -36,7 +36,6 @@ from typing import BinaryIO, Optional, TextIO, Tuple
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @article{article,
 author = {Macleod, Malcolm and Hainsworth, Stephen},

--- a/mirdata/datasets/ikala.py
+++ b/mirdata/datasets/ikala.py
@@ -25,7 +25,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """@inproceedings{chan2015vocal,
     title={Vocal activity informed singing voice separation with the iKala dataset},
     author={Chan, Tak-Shing and Yeh, Tzu-Chun and Fan, Zhe-Cheng and Chen, Hung-Wei and Su, Li and Yang, Yi-Hsuan and

--- a/mirdata/datasets/jtd.py
+++ b/mirdata/datasets/jtd.py
@@ -64,7 +64,6 @@ import numpy as np
 
 from mirdata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @article{jazz-trio-database
     title = {Jazz Trio Database: Automated Annotation of Jazz Piano Trio Recordings Processed Using Audio Source Separation},

--- a/mirdata/datasets/maestro.py
+++ b/mirdata/datasets/maestro.py
@@ -43,7 +43,6 @@ from smart_open import open
 
 from mirdata import core, download_utils, io
 
-
 BIBTEX = """@inproceedings{
   hawthorne2018enabling,
   title={Enabling Factorized Piano Music Modeling and Generation with the {MAESTRO} Dataset},

--- a/mirdata/datasets/medleydb_pitch.py
+++ b/mirdata/datasets/medleydb_pitch.py
@@ -28,7 +28,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """@inproceedings{bittner2014medleydb,
     Author = {Bittner, Rachel M and Salamon, Justin and Tierney, Mike and Mauch, Matthias and Cannam, Chris and Bello, Juan P},
     Booktitle = {International Society of Music Information Retrieval (ISMIR)},

--- a/mirdata/datasets/mtg_jamendo_autotagging_moodtheme.py
+++ b/mirdata/datasets/mtg_jamendo_autotagging_moodtheme.py
@@ -36,6 +36,7 @@
     This work has received funding from the European Union's Horizon 2020 research and innovation programme under
     grant agreement No 688382 "AudioCommons".
 """
+
 import csv
 import os
 from typing import Optional, Tuple, BinaryIO

--- a/mirdata/datasets/phenicx_anechoic.py
+++ b/mirdata/datasets/phenicx_anechoic.py
@@ -53,7 +53,6 @@ import numpy as np
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @article{miron2016score,
   title={Score-informed source separation for multichannel orchestral recordings},

--- a/mirdata/datasets/salami.py
+++ b/mirdata/datasets/salami.py
@@ -27,7 +27,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """@inproceedings{smith2011salami,
     title={Design and creation of a large-scale database of structural annotations.},
     author={Smith, Jordan Bennett Louis and Burgoyne, John Ashley and

--- a/mirdata/datasets/simac.py
+++ b/mirdata/datasets/simac.py
@@ -25,7 +25,6 @@ from typing import BinaryIO, Optional, TextIO, Tuple
 
 from mirdata import annotations, core, io
 
-
 BIBTEX = """
 @INPROCEEDINGS{1576040,
   author={Herrera, P. and Bello, J. and Widmer, G. and Sandler, M. and Celma, O. and Vignoli, F. and Pampalk, E. and Cano, P. and Pauws, S. and Serra, X.},

--- a/mirdata/datasets/tonality_classicaldb.py
+++ b/mirdata/datasets/tonality_classicaldb.py
@@ -43,7 +43,6 @@ import numpy as np
 
 from mirdata import core, download_utils, io
 
-
 BIBTEX = """@article{gomez2006tonal,
   title={Tonal description of music audio signals},
   author={G{\'o}mez, Emilia},

--- a/mirdata/datasets/tonas.py
+++ b/mirdata/datasets/tonas.py
@@ -54,7 +54,6 @@ from smart_open import open
 
 from mirdata import annotations, core, io
 
-
 BIBTEX = """
 Music material:
 @inproceedings{tonas_music,

--- a/mirdata/datasets/vocadito.py
+++ b/mirdata/datasets/vocadito.py
@@ -26,7 +26,6 @@ from smart_open import open
 
 from mirdata import annotations, core, download_utils, io
 
-
 BIBTEX = """
 @techreport{bittner2021vocadito,
       title={vocadito: A dataset of solo vocals with $f_0$, note, and lyric annotations}, 

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -274,9 +274,7 @@ def download_from_remote(remote, save_dir, force_overwrite, allow_invalid_checks
                             If this error persists, please raise an issue at
                             https://github.com/mir-dataset-loaders/mirdata,
                             and tag it with 'broken-link'.
-                            """.format(
-                    remote.url
-                )
+                            """.format(remote.url)
                 logging.error(error_msg)
                 raise exc
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "Deprecated>=1.2.14",
     "h5py>=3.7.0",
     "librosa>=0.10.1",
-    "numpy>=1.21.6",
+    "numpy>=1.21.6,<=2.3",
     "pandas>=1.3.5",
     "pretty_midi>=0.2.10",
     "pyyaml>=6.0",
@@ -34,6 +34,7 @@ dependencies = [
     "scipy>=1.7.3",
     "tqdm>=4.66.1",
     "smart_open[all]>=5.0.0",
+    "opencv-python>=4.13.0.90",
 ]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "Deprecated>=1.2.14",
     "h5py>=3.7.0",
     "librosa>=0.10.1",
-    "numpy>=1.21.6,<=2.3",
+    "numpy>=1.21.6",
     "pandas>=1.3.5",
     "pretty_midi>=0.2.10",
     "pyyaml>=6.0",
@@ -34,7 +34,6 @@ dependencies = [
     "scipy>=1.7.3",
     "tqdm>=4.66.1",
     "smart_open[all]>=5.0.0",
-    "opencv-python>=4.13.0.90",
 ]
 
 [tool.setuptools.package-data]
@@ -77,6 +76,7 @@ cipi = ["music21==6.7.1"]
 gcs = ["smart_open[gcs]"]
 s3 = ["smart_open[s3]"]
 http = ["smart_open[http]"]
+multivox = ["moviepy>=2.2.1"]
 
 [project.urls]
 Homepage = "https://github.com/mir-dataset-loaders/mirdata"

--- a/tests/datasets/test_baf.py
+++ b/tests/datasets/test_baf.py
@@ -8,7 +8,6 @@ from tests.test_utils import run_track_tests
 
 from mirdata.datasets import baf
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/mir_datasets/baf")
 TRACK_ID = "query_0001"
 TRACK_ID2 = "query_0002"

--- a/tests/datasets/test_idmt_smt_audio_effects.py
+++ b/tests/datasets/test_idmt_smt_audio_effects.py
@@ -7,7 +7,6 @@ from mirdata.datasets import idmt_smt_audio_effects
 from mirdata import download_utils
 from tests.test_utils import run_track_tests
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/mir_datasets/idmt_smt_audio_effects")
 
 


### PR DESCRIPTION
Related to PR #696 

**[ISSUE]** 
* Due to the recent update from `black`, CI requires new formatting. 
* To support visual datasets, new dependencies needs to be added. 

**[SOLUTION]**
* Reformatting 34 loader scripts + 2 test dataset scripts.
* Adding `moviepy' dependency. - only for loaders that needed (Multivox) 
