### PR TITLE
Remove chardet, pytest-pep8 from dependencies, update music21 and fix haydn_op20 loader

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -21,7 +21,6 @@ dependencies:
 
   # optional, but required for testing
   - pytest>=7.4.3
-  - pytest-pep8>=1.0.6
   - pytest-cov>=4.1.0
   - pytest-mock>=3.11.1
   - pytest-localserver>=0.8.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,3 @@
-chardet>=5.0.0
 dali-dataset>=1.0
 Deprecated>=1.2.13
 librosa>=0.10.1

--- a/mirdata/datasets/haydn_op20.py
+++ b/mirdata/datasets/haydn_op20.py
@@ -142,8 +142,7 @@ def _split_score_annotations(fhandle: TextIO):
     score = music21.converter.parse(fhandle.name, format="humdrum")
 
     rna = {
-        rn.offset: rn
-        for rn in list(score.flatten().getElementsByClass("RomanNumeral"))
+        rn.offset: rn for rn in list(score.flatten().getElementsByClass("RomanNumeral"))
     }
     score.remove(list(rna.values()), recurse=True)
     rna_clean = [(offset, rn) for offset, rn in rna.items() if rn]

--- a/mirdata/datasets/haydn_op20.py
+++ b/mirdata/datasets/haydn_op20.py
@@ -141,7 +141,10 @@ def _split_score_annotations(fhandle: TextIO):
     """
     score = music21.converter.parse(fhandle.name, format="humdrum")
 
-    rna = {rn.offset: rn for rn in list(score.flat.getElementsByClass("RomanNumeral"))}
+    rna = {
+        rn.offset: rn
+        for rn in list(score.flatten().getElementsByClass("RomanNumeral"))
+    }
     score.remove(list(rna.values()), recurse=True)
     rna_clean = [(offset, rn) for offset, rn in rna.items() if rn]
     return score, rna_clean

--- a/mirdata/download_utils.py
+++ b/mirdata/download_utils.py
@@ -1,6 +1,5 @@
 """Utilities for downloading from the web."""
 
-import chardet
 import glob
 import logging
 import os
@@ -341,23 +340,21 @@ def extractall_unicode(zfile, out_dir):
 
     for m in zfile.infolist():
         data = zfile.read(m)  # extract zipped data into memory
-
         filename = m.filename
 
-        # if block to deal with irmas and good-sounds archives
-        # check if the zip archive does not have the encoding info set
-        # encode-decode filename only if it's different than the original name
-        if (m.flag_bits & ZIP_FILENAME_UTF8_FLAG == 0) and filename.encode(
-            "cp437"
-        ).decode(errors="ignore") != filename:
-            filename_bytes = filename.encode("cp437")
-            if filename_bytes.decode("utf-8", "replace") != filename_bytes.decode(
-                errors="ignore"
-            ):
-                guessed_encoding = chardet.detect(filename_bytes)["encoding"] or "utf8"
-                filename = filename_bytes.decode(guessed_encoding, "replace")
-            else:
-                filename = filename_bytes.decode("utf-8", "replace")
+        # Some dataset archives, including IRMAS and GOOD-SOUNDS, store UTF-8
+        # filenames without setting the ZIP UTF-8 flag.
+        if m.flag_bits & ZIP_FILENAME_UTF8_FLAG == 0:
+            try:
+                filename_bytes = filename.encode("cp437")
+            except UnicodeEncodeError:
+                filename_bytes = None
+
+            if filename_bytes is not None:
+                try:
+                    filename = filename_bytes.decode("utf-8")
+                except UnicodeDecodeError:
+                    pass
 
         disk_file_name = os.path.join(out_dir, filename)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11"
 ]
 dependencies = [
-    "chardet>=5.0.0",
     "Deprecated>=1.2.14",
     "h5py>=3.7.0",
     "librosa>=0.10.1",
@@ -52,7 +51,6 @@ tests = [
     "future>=0.18.3",
     "coveralls>=3.3.1",
     "types-PyYAML",
-    "types-chardet",
     "black>=23.3.0",
     "flake8>=5.0.4",
     "mypy>=0.982",
@@ -71,8 +69,8 @@ docs = [
 compmusic_hindustani_rhythm = ["openpyxl==3.0.10"]
 dali = ["dali-dataset==1.1"]
 compmusic_carnatic_rhythm = ["openpyxl==3.0.10"]
-haydn_op20 = ["music21==6.7.1"]
-cipi = ["music21==6.7.1"]
+haydn_op20 = ["music21>=7.3.3"]
+cipi = ["music21>=7.3.3"]
 gcs = ["smart_open[gcs]"]
 s3 = ["smart_open[s3]"]
 http = ["smart_open[http]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ tests = [
     "attrs>=23.1.0",
     "pytest>=7.2.0",
     "pytest-cov>=4.1.0",
-    "pytest-pep8>=1.0.6",
     "pytest-mock>=3.10.0",
     "pytest-localserver>=0.7.1",
     "testcontainers>=2.3",

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -520,6 +520,22 @@ def test_extractall_unicode(tmp_path, mocker, mock_download_from_remote, mock_un
             assert os.path.exists(expected_file_location)
 
 
+def test_extractall_unicode_keeps_uncodable_filename(tmp_path, mocker):
+    member = mocker.Mock()
+    member.filename = "plain😀.txt"
+    member.flag_bits = 0
+
+    zfile = mocker.Mock()
+    zfile.infolist.return_value = [member]
+    zfile.read.return_value = b"content"
+
+    download_utils.extractall_unicode(zfile, str(tmp_path))
+
+    expected_file_location = os.path.join(str(tmp_path), "plain😀.txt")
+    assert os.path.exists(expected_file_location)
+    assert Path(expected_file_location).read_bytes() == b"content"
+
+
 def test_extractall_cp437(tmp_path, mocker, mock_download_from_remote, mock_unzip):
     zfile = zipfile.ZipFile("tests/resources/utfissue.zip", "r")
     zfile.extractall(str(tmp_path))

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -3,7 +3,6 @@ import os
 from pathlib import Path
 import shutil
 import zipfile
-import re
 
 from mirdata import download_utils, core
 
@@ -504,34 +503,31 @@ def test_download_tar_file_ignorechecksum(
     _clean("a")
 
 
-def test_extractall_unicode(mocker, mock_download_from_remote, mock_unzip):
+def test_extractall_unicode(tmp_path, mocker, mock_download_from_remote, mock_unzip):
     zip_files = ("tests/resources/utfissue.zip", "tests/resources/utfissuewin.zip")
     expected_files_all = (
         ["pic👨‍👩‍👧‍👦🎂.jpg", "Benoît.txt", "Icon"],
-        ["pic👨‍👩‍👧‍👦🎂.jpg", "BenoŒt.txt", "Icon"],
+        ["pic👨‍👩‍👧‍👦🎂.jpg", "Benoît.txt", "Icon"],
     )
     for zipf, expected_files in zip(zip_files, expected_files_all):
         zfile = zipfile.ZipFile(zipf, "r")
-        download_utils.extractall_unicode(zfile, os.path.dirname("tests/resources/"))
+        download_utils.extractall_unicode(zfile, str(tmp_path))
         zfile.close()
         for expected_file in expected_files:
             expected_file_location = os.path.join(
-                "tests", "resources", "utfissue", expected_file
+                str(tmp_path), "utfissue", expected_file
             )
             assert os.path.exists(expected_file_location)
-            os.remove(expected_file_location)
 
 
-def test_extractall_cp437(mocker, mock_download_from_remote, mock_unzip):
+def test_extractall_cp437(tmp_path, mocker, mock_download_from_remote, mock_unzip):
     zfile = zipfile.ZipFile("tests/resources/utfissue.zip", "r")
-    zfile.extractall(os.path.dirname("tests/resources/"))
+    zfile.extractall(str(tmp_path))
     zfile.close()
     expected_files = ["pic👨‍👩‍👧‍👦🎂.jpg", "Benoît.txt", "Icon"]
     for expected_file in expected_files:
-        expected_file_location = os.path.join("tests", "resources", expected_file)
+        expected_file_location = os.path.join(str(tmp_path), expected_file)
         assert not os.path.exists(expected_file_location)
-    shutil.rmtree(os.path.join("tests", "resources", "__MACOSX"))
-    shutil.rmtree(os.path.join("tests", "resources", "utfissue"))
 
 
 def test_index_duplicate_prevention(mocker, mock_path):

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -522,7 +522,7 @@ def test_extractall_unicode(tmp_path, mocker, mock_download_from_remote, mock_un
 
 def test_extractall_unicode_keeps_uncodable_filename(tmp_path, mocker):
     member = mocker.Mock()
-    member.filename = "plain😀.txt"
+    member.filename = "plainĀ.txt"
     member.flag_bits = 0
 
     zfile = mocker.Mock()
@@ -531,7 +531,7 @@ def test_extractall_unicode_keeps_uncodable_filename(tmp_path, mocker):
 
     download_utils.extractall_unicode(zfile, str(tmp_path))
 
-    expected_file_location = os.path.join(str(tmp_path), "plain😀.txt")
+    expected_file_location = os.path.join(str(tmp_path), "plainĀ.txt")
     assert os.path.exists(expected_file_location)
     assert Path(expected_file_location).read_bytes() == b"content"
 


### PR DESCRIPTION
Closes #703, Closes #704

### Description
Currently CI was failing because of **chardet** and **music21**. 

Recent updates in **chardet** changed its encoding prediction, causing unicode extraction test to fail. 
Encoding issue was found from _irmas_ and _goodsounds_ datasets, however, those two datasets can be encoded well with UTF-8. Therefore, fallback to chardet prediction in `extractall_unicode` is unnecessary.

Recent updates in **music21** changed the API: score.flat() -> score.flatten(), which breaks the test.

**++ 0629**

**pytest** loads the **pytest-pep8** automatically, which is no longer compatible with **pytest 9**, and it rejects its outdate `pytest_collect_file(path, parent)` hook signature. 
This makes **pytest** fail before any tests run. 

**Mirdata** already uses **flake8** for style checks, and currently, test does not use **pytest-pep8**. So **pytest-pep8** is no longer needed.

### Changes
* Remove **Chardet** from dependencies, remove the encoding prediction fallback in `extractall_unicode`
* Update **music21** to support newer version 
* Fix _haydn_op20_ loader to support the new **music21** API.

**++0629**
* Remove `pytest-pep8` from **pyproject.toml** and **CI environment**.
